### PR TITLE
(break): redo IA for docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -6,64 +6,167 @@ instances:
         owner: fern-api
         repo: fern
         branch: main
-  # - url: fern-beta.docs.buildwithfern.com/learn
-  #   custom-domain: staging.buildwithfern.com/learn
 title: Fern | Documentation
 
-tabs:
-  overview:
-    display-name: Overview
-    icon: "globe"
-  sdks:
-    display-name: SDKs
-    slug: sdks
-    icon: code
-  docs:
-    display-name: Docs
-    slug: docs
-    icon: book
-
-navigation:
-  - tab: overview
-    layout:
+navigation: 
+  - section: Home
+    contents: 
       - page: Introduction
-        path: ./docs/pages/overview/introduction.mdx
-      - page: Why Fern?
-        path: ./docs/pages/overview/why-fern.mdx
-      - page: Get started
-        path: ./docs/pages/overview/get-started.mdx
-      - section: Define your API
+        path: ./overview/intro.mdx
+  - section: SDKs
+    contents: 
+      - page: Overview
+        path: ./overview/dummy.mdx
+      - page: Quickstart
+        path: ./overview/dummy.mdx
+      - section: Features
+        contents: 
+          - page: Strongly typed
+            path: ./overview/dummy.mdx
+          - page: Idiomatic method names
+            path: ./overview/dummy.mdx
+          - page: Schema Validation
+            path: ./overview/dummy.mdx
+          - page: Auto-Pagination
+            path: ./overview/dummy.mdx
+          - page: Retries with backoff
+            path: ./overview/dummy.mdx
+          - page: Webhook Signature Verification
+            path: ./overview/dummy.mdx
+          - page: Forward Compatibility  
+            path: ./overview/dummy.mdx
+          - page: Multipart Form Data
+            path: ./overview/dummy.mdx
+          - page: Idempotency Headers
+            path: ./overview/dummy.mdx
+          - page: Server-Sent Events
+            path: ./overview/dummy.mdx
+          - page: Integration Tests
+            path: ./overview/dummy.mdx
+          - page: Code Snippets
+            path: ./overview/dummy.mdx
+          - page: Augment with custom code
+            path: ./overview/dummy.mdx
+          - page: Merging multiple APIs
+            path: ./overview/dummy.mdx
+          - page: GitHub integration
+            path: ./overview/dummy.mdx
+  - section: Docs
+    contents: 
+      - page: Overview
+        path: ./overview/dummy.mdx
+      - page: Quickstart
+        path: ./overview/dummy.mdx
+      - section: Global Settings
+        contents: 
+          - page: URLs
+            path: ./overview/dummy.mdx
+          - page: Colors
+            path: ./overview/dummy.mdx
+          - page: Layout
+            path: ./overview/dummy.mdx
+          - page: Navigation
+            path: ./overview/dummy.mdx
+          - page: Typography
+            path: ./overview/dummy.mdx
+          - page: CSS and JS Overrides
+            path: ./overview/dummy.mdx
+          - page: Call to actions
+            path: ./overview/dummy.mdx
+      - section: Writing Content
+        contents: 
+          - page: Page Titles and Metadata
+            path: ./overview/dummy.mdx
+          - page: Headers and Text
+            path: ./overview/dummy.mdx
+          - page: Images, Videos and Embeds
+            path: ./overview/dummy.mdx
+          - page: Lists and Tables
+            path: ./overview/dummy.mdx
+          - page: Code Blocks
+            path: ./overview/dummy.mdx
+      - section: API References
+        contents: 
+          - page: API Definition Setup
+            path: ./overview/dummy.mdx
+          - page: Errors, Audiences, and Snippets 
+            path: ./overview/dummy.mdx
+          - page: API Playground
+            path: ./overview/dummy.mdx
+      - section: Custom Components
+        contents: 
+          - page: Cards
+            path: ./overview/dummy.mdx
+          - page: CodeBlocks
+            path: ./overview/dummy.mdx
+          - page: Callouts
+            path: ./overview/dummy.mdx
+          - page: Icons
+            path: ./overview/dummy.mdx
+          - page: Availability
+            path: ./overview/dummy.mdx
+          - page: Tabs
+            path: ./overview/dummy.mdx
+          - page: Accordion
+            path: ./overview/dummy.mdx
+          - page: Steps
+            path: ./overview/dummy.mdx
+          - page: Endpoint Snippets
+            path: ./overview/dummy.mdx
+  - section: Configuration
+    contents: 
+      - section: Fern Folder
         contents:
-          # TBD
-          # - page: Overview
-          #   path: ./docs/pages/overview/define-your-api/api-overview.mdx
-          - section: OpenAPI
-            slug: openapi
-            contents:
+          - page: Overview
+            path: ./overview/dummy.mdx
+          - page: generators.yml
+            path: ./overview/dummy.mdx
+          - page: docs.yml
+            path: ./overview/dummy.mdx
+      - section: API Definitions
+        contents:
+          - section: OpenAPI Spec
+            contents: 
               - page: Overview
-                path: ./docs/pages/overview/define-your-api/openapi/openapi-overview.mdx
-              - page: OpenAPI Extensions
-                path: ./docs/pages/overview/define-your-api/openapi/extensions.mdx
-                slug: extensions
-              - page: OpenAPI Examples
-                path: ./docs/pages/overview/define-your-api/openapi/examples.mdx
-                slug: examples
+                path: ./overview/dummy.mdx
+              - section: Extensions
+                contents: 
+                  - page: Overriding Names
+                    path: ./overview/dummy.mdx
+                  - page: Auth and Global Headers
+                    path: ./overview/dummy.mdx
+                  - page: Audiences
+                    path: ./overview/dummy.mdx
+                  - page: Ignoring Endpoints
+                    path: ./overview/dummy.mdx
+                  - page: Overlaying Customizations
+                    path: ./overview/dummy.mdx
+                  - page: Server Sent Events
+                    path: ./overview/dummy.mdx
+                  - page: Examples
+                    path: ./overview/dummy.mdx
+          - section: AsyncAPI Spec
+            contents: 
+              - page: Overview
+                path: ./overview/dummy.mdx
+          - section: gRPC
+            contents: 
+              - page: Overview
+                path: ./overview/dummy.mdx
           - section: Fern Definition
-            slug: ferndef
             contents:
               - page: Overview
-                path: ./docs/pages/overview/define-your-api/ferndef/ferndef-overview.mdx
+                path: ./overview/dummy.mdx
               - page: Export to OpenAPI
-                slug: export-openapi
-                path: ./docs/pages/overview/define-your-api/ferndef/export-openapi.mdx
+                path: ./overview/dummy.mdx
               - page: Types
-                path: ./docs/pages/overview/define-your-api/ferndef/types.mdx
+                path: ./overview/dummy.mdx
               - page: Endpoints
-                path: ./docs/pages/overview/define-your-api/ferndef/endpoints.mdx
+                path: ./overview/dummy.mdx
               - page: Errors
-                path: ./docs/pages/overview/define-your-api/ferndef/errors.mdx
+                path: ./overview/dummy.mdx
               - page: Imports
-                path: ./docs/pages/overview/define-your-api/ferndef/imports.mdx
+                path: ./overview/dummy.mdx
               - page: Examples
                 path: ./docs/pages/overview/define-your-api/ferndef/examples.mdx
               - page: Audiences
@@ -74,206 +177,22 @@ navigation:
                 path: ./docs/pages/overview/define-your-api/ferndef/api-yml.mdx
               - page: Packages
                 path: ./docs/pages/overview/define-your-api/ferndef/packages.mdx
-              - page: Comparison with OpenAPI
-                path: ./docs/pages/overview/define-your-api/ferndef/comparison.mdx
-      - section: Fern CLI tool
-        slug: cli
+      - section: Fern CLI
         contents:
-          - page: Overview
-            path: ./docs/pages/overview/cli/cli-overview.mdx
-          - section: CLI commands
-            slug: commands
-            contents:
-              - page: fern generate
-                path: ./docs/pages/overview/cli/cli-commands/fern-generate.mdx
-              - page: fern check
-                path: ./docs/pages/overview/cli/cli-commands/fern-check.mdx
-              - page: fern add
-                path: ./docs/pages/overview/cli/cli-commands/fern-add.mdx
-              - page: fern init
-                path: ./docs/pages/overview/cli/cli-commands/fern-init.mdx
-              - page: fern write-definition
-                path: ./docs/pages/overview/cli/cli-commands/fern-write-definition.mdx
-              - page: fern upgrade
-                path: ./docs/pages/overview/cli/cli-commands/fern-upgrade.mdx
-              - page: fern token
-                path: ./docs/pages/overview/cli/cli-commands/fern-token.mdx
-              - page: fern login
-                path: ./docs/pages/overview/cli/cli-commands/fern-login.mdx
-              - page: fern format
-                path: ./docs/pages/overview/cli/cli-commands/fern-format.mdx
-              - page: fern help
-                path: ./docs/pages/overview/cli/cli-commands/fern-help.mdx
-              - page: fern version
-                path: ./docs/pages/overview/cli/cli-commands/fern-version.mdx
-      - section: Changelog
-        contents:
-          - page: December 2023
-            path: ./docs/pages/overview/changelog/december-2023.mdx
-          - page: February 2024
-            path: ./docs/pages/overview/changelog/february-2024.mdx
-  - tab: sdks
-    layout:
-      - page: Overview
-        path: ./docs/pages/fern-sdks/sdks-overview.mdx
-      - section: Fern SDKs Quickstarts
-        slug: quickstarts
-        contents:
-          - page: Fern SDKs Quickstart with OpenAPI
-            slug: openapi
-            path: ./docs/pages/fern-sdks/sdks-quickstarts/sdks-quickstart-openapi.mdx
-          - page: Fern SDKs Quickstart with Fern Def
-            slug: ferndef
-            path: ./docs/pages/fern-sdks/sdks-quickstarts/sdks-quickstart-ferndef.mdx
-      - section: SDK generators
-        contents:
-          - page: TypeScript SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/typescript-sdk.mdx
-            slug: typescript
-          - page: Python SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/python-sdk.mdx
-            slug: python
-          - page: Java SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/java-sdk.mdx
-            slug: java
-          - page: Go SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/go-sdk.mdx
-            slug: go
-          - page: Ruby SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/ruby-sdk.mdx
-            slug: ruby
-          - page: C# SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/csharp-sdk.mdx
-            slug: csharp
-          - page: PHP SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/php-sdk.mdx
-            slug: php
-          - page: Swift SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/swift-sdk.mdx
-            slug: swift
-          - page: Rust SDK
-            path: ./docs/pages/fern-sdks/sdk-generators/rust-sdk.mdx
-            slug: rust
-      - section: Other generators
-        contents:
-          - section: Server-side
-            contents:
-              - page: Express.js
-                path: ./docs/pages/fern-sdks/other-generators/server-side/express.mdx
-                slug: express
-              - page: FastAPI
-                path: ./docs/pages/fern-sdks/other-generators/server-side/fastapi.mdx
-                slug: fastapi
-              - page: Spring
-                path: ./docs/pages/fern-sdks/other-generators/server-side/spring.mdx
-          - section: Specification
-            slug: spec
-            contents:
-              - page: OpenAPI generator
-                slug: openapi
-                path: ./docs/pages/fern-sdks/other-generators/spec/openapi-generator.mdx
-              - page: Postman Collection generator
-                slug: postman
-                path: ./docs/pages/fern-sdks/other-generators/spec/postman-collection.mdx
-      - section: Guides
-        contents:
-          - page: Publish to Maven Central
-            path: ./docs/pages/fern-sdks/guides/publish-to-maven-central.mdx
-            slug: publish-maven
-          - page: Update SDKs with Fern's GitHub Bot
-            path: ./docs/pages/fern-sdks/guides/github-bot.mdx
-            slug: github-bot
-      - api: API Reference
-        api-name: public-api
-        # audiences:
-        #   - external
-        snippets:
-          python: fern-api
-          typescript: "@fern-api/node-sdk"
-  - tab: docs
-    layout:
-      - page: Overview
-        path: ./docs/pages/fern-docs/docs-overview.mdx
-      - section: Quickstarts
-        slug: quickstarts
-        contents:
-          - page: Use OpenAPI
-            slug: openapi
-            path: ./docs/pages/fern-docs/docs-quickstarts/docs-quickstart-openapi.mdx
-          - page: Use a Fern Definition
-            slug: ferndef
-            path: ./docs/pages/fern-docs/docs-quickstarts/docs-quickstart-ferndef.mdx
-      - section: Configuration
-        slug: config
-        contents:
-          - page: Overview
-            path: ./docs/pages/fern-docs/config/config-overview.mdx
-          - page: Navigation
-            path: ./docs/pages/fern-docs/config/navigation.mdx
-          - page: PR previews
-            slug: previews
-            path: ./docs/pages/fern-docs/config/previews.mdx
-          - section: Customize branding
-            slug: branding
-            contents:
-              - page: Colors, fonts, and background image
-                path: ./docs/pages/fern-docs/config/branding/colors-fonts-background-image.mdx
-                slug: colors-fonts-background-image
-              - page: Logo and favicon
-                path: ./docs/pages/fern-docs/config/branding/logo-and-favicon.mdx
-              - page: Custom domain
-                path: ./docs/pages/fern-docs/config/branding/custom-domain.mdx
-
-      - section: Write content
-        slug: content
-        contents:
-          - page: Write Markdown content
-            path: ./docs/pages/fern-docs/content/write-markdown.mdx
-            slug: write-markdown
-          - page: Frontmatter
-            path: ./docs/pages/fern-docs/content/front-matter.mdx
-          - page: Code snippets
-            path: ./docs/pages/fern-docs/content/code-snippets.mdx
-
-      - section: API references
-        contents:
-          - page: Generate API reference
-            path: ./docs/pages/fern-docs/content/generate-api-ref.mdx
-            slug: generate-api-ref
-          - page: Audiences
-            path: ./docs/pages/fern-docs/config/audiences.mdx
-          - page: SDK snippets
-            path: ./docs/pages/fern-docs/config/sdk-snippets.mdx
-          - page: Endpoint errors
-            path: ./docs/pages/fern-docs/config/endpoint-errors.mdx
-
-      - section: Components
-        slug: components
-        contents:
-          - page: Accordion
-            path: ./docs/pages/fern-docs/components/accordion.mdx
-          - page: Availability
-            path: ./docs/pages/fern-docs/components/availability.mdx
-          - page: Callout
-            path: ./docs/pages/fern-docs/components/callout.mdx
-          - page: Cards
-            path: ./docs/pages/fern-docs/components/card.mdx
-          - page: Code Blocks
-            path: ./docs/pages/fern-docs/components/codeblocks.mdx
-            slug: codeblocks
-          - page: Endpoint Snippets
-            path: ./docs/pages/fern-docs/components/endpoint-snippets.mdx
-          - page: Icon
-            path: ./docs/pages/fern-docs/components/icon.mdx
-          - page: Steps
-            path: ./docs/pages/fern-docs/components/steps.mdx
-          - page: Tabs
-            path: ./docs/pages/fern-docs/components/tabs.mdx
+          - page: fern init
+            path: ./overview/dummy.mdx
+          - page: fern check
+            path: ./overview/dummy.mdx
+          - page: fern generate
+            path: ./overview/dummy.mdx
+          - page: fern login
+            path: ./overview/dummy.mdx
+          - page: fern token
+            path: ./overview/dummy.mdx
+  - api: API Reference
+    api-name: public-api
 
 navbar-links:
-  - type: minimal
-    text: GitHub
-    url: https://github.com/fern-api/fern
   - type: filled
     text: Book a demo
     url: https://buildwithfern.com/contact
@@ -283,15 +202,14 @@ logo:
   light: ./docs/images/logo-green.png
   dark: ./docs/images/logo-white.png
   height: 30
-# background-image:
-#   dark: ./docs/images/background.svg
+
 colors:
   accentPrimary:
     dark: "#ADFF8C"
-    light: "#418326"
+    # light: "#418326"
   background:
     dark: "#000000"
-    light: "#FFFFFF"
+    # light: "#FFFFFF"
 favicon: ./docs/images/favicon.ico
 
 layout:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -8,19 +8,40 @@ instances:
         branch: main
 title: Fern | Documentation
 
-navigation: 
-  - section: Home
-    contents: 
+tabs:
+  home:
+    display-name: Home
+    icon: globe
+  sdks:
+    display-name: Generate SDKs
+    slug: sdks
+    icon: code
+  docs:
+    display-name: Generate docs
+    slug: docs
+    icon: book
+  config:
+    display-name: Configure
+    slug: config
+    icon: puzzle
+  api:
+    display-name: API reference
+    slug: api
+    icon: asterisk
+
+navigation:
+  - tab: home
+    layout:
       - page: Introduction
         path: ./overview/intro.mdx
-  - section: SDKs
-    contents: 
+  - tab: sdks
+    layout:
       - page: Overview
         path: ./overview/dummy.mdx
       - page: Quickstart
         path: ./overview/dummy.mdx
       - section: Features
-        contents: 
+        contents:
           - page: Strongly typed
             path: ./overview/dummy.mdx
           - page: Idiomatic method names
@@ -33,7 +54,7 @@ navigation:
             path: ./overview/dummy.mdx
           - page: Webhook Signature Verification
             path: ./overview/dummy.mdx
-          - page: Forward Compatibility  
+          - page: Forward Compatibility
             path: ./overview/dummy.mdx
           - page: Multipart Form Data
             path: ./overview/dummy.mdx
@@ -51,16 +72,18 @@ navigation:
             path: ./overview/dummy.mdx
           - page: GitHub integration
             path: ./overview/dummy.mdx
-  - section: Docs
-    contents: 
+  - tab: docs
+    layout:
       - page: Overview
         path: ./overview/dummy.mdx
       - page: Quickstart
         path: ./overview/dummy.mdx
       - section: Global Settings
-        contents: 
+        collapsed: true
+        contents:
           - page: URLs
             path: ./overview/dummy.mdx
+            slug: urls
           - page: Colors
             path: ./overview/dummy.mdx
           - page: Layout
@@ -74,7 +97,8 @@ navigation:
           - page: Call to actions
             path: ./overview/dummy.mdx
       - section: Writing Content
-        contents: 
+        collapsed: true
+        contents:
           - page: Page Titles and Metadata
             path: ./overview/dummy.mdx
           - page: Headers and Text
@@ -86,35 +110,37 @@ navigation:
           - page: Code Blocks
             path: ./overview/dummy.mdx
       - section: API References
-        contents: 
+        collapsed: true
+        contents:
           - page: API Definition Setup
             path: ./overview/dummy.mdx
-          - page: Errors, Audiences, and Snippets 
+          - page: Errors, Audiences, and Snippets
             path: ./overview/dummy.mdx
           - page: API Playground
             path: ./overview/dummy.mdx
       - section: Custom Components
-        contents: 
-          - page: Cards
-            path: ./overview/dummy.mdx
-          - page: CodeBlocks
-            path: ./overview/dummy.mdx
-          - page: Callouts
-            path: ./overview/dummy.mdx
-          - page: Icons
+        collapsed: true
+        contents:
+          - page: Accordion
             path: ./overview/dummy.mdx
           - page: Availability
             path: ./overview/dummy.mdx
-          - page: Tabs
+          - page: Callout
             path: ./overview/dummy.mdx
-          - page: Accordion
+          - page: Cards
             path: ./overview/dummy.mdx
-          - page: Steps
+          - page: Code Blocks
             path: ./overview/dummy.mdx
           - page: Endpoint Snippets
             path: ./overview/dummy.mdx
-  - section: Configuration
-    contents: 
+          - page: Icon
+            path: ./overview/dummy.mdx
+          - page: Steps
+            path: ./overview/dummy.mdx
+          - page: Tabs
+            path: ./overview/dummy.mdx
+  - tab: config
+    layout:
       - section: Fern Folder
         contents:
           - page: Overview
@@ -126,11 +152,11 @@ navigation:
       - section: API Definitions
         contents:
           - section: OpenAPI Spec
-            contents: 
+            contents:
               - page: Overview
                 path: ./overview/dummy.mdx
               - section: Extensions
-                contents: 
+                contents:
                   - page: Overriding Names
                     path: ./overview/dummy.mdx
                   - page: Auth and Global Headers
@@ -146,11 +172,11 @@ navigation:
                   - page: Examples
                     path: ./overview/dummy.mdx
           - section: AsyncAPI Spec
-            contents: 
+            contents:
               - page: Overview
                 path: ./overview/dummy.mdx
           - section: gRPC
-            contents: 
+            contents:
               - page: Overview
                 path: ./overview/dummy.mdx
           - section: Fern Definition
@@ -189,8 +215,10 @@ navigation:
             path: ./overview/dummy.mdx
           - page: fern token
             path: ./overview/dummy.mdx
-  - api: API Reference
-    api-name: public-api
+  - tab: api
+    layout:
+      - api: API Reference
+        api-name: public-api
 
 navbar-links:
   - type: filled
@@ -204,7 +232,7 @@ logo:
   height: 30
 
 colors:
-  accentPrimary:
+  accent-primary:
     dark: "#ADFF8C"
     # light: "#418326"
   background:

--- a/fern/overview/dummy.mdx
+++ b/fern/overview/dummy.mdx
@@ -1,0 +1,9 @@
+---
+excerpt: "This page is under construction"
+---
+
+<Card
+  title="TBD"
+>
+  This page is under construction
+</Card>

--- a/fern/overview/intro.mdx
+++ b/fern/overview/intro.mdx
@@ -1,0 +1,45 @@
+---
+title: "Fern"
+description: "Level-up your API developer experience"
+---
+
+**Fern is a toolkit for improving API developer experience.** Fern reads your API Definition (e.g. OpenAPI) 
+and generates documentation, SDKs, and server-side code.
+
+- **Docs:** A beautiful docs website that can be customized to match your brand. 
+- **SDKs:** Client libraries in multiple languages that stay in sync with your API. 
+- **Server-side code generation:** Generate boilerplate on the server
+  side, like Pydantic models for FastAPI and Jersey interfaces for Spring Boot.
+
+## Getting started
+
+<Cards>
+  <Card
+    title="Docs"
+    icon="fa-solid fa-browser"
+    href="/api-reference"
+  >
+    Generate a Stripe-like docs website
+  </Card>
+  <Card
+    title="SDKs"
+    icon="fa-brands fa-codepen"
+    href="https://discord.com/invite/JkkXumPzcG"
+  >
+    Generate client libraries in multiple languages
+  </Card>
+  <Card
+    title="Server-side boilerplate"
+    icon="fa-solid fa-pen"
+    href="https://blog.buildwithfern.com"
+  >
+    Generate boilerplate on the server side
+  </Card>
+  <Card
+    title="Schedule a demo"
+    icon="fa-solid fa-face-awesome"
+    href="https://security.buildwithfern.com"
+  >
+    Schedule a demo with our team
+  </Card>
+</Cards>

--- a/seed/csharp-model/alias/src/SeedAlias.sln
+++ b/seed/csharp-model/alias/src/SeedAlias.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAlias", "SeedAlias\SeedAlias.csproj", "{083FE339-31EF-4F76-ADEA-443E3227B729}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAlias.Test", "SeedAlias.Test\SeedAlias.Test.csproj", "{BD3D1717-4445-486C-A5A7-72FE0E153490}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{083FE339-31EF-4F76-ADEA-443E3227B729}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{083FE339-31EF-4F76-ADEA-443E3227B729}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{083FE339-31EF-4F76-ADEA-443E3227B729}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{083FE339-31EF-4F76-ADEA-443E3227B729}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD3D1717-4445-486C-A5A7-72FE0E153490}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD3D1717-4445-486C-A5A7-72FE0E153490}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD3D1717-4445-486C-A5A7-72FE0E153490}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD3D1717-4445-486C-A5A7-72FE0E153490}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.sln
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApiWideBasePath", "SeedApiWideBasePath\SeedApiWideBasePath.csproj", "{5720F8F7-92C9-4F7C-B85C-8D9BC127BA73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApiWideBasePath.Test", "SeedApiWideBasePath.Test\SeedApiWideBasePath.Test.csproj", "{16D5CA98-193D-4BD9-A563-C1AED4854CEC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5720F8F7-92C9-4F7C-B85C-8D9BC127BA73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5720F8F7-92C9-4F7C-B85C-8D9BC127BA73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5720F8F7-92C9-4F7C-B85C-8D9BC127BA73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5720F8F7-92C9-4F7C-B85C-8D9BC127BA73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16D5CA98-193D-4BD9-A563-C1AED4854CEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16D5CA98-193D-4BD9-A563-C1AED4854CEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16D5CA98-193D-4BD9-A563-C1AED4854CEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16D5CA98-193D-4BD9-A563-C1AED4854CEC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/audiences/src/SeedAudiences.sln
+++ b/seed/csharp-model/audiences/src/SeedAudiences.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAudiences", "SeedAudiences\SeedAudiences.csproj", "{6339F7DC-D278-4931-A711-58A5E24302E6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAudiences.Test", "SeedAudiences.Test\SeedAudiences.Test.csproj", "{A68A00EB-1628-48B6-B86A-E006540E35CA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6339F7DC-D278-4931-A711-58A5E24302E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6339F7DC-D278-4931-A711-58A5E24302E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6339F7DC-D278-4931-A711-58A5E24302E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6339F7DC-D278-4931-A711-58A5E24302E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A68A00EB-1628-48B6-B86A-E006540E35CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A68A00EB-1628-48B6-B86A-E006540E35CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A68A00EB-1628-48B6-B86A-E006540E35CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A68A00EB-1628-48B6-B86A-E006540E35CA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/auth-environment-variables/src/SeedAuthEnvironmentVariables.sln
+++ b/seed/csharp-model/auth-environment-variables/src/SeedAuthEnvironmentVariables.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAuthEnvironmentVariables", "SeedAuthEnvironmentVariables\SeedAuthEnvironmentVariables.csproj", "{0F02542E-48DE-47E3-A297-B6FBDA0060CF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAuthEnvironmentVariables.Test", "SeedAuthEnvironmentVariables.Test\SeedAuthEnvironmentVariables.Test.csproj", "{8D21C094-F7D4-4440-A24F-78D53226FDFB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0F02542E-48DE-47E3-A297-B6FBDA0060CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F02542E-48DE-47E3-A297-B6FBDA0060CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F02542E-48DE-47E3-A297-B6FBDA0060CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F02542E-48DE-47E3-A297-B6FBDA0060CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D21C094-F7D4-4440-A24F-78D53226FDFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D21C094-F7D4-4440-A24F-78D53226FDFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D21C094-F7D4-4440-A24F-78D53226FDFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D21C094-F7D4-4440-A24F-78D53226FDFB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth.sln
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBasicAuth", "SeedBasicAuth\SeedBasicAuth.csproj", "{CA70CB90-8E61-4AA2-B6F6-070AC00A0FB5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBasicAuth.Test", "SeedBasicAuth.Test\SeedBasicAuth.Test.csproj", "{64AA86D6-7364-46E6-BD17-F0E027F088EC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA70CB90-8E61-4AA2-B6F6-070AC00A0FB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA70CB90-8E61-4AA2-B6F6-070AC00A0FB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA70CB90-8E61-4AA2-B6F6-070AC00A0FB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA70CB90-8E61-4AA2-B6F6-070AC00A0FB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64AA86D6-7364-46E6-BD17-F0E027F088EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64AA86D6-7364-46E6-BD17-F0E027F088EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64AA86D6-7364-46E6-BD17-F0E027F088EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64AA86D6-7364-46E6-BD17-F0E027F088EC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.sln
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBearerTokenEnvironmentVariable", "SeedBearerTokenEnvironmentVariable\SeedBearerTokenEnvironmentVariable.csproj", "{CDBF5143-960F-40C5-8940-2817988733DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBearerTokenEnvironmentVariable.Test", "SeedBearerTokenEnvironmentVariable.Test\SeedBearerTokenEnvironmentVariable.Test.csproj", "{22C6AE2E-CD7A-459F-8A4A-E8BE1EEE3CBC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CDBF5143-960F-40C5-8940-2817988733DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDBF5143-960F-40C5-8940-2817988733DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDBF5143-960F-40C5-8940-2817988733DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDBF5143-960F-40C5-8940-2817988733DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22C6AE2E-CD7A-459F-8A4A-E8BE1EEE3CBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22C6AE2E-CD7A-459F-8A4A-E8BE1EEE3CBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22C6AE2E-CD7A-459F-8A4A-E8BE1EEE3CBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22C6AE2E-CD7A-459F-8A4A-E8BE1EEE3CBC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/bytes/src/SeedBytes.sln
+++ b/seed/csharp-model/bytes/src/SeedBytes.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBytes", "SeedBytes\SeedBytes.csproj", "{BF0B513C-FF33-4912-80D6-3C95A817971A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBytes.Test", "SeedBytes.Test\SeedBytes.Test.csproj", "{C6670044-72A5-4779-96EC-921E1DDAF074}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BF0B513C-FF33-4912-80D6-3C95A817971A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF0B513C-FF33-4912-80D6-3C95A817971A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF0B513C-FF33-4912-80D6-3C95A817971A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF0B513C-FF33-4912-80D6-3C95A817971A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6670044-72A5-4779-96EC-921E1DDAF074}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6670044-72A5-4779-96EC-921E1DDAF074}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6670044-72A5-4779-96EC-921E1DDAF074}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6670044-72A5-4779-96EC-921E1DDAF074}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi.sln
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{6E6F6B65-3D4E-4179-B367-D377AA8BEE9F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{CF50B25F-9F11-45B1-8EF6-B8836B4DDF2F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6E6F6B65-3D4E-4179-B367-D377AA8BEE9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E6F6B65-3D4E-4179-B367-D377AA8BEE9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E6F6B65-3D4E-4179-B367-D377AA8BEE9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E6F6B65-3D4E-4179-B367-D377AA8BEE9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF50B25F-9F11-45B1-8EF6-B8836B4DDF2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF50B25F-9F11-45B1-8EF6-B8836B4DDF2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF50B25F-9F11-45B1-8EF6-B8836B4DDF2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF50B25F-9F11-45B1-8EF6-B8836B4DDF2F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/circular-references/src/SeedApi.sln
+++ b/seed/csharp-model/circular-references/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{728568F0-CA92-4D3A-A792-A56BCC89A4CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{6B822F48-2B3A-4A6A-8FCE-2BDAA34BAF41}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{728568F0-CA92-4D3A-A792-A56BCC89A4CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{728568F0-CA92-4D3A-A792-A56BCC89A4CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{728568F0-CA92-4D3A-A792-A56BCC89A4CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{728568F0-CA92-4D3A-A792-A56BCC89A4CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B822F48-2B3A-4A6A-8FCE-2BDAA34BAF41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B822F48-2B3A-4A6A-8FCE-2BDAA34BAF41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B822F48-2B3A-4A6A-8FCE-2BDAA34BAF41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B822F48-2B3A-4A6A-8FCE-2BDAA34BAF41}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/code-samples/src/SeedCodeSamples.sln
+++ b/seed/csharp-model/code-samples/src/SeedCodeSamples.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCodeSamples", "SeedCodeSamples\SeedCodeSamples.csproj", "{B05B4253-CDDE-443C-88BD-A498827A3131}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCodeSamples.Test", "SeedCodeSamples.Test\SeedCodeSamples.Test.csproj", "{82F0AFD7-059D-47B9-B0A0-1646166A5F57}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B05B4253-CDDE-443C-88BD-A498827A3131}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B05B4253-CDDE-443C-88BD-A498827A3131}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B05B4253-CDDE-443C-88BD-A498827A3131}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B05B4253-CDDE-443C-88BD-A498827A3131}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82F0AFD7-059D-47B9-B0A0-1646166A5F57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82F0AFD7-059D-47B9-B0A0-1646166A5F57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82F0AFD7-059D-47B9-B0A0-1646166A5F57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82F0AFD7-059D-47B9-B0A0-1646166A5F57}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/custom-auth/src/SeedCustomAuth.sln
+++ b/seed/csharp-model/custom-auth/src/SeedCustomAuth.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCustomAuth", "SeedCustomAuth\SeedCustomAuth.csproj", "{481BF4C7-6FA9-444B-AA54-15247A9D5975}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCustomAuth.Test", "SeedCustomAuth.Test\SeedCustomAuth.Test.csproj", "{5BB7926E-84EA-437F-9C4C-0C97AC77BDFD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{481BF4C7-6FA9-444B-AA54-15247A9D5975}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{481BF4C7-6FA9-444B-AA54-15247A9D5975}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{481BF4C7-6FA9-444B-AA54-15247A9D5975}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{481BF4C7-6FA9-444B-AA54-15247A9D5975}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BB7926E-84EA-437F-9C4C-0C97AC77BDFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BB7926E-84EA-437F-9C4C-0C97AC77BDFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BB7926E-84EA-437F-9C4C-0C97AC77BDFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BB7926E-84EA-437F-9C4C-0C97AC77BDFD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/enum/src/SeedEnum.sln
+++ b/seed/csharp-model/enum/src/SeedEnum.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedEnum", "SeedEnum\SeedEnum.csproj", "{5528A55B-A404-47D2-B857-9EEE3A838BEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedEnum.Test", "SeedEnum.Test\SeedEnum.Test.csproj", "{2B3875EE-30B8-4F1C-A862-9EB82717C05C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5528A55B-A404-47D2-B857-9EEE3A838BEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5528A55B-A404-47D2-B857-9EEE3A838BEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5528A55B-A404-47D2-B857-9EEE3A838BEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5528A55B-A404-47D2-B857-9EEE3A838BEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B3875EE-30B8-4F1C-A862-9EB82717C05C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B3875EE-30B8-4F1C-A862-9EB82717C05C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B3875EE-30B8-4F1C-A862-9EB82717C05C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B3875EE-30B8-4F1C-A862-9EB82717C05C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/error-property/src/SeedErrorProperty.sln
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedErrorProperty", "SeedErrorProperty\SeedErrorProperty.csproj", "{DFE1FFB3-FE5F-46C3-972B-CDBD0DE5C68F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedErrorProperty.Test", "SeedErrorProperty.Test\SeedErrorProperty.Test.csproj", "{3E66FB34-1FAC-4341-A644-0BCDED079886}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DFE1FFB3-FE5F-46C3-972B-CDBD0DE5C68F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFE1FFB3-FE5F-46C3-972B-CDBD0DE5C68F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFE1FFB3-FE5F-46C3-972B-CDBD0DE5C68F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFE1FFB3-FE5F-46C3-972B-CDBD0DE5C68F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E66FB34-1FAC-4341-A644-0BCDED079886}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E66FB34-1FAC-4341-A644-0BCDED079886}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E66FB34-1FAC-4341-A644-0BCDED079886}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E66FB34-1FAC-4341-A644-0BCDED079886}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/examples/src/SeedExamples.sln
+++ b/seed/csharp-model/examples/src/SeedExamples.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExamples", "SeedExamples\SeedExamples.csproj", "{C41D47FA-6EC2-4FB7-8D44-4633D63CF96F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExamples.Test", "SeedExamples.Test\SeedExamples.Test.csproj", "{6551EAEE-F6AB-4E22-A51E-3D9150117140}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C41D47FA-6EC2-4FB7-8D44-4633D63CF96F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C41D47FA-6EC2-4FB7-8D44-4633D63CF96F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C41D47FA-6EC2-4FB7-8D44-4633D63CF96F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C41D47FA-6EC2-4FB7-8D44-4633D63CF96F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6551EAEE-F6AB-4E22-A51E-3D9150117140}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6551EAEE-F6AB-4E22-A51E-3D9150117140}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6551EAEE-F6AB-4E22-A51E-3D9150117140}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6551EAEE-F6AB-4E22-A51E-3D9150117140}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive.sln
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExhaustive", "SeedExhaustive\SeedExhaustive.csproj", "{6C36BE44-DC80-41CF-900C-E01D3FECF0C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExhaustive.Test", "SeedExhaustive.Test\SeedExhaustive.Test.csproj", "{F4D1CF16-19DD-4907-9428-459839562A0E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6C36BE44-DC80-41CF-900C-E01D3FECF0C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C36BE44-DC80-41CF-900C-E01D3FECF0C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C36BE44-DC80-41CF-900C-E01D3FECF0C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C36BE44-DC80-41CF-900C-E01D3FECF0C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4D1CF16-19DD-4907-9428-459839562A0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4D1CF16-19DD-4907-9428-459839562A0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4D1CF16-19DD-4907-9428-459839562A0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4D1CF16-19DD-4907-9428-459839562A0E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/extends/src/SeedExtends.sln
+++ b/seed/csharp-model/extends/src/SeedExtends.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExtends", "SeedExtends\SeedExtends.csproj", "{CF559664-4E38-4C2E-8C58-5A91366F7E3B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExtends.Test", "SeedExtends.Test\SeedExtends.Test.csproj", "{B5D99D66-CFCB-4636-8D38-66FE8BACE75B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF559664-4E38-4C2E-8C58-5A91366F7E3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF559664-4E38-4C2E-8C58-5A91366F7E3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF559664-4E38-4C2E-8C58-5A91366F7E3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF559664-4E38-4C2E-8C58-5A91366F7E3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5D99D66-CFCB-4636-8D38-66FE8BACE75B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5D99D66-CFCB-4636-8D38-66FE8BACE75B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5D99D66-CFCB-4636-8D38-66FE8BACE75B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5D99D66-CFCB-4636-8D38-66FE8BACE75B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/file-download/src/SeedFileDownload.sln
+++ b/seed/csharp-model/file-download/src/SeedFileDownload.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileDownload", "SeedFileDownload\SeedFileDownload.csproj", "{F2ABA1BC-A52F-4E9B-923E-E84A0EC9FC7D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileDownload.Test", "SeedFileDownload.Test\SeedFileDownload.Test.csproj", "{93D28748-1FCD-4F9D-981D-28AAF6B701C2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F2ABA1BC-A52F-4E9B-923E-E84A0EC9FC7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2ABA1BC-A52F-4E9B-923E-E84A0EC9FC7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2ABA1BC-A52F-4E9B-923E-E84A0EC9FC7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2ABA1BC-A52F-4E9B-923E-E84A0EC9FC7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93D28748-1FCD-4F9D-981D-28AAF6B701C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93D28748-1FCD-4F9D-981D-28AAF6B701C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93D28748-1FCD-4F9D-981D-28AAF6B701C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93D28748-1FCD-4F9D-981D-28AAF6B701C2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/file-upload/src/SeedFileUpload.sln
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileUpload", "SeedFileUpload\SeedFileUpload.csproj", "{7A11ADFC-9462-46E6-B32B-296DC9813CC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileUpload.Test", "SeedFileUpload.Test\SeedFileUpload.Test.csproj", "{3DA50129-789F-4318-878A-72946432C176}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7A11ADFC-9462-46E6-B32B-296DC9813CC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A11ADFC-9462-46E6-B32B-296DC9813CC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A11ADFC-9462-46E6-B32B-296DC9813CC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A11ADFC-9462-46E6-B32B-296DC9813CC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DA50129-789F-4318-878A-72946432C176}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DA50129-789F-4318-878A-72946432C176}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DA50129-789F-4318-878A-72946432C176}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DA50129-789F-4318-878A-72946432C176}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/folders/src/SeedApi.sln
+++ b/seed/csharp-model/folders/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{D6696DCB-1107-41FB-AEB9-781DD68B425E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{B2B1C5AD-274B-4995-A735-0FB2BF84E027}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D6696DCB-1107-41FB-AEB9-781DD68B425E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6696DCB-1107-41FB-AEB9-781DD68B425E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6696DCB-1107-41FB-AEB9-781DD68B425E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6696DCB-1107-41FB-AEB9-781DD68B425E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2B1C5AD-274B-4995-A735-0FB2BF84E027}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2B1C5AD-274B-4995-A735-0FB2BF84E027}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2B1C5AD-274B-4995-A735-0FB2BF84E027}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2B1C5AD-274B-4995-A735-0FB2BF84E027}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.sln
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedIdempotencyHeaders", "SeedIdempotencyHeaders\SeedIdempotencyHeaders.csproj", "{9C135C11-37FA-4E7C-86CA-11F2267EB7F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedIdempotencyHeaders.Test", "SeedIdempotencyHeaders.Test\SeedIdempotencyHeaders.Test.csproj", "{FE283ACC-2F8B-48F2-B337-2735BE1C4F1D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9C135C11-37FA-4E7C-86CA-11F2267EB7F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C135C11-37FA-4E7C-86CA-11F2267EB7F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C135C11-37FA-4E7C-86CA-11F2267EB7F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C135C11-37FA-4E7C-86CA-11F2267EB7F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE283ACC-2F8B-48F2-B337-2735BE1C4F1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE283ACC-2F8B-48F2-B337-2735BE1C4F1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE283ACC-2F8B-48F2-B337-2735BE1C4F1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE283ACC-2F8B-48F2-B337-2735BE1C4F1D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/imdb/src/SeedApi.sln
+++ b/seed/csharp-model/imdb/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{52C07574-8FE5-4F5C-A8F5-5591887E714D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{17365BF8-27CF-4197-9674-6D15CAB51696}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{52C07574-8FE5-4F5C-A8F5-5591887E714D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52C07574-8FE5-4F5C-A8F5-5591887E714D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52C07574-8FE5-4F5C-A8F5-5591887E714D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52C07574-8FE5-4F5C-A8F5-5591887E714D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17365BF8-27CF-4197-9674-6D15CAB51696}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17365BF8-27CF-4197-9674-6D15CAB51696}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17365BF8-27CF-4197-9674-6D15CAB51696}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17365BF8-27CF-4197-9674-6D15CAB51696}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/literal/src/SeedLiteral.sln
+++ b/seed/csharp-model/literal/src/SeedLiteral.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedLiteral", "SeedLiteral\SeedLiteral.csproj", "{C0C0170A-BEF3-46F4-A865-6C2710F70D12}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedLiteral.Test", "SeedLiteral.Test\SeedLiteral.Test.csproj", "{1ECBED71-8890-4F89-B879-1E04911288F3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C0C0170A-BEF3-46F4-A865-6C2710F70D12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0C0170A-BEF3-46F4-A865-6C2710F70D12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0C0170A-BEF3-46F4-A865-6C2710F70D12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0C0170A-BEF3-46F4-A865-6C2710F70D12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1ECBED71-8890-4F89-B879-1E04911288F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1ECBED71-8890-4F89-B879-1E04911288F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1ECBED71-8890-4F89-B879-1E04911288F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1ECBED71-8890-4F89-B879-1E04911288F3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.sln
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedMultiUrlEnvironment", "SeedMultiUrlEnvironment\SeedMultiUrlEnvironment.csproj", "{1E4A640F-258A-4FA9-B414-74E0112B7728}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedMultiUrlEnvironment.Test", "SeedMultiUrlEnvironment.Test\SeedMultiUrlEnvironment.Test.csproj", "{FCBE46D9-CE1E-48B3-BD9B-FF6B9131A76E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E4A640F-258A-4FA9-B414-74E0112B7728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E4A640F-258A-4FA9-B414-74E0112B7728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E4A640F-258A-4FA9-B414-74E0112B7728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E4A640F-258A-4FA9-B414-74E0112B7728}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCBE46D9-CE1E-48B3-BD9B-FF6B9131A76E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCBE46D9-CE1E-48B3-BD9B-FF6B9131A76E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCBE46D9-CE1E-48B3-BD9B-FF6B9131A76E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCBE46D9-CE1E-48B3-BD9B-FF6B9131A76E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment.sln
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNoEnvironment", "SeedNoEnvironment\SeedNoEnvironment.csproj", "{FC75CA1B-7AEC-4BE5-B05E-DBB0DE0BFB7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNoEnvironment.Test", "SeedNoEnvironment.Test\SeedNoEnvironment.Test.csproj", "{5566E99B-F21F-4460-B28D-4DF0DC0787E2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FC75CA1B-7AEC-4BE5-B05E-DBB0DE0BFB7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC75CA1B-7AEC-4BE5-B05E-DBB0DE0BFB7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC75CA1B-7AEC-4BE5-B05E-DBB0DE0BFB7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC75CA1B-7AEC-4BE5-B05E-DBB0DE0BFB7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5566E99B-F21F-4460-B28D-4DF0DC0787E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5566E99B-F21F-4460-B28D-4DF0DC0787E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5566E99B-F21F-4460-B28D-4DF0DC0787E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5566E99B-F21F-4460-B28D-4DF0DC0787E2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/object/src/SeedObject.sln
+++ b/seed/csharp-model/object/src/SeedObject.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObject", "SeedObject\SeedObject.csproj", "{C4C343FA-13E8-4851-B860-F5FC925BF0DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObject.Test", "SeedObject.Test\SeedObject.Test.csproj", "{0242C866-0F36-445D-B35B-DFC30BB842F4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C4C343FA-13E8-4851-B860-F5FC925BF0DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4C343FA-13E8-4851-B860-F5FC925BF0DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4C343FA-13E8-4851-B860-F5FC925BF0DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4C343FA-13E8-4851-B860-F5FC925BF0DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0242C866-0F36-445D-B35B-DFC30BB842F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0242C866-0F36-445D-B35B-DFC30BB842F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0242C866-0F36-445D-B35B-DFC30BB842F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0242C866-0F36-445D-B35B-DFC30BB842F4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.sln
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports", "SeedObjectsWithImports\SeedObjectsWithImports.csproj", "{AD53C5A6-DF12-4372-BCC5-5F57BCFC0720}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports.Test", "SeedObjectsWithImports.Test\SeedObjectsWithImports.Test.csproj", "{E77C2C06-252B-4AE8-8132-7BE4DFF4C148}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AD53C5A6-DF12-4372-BCC5-5F57BCFC0720}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD53C5A6-DF12-4372-BCC5-5F57BCFC0720}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD53C5A6-DF12-4372-BCC5-5F57BCFC0720}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD53C5A6-DF12-4372-BCC5-5F57BCFC0720}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E77C2C06-252B-4AE8-8132-7BE4DFF4C148}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E77C2C06-252B-4AE8-8132-7BE4DFF4C148}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E77C2C06-252B-4AE8-8132-7BE4DFF4C148}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E77C2C06-252B-4AE8-8132-7BE4DFF4C148}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports.sln
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports", "SeedObjectsWithImports\SeedObjectsWithImports.csproj", "{515431B4-64D0-4CC1-81AD-A81DB419D88D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports.Test", "SeedObjectsWithImports.Test\SeedObjectsWithImports.Test.csproj", "{E8DC6CAD-3FFD-4B69-9C3A-DC36C8ABB899}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{515431B4-64D0-4CC1-81AD-A81DB419D88D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{515431B4-64D0-4CC1-81AD-A81DB419D88D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{515431B4-64D0-4CC1-81AD-A81DB419D88D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{515431B4-64D0-4CC1-81AD-A81DB419D88D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8DC6CAD-3FFD-4B69-9C3A-DC36C8ABB899}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8DC6CAD-3FFD-4B69-9C3A-DC36C8ABB899}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8DC6CAD-3FFD-4B69-9C3A-DC36C8ABB899}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8DC6CAD-3FFD-4B69-9C3A-DC36C8ABB899}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/package-yml/src/SeedPackageYml.sln
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPackageYml", "SeedPackageYml\SeedPackageYml.csproj", "{AC6CE60D-2330-427A-864C-DD577CC73F15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPackageYml.Test", "SeedPackageYml.Test\SeedPackageYml.Test.csproj", "{FE5DC944-7847-430F-8BDA-901EEECDBA18}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC6CE60D-2330-427A-864C-DD577CC73F15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC6CE60D-2330-427A-864C-DD577CC73F15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC6CE60D-2330-427A-864C-DD577CC73F15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC6CE60D-2330-427A-864C-DD577CC73F15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE5DC944-7847-430F-8BDA-901EEECDBA18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE5DC944-7847-430F-8BDA-901EEECDBA18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE5DC944-7847-430F-8BDA-901EEECDBA18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE5DC944-7847-430F-8BDA-901EEECDBA18}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/plain-text/src/SeedPlainText.sln
+++ b/seed/csharp-model/plain-text/src/SeedPlainText.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPlainText", "SeedPlainText\SeedPlainText.csproj", "{760317FC-11B4-4990-8F1D-2D323A9B1F99}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPlainText.Test", "SeedPlainText.Test\SeedPlainText.Test.csproj", "{18385195-19A4-47A0-9B41-24479D898073}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{760317FC-11B4-4990-8F1D-2D323A9B1F99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{760317FC-11B4-4990-8F1D-2D323A9B1F99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{760317FC-11B4-4990-8F1D-2D323A9B1F99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{760317FC-11B4-4990-8F1D-2D323A9B1F99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18385195-19A4-47A0-9B41-24479D898073}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18385195-19A4-47A0-9B41-24479D898073}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18385195-19A4-47A0-9B41-24479D898073}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18385195-19A4-47A0-9B41-24479D898073}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters.sln
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedQueryParameters", "SeedQueryParameters\SeedQueryParameters.csproj", "{A1201655-1AD9-4DEF-845D-36DCBE7F5755}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedQueryParameters.Test", "SeedQueryParameters.Test\SeedQueryParameters.Test.csproj", "{6C70FA2B-5297-4195-95E1-BF8F912A1F1D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1201655-1AD9-4DEF-845D-36DCBE7F5755}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1201655-1AD9-4DEF-845D-36DCBE7F5755}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1201655-1AD9-4DEF-845D-36DCBE7F5755}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1201655-1AD9-4DEF-845D-36DCBE7F5755}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C70FA2B-5297-4195-95E1-BF8F912A1F1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C70FA2B-5297-4195-95E1-BF8F912A1F1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C70FA2B-5297-4195-95E1-BF8F912A1F1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C70FA2B-5297-4195-95E1-BF8F912A1F1D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.sln
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNurseryApi", "SeedNurseryApi\SeedNurseryApi.csproj", "{8BD2930B-E85A-4B89-A000-3A45C184F2B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNurseryApi.Test", "SeedNurseryApi.Test\SeedNurseryApi.Test.csproj", "{93B8C171-ED0F-489F-AFC3-04CB0A2CA908}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8BD2930B-E85A-4B89-A000-3A45C184F2B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD2930B-E85A-4B89-A000-3A45C184F2B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD2930B-E85A-4B89-A000-3A45C184F2B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD2930B-E85A-4B89-A000-3A45C184F2B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93B8C171-ED0F-489F-AFC3-04CB0A2CA908}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93B8C171-ED0F-489F-AFC3-04CB0A2CA908}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93B8C171-ED0F-489F-AFC3-04CB0A2CA908}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93B8C171-ED0F-489F-AFC3-04CB0A2CA908}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/response-property/src/SeedResponseProperty.sln
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedResponseProperty", "SeedResponseProperty\SeedResponseProperty.csproj", "{7615215C-7AB0-40C4-AE9A-C3EDAECC3D87}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedResponseProperty.Test", "SeedResponseProperty.Test\SeedResponseProperty.Test.csproj", "{3F22EB74-4C46-44D0-A562-70FF82983818}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7615215C-7AB0-40C4-AE9A-C3EDAECC3D87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7615215C-7AB0-40C4-AE9A-C3EDAECC3D87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7615215C-7AB0-40C4-AE9A-C3EDAECC3D87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7615215C-7AB0-40C4-AE9A-C3EDAECC3D87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F22EB74-4C46-44D0-A562-70FF82983818}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F22EB74-4C46-44D0-A562-70FF82983818}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F22EB74-4C46-44D0-A562-70FF82983818}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F22EB74-4C46-44D0-A562-70FF82983818}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.sln
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentDefault", "SeedSingleUrlEnvironmentDefault\SeedSingleUrlEnvironmentDefault.csproj", "{11E2642C-AB4E-403D-A12B-3C334034CA17}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentDefault.Test", "SeedSingleUrlEnvironmentDefault.Test\SeedSingleUrlEnvironmentDefault.Test.csproj", "{E44EF87A-3DD7-46A0-8AFA-F08C41C70BB9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11E2642C-AB4E-403D-A12B-3C334034CA17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11E2642C-AB4E-403D-A12B-3C334034CA17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11E2642C-AB4E-403D-A12B-3C334034CA17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11E2642C-AB4E-403D-A12B-3C334034CA17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E44EF87A-3DD7-46A0-8AFA-F08C41C70BB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E44EF87A-3DD7-46A0-8AFA-F08C41C70BB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E44EF87A-3DD7-46A0-8AFA-F08C41C70BB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E44EF87A-3DD7-46A0-8AFA-F08C41C70BB9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.sln
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentNoDefault", "SeedSingleUrlEnvironmentNoDefault\SeedSingleUrlEnvironmentNoDefault.csproj", "{9AD5B8F5-4E08-4326-94EB-9C6E6EAA1BAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentNoDefault.Test", "SeedSingleUrlEnvironmentNoDefault.Test\SeedSingleUrlEnvironmentNoDefault.Test.csproj", "{8E6E0B98-563F-4FD3-A79C-8E3FC29BC536}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9AD5B8F5-4E08-4326-94EB-9C6E6EAA1BAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AD5B8F5-4E08-4326-94EB-9C6E6EAA1BAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AD5B8F5-4E08-4326-94EB-9C6E6EAA1BAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AD5B8F5-4E08-4326-94EB-9C6E6EAA1BAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E6E0B98-563F-4FD3-A79C-8E3FC29BC536}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E6E0B98-563F-4FD3-A79C-8E3FC29BC536}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E6E0B98-563F-4FD3-A79C-8E3FC29BC536}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E6E0B98-563F-4FD3-A79C-8E3FC29BC536}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/streaming/src/SeedStreaming.sln
+++ b/seed/csharp-model/streaming/src/SeedStreaming.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedStreaming", "SeedStreaming\SeedStreaming.csproj", "{77F07CE7-F23D-41FB-B317-AE35F2FF3F0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedStreaming.Test", "SeedStreaming.Test\SeedStreaming.Test.csproj", "{F6ED9771-4D09-4184-8D99-DE8DBDB1695B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{77F07CE7-F23D-41FB-B317-AE35F2FF3F0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77F07CE7-F23D-41FB-B317-AE35F2FF3F0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77F07CE7-F23D-41FB-B317-AE35F2FF3F0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77F07CE7-F23D-41FB-B317-AE35F2FF3F0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6ED9771-4D09-4184-8D99-DE8DBDB1695B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6ED9771-4D09-4184-8D99-DE8DBDB1695B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6ED9771-4D09-4184-8D99-DE8DBDB1695B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6ED9771-4D09-4184-8D99-DE8DBDB1695B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/trace/src/SeedTrace.sln
+++ b/seed/csharp-model/trace/src/SeedTrace.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedTrace", "SeedTrace\SeedTrace.csproj", "{8FF6057D-41C3-4EA1-91A3-54F9CC946C75}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedTrace.Test", "SeedTrace.Test\SeedTrace.Test.csproj", "{B02E6832-32DB-4C1C-B2E8-7D94BDF17607}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8FF6057D-41C3-4EA1-91A3-54F9CC946C75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FF6057D-41C3-4EA1-91A3-54F9CC946C75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FF6057D-41C3-4EA1-91A3-54F9CC946C75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FF6057D-41C3-4EA1-91A3-54F9CC946C75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B02E6832-32DB-4C1C-B2E8-7D94BDF17607}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B02E6832-32DB-4C1C-B2E8-7D94BDF17607}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B02E6832-32DB-4C1C-B2E8-7D94BDF17607}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B02E6832-32DB-4C1C-B2E8-7D94BDF17607}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.sln
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUndiscriminatedUnions", "SeedUndiscriminatedUnions\SeedUndiscriminatedUnions.csproj", "{8B7906B2-0153-4BF7-ABAA-50D5DCEC29D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUndiscriminatedUnions.Test", "SeedUndiscriminatedUnions.Test\SeedUndiscriminatedUnions.Test.csproj", "{17D2E05B-DEC1-4BBF-B21C-FB0401B7DA45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8B7906B2-0153-4BF7-ABAA-50D5DCEC29D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B7906B2-0153-4BF7-ABAA-50D5DCEC29D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B7906B2-0153-4BF7-ABAA-50D5DCEC29D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B7906B2-0153-4BF7-ABAA-50D5DCEC29D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17D2E05B-DEC1-4BBF-B21C-FB0401B7DA45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17D2E05B-DEC1-4BBF-B21C-FB0401B7DA45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17D2E05B-DEC1-4BBF-B21C-FB0401B7DA45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17D2E05B-DEC1-4BBF-B21C-FB0401B7DA45}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/unions/src/SeedUnions.sln
+++ b/seed/csharp-model/unions/src/SeedUnions.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnions", "SeedUnions\SeedUnions.csproj", "{3B9EE446-D74E-4865-AE5F-6ADF73048199}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnions.Test", "SeedUnions.Test\SeedUnions.Test.csproj", "{14A00FCC-4BF6-4618-A651-A4166E01FCEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3B9EE446-D74E-4865-AE5F-6ADF73048199}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B9EE446-D74E-4865-AE5F-6ADF73048199}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B9EE446-D74E-4865-AE5F-6ADF73048199}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B9EE446-D74E-4865-AE5F-6ADF73048199}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14A00FCC-4BF6-4618-A651-A4166E01FCEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14A00FCC-4BF6-4618-A651-A4166E01FCEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14A00FCC-4BF6-4618-A651-A4166E01FCEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14A00FCC-4BF6-4618-A651-A4166E01FCEB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny.sln
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnknownAsAny", "SeedUnknownAsAny\SeedUnknownAsAny.csproj", "{FBAD564A-5D7F-4735-B99C-6CB514E23D1D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnknownAsAny.Test", "SeedUnknownAsAny.Test\SeedUnknownAsAny.Test.csproj", "{2A5B80ED-57A3-40E9-8BAE-F1B3E9F89888}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FBAD564A-5D7F-4735-B99C-6CB514E23D1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBAD564A-5D7F-4735-B99C-6CB514E23D1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBAD564A-5D7F-4735-B99C-6CB514E23D1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBAD564A-5D7F-4735-B99C-6CB514E23D1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A5B80ED-57A3-40E9-8BAE-F1B3E9F89888}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A5B80ED-57A3-40E9-8BAE-F1B3E9F89888}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A5B80ED-57A3-40E9-8BAE-F1B3E9F89888}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A5B80ED-57A3-40E9-8BAE-F1B3E9F89888}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/variables/src/SeedVariables.sln
+++ b/seed/csharp-model/variables/src/SeedVariables.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedVariables", "SeedVariables\SeedVariables.csproj", "{53FCFCD1-5C19-4458-897F-09F1C2E77B5F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedVariables.Test", "SeedVariables.Test\SeedVariables.Test.csproj", "{B66027E7-332B-4786-9117-2DB33AC484A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53FCFCD1-5C19-4458-897F-09F1C2E77B5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53FCFCD1-5C19-4458-897F-09F1C2E77B5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53FCFCD1-5C19-4458-897F-09F1C2E77B5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53FCFCD1-5C19-4458-897F-09F1C2E77B5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B66027E7-332B-4786-9117-2DB33AC484A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B66027E7-332B-4786-9117-2DB33AC484A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B66027E7-332B-4786-9117-2DB33AC484A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B66027E7-332B-4786-9117-2DB33AC484A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-model/websocket/src/SeedWebsocket.sln
+++ b/seed/csharp-model/websocket/src/SeedWebsocket.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedWebsocket", "SeedWebsocket\SeedWebsocket.csproj", "{75058241-60F6-4B75-BEB5-3292813D3A83}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedWebsocket.Test", "SeedWebsocket.Test\SeedWebsocket.Test.csproj", "{C46E806A-C884-4576-A84E-AE3F6870E591}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{75058241-60F6-4B75-BEB5-3292813D3A83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75058241-60F6-4B75-BEB5-3292813D3A83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75058241-60F6-4B75-BEB5-3292813D3A83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75058241-60F6-4B75-BEB5-3292813D3A83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C46E806A-C884-4576-A84E-AE3F6870E591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C46E806A-C884-4576-A84E-AE3F6870E591}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C46E806A-C884-4576-A84E-AE3F6870E591}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C46E806A-C884-4576-A84E-AE3F6870E591}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/alias/src/SeedAlias.sln
+++ b/seed/csharp-sdk/alias/src/SeedAlias.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAlias", "SeedAlias\SeedAlias.csproj", "{5BAF3B3F-D2E9-4288-B799-70439165548A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAlias.Test", "SeedAlias.Test\SeedAlias.Test.csproj", "{3D83EE5C-6FA8-4424-BFD9-1D60387DAF04}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5BAF3B3F-D2E9-4288-B799-70439165548A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BAF3B3F-D2E9-4288-B799-70439165548A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BAF3B3F-D2E9-4288-B799-70439165548A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BAF3B3F-D2E9-4288-B799-70439165548A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D83EE5C-6FA8-4424-BFD9-1D60387DAF04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D83EE5C-6FA8-4424-BFD9-1D60387DAF04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D83EE5C-6FA8-4424-BFD9-1D60387DAF04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D83EE5C-6FA8-4424-BFD9-1D60387DAF04}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.sln
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApiWideBasePath", "SeedApiWideBasePath\SeedApiWideBasePath.csproj", "{004837B2-DF01-490B-AC00-71C336033A9B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApiWideBasePath.Test", "SeedApiWideBasePath.Test\SeedApiWideBasePath.Test.csproj", "{4381D5BB-EB2E-40CF-B2C5-4A154D998AD9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{004837B2-DF01-490B-AC00-71C336033A9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{004837B2-DF01-490B-AC00-71C336033A9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{004837B2-DF01-490B-AC00-71C336033A9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{004837B2-DF01-490B-AC00-71C336033A9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4381D5BB-EB2E-40CF-B2C5-4A154D998AD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4381D5BB-EB2E-40CF-B2C5-4A154D998AD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4381D5BB-EB2E-40CF-B2C5-4A154D998AD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4381D5BB-EB2E-40CF-B2C5-4A154D998AD9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.sln
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAudiences", "SeedAudiences\SeedAudiences.csproj", "{8904FBF6-C471-465E-AA1F-CF936AF00A8A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAudiences.Test", "SeedAudiences.Test\SeedAudiences.Test.csproj", "{DC50B6B6-4D8C-4CB3-97E2-588A8966C4F4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8904FBF6-C471-465E-AA1F-CF936AF00A8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8904FBF6-C471-465E-AA1F-CF936AF00A8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8904FBF6-C471-465E-AA1F-CF936AF00A8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8904FBF6-C471-465E-AA1F-CF936AF00A8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC50B6B6-4D8C-4CB3-97E2-588A8966C4F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC50B6B6-4D8C-4CB3-97E2-588A8966C4F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC50B6B6-4D8C-4CB3-97E2-588A8966C4F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC50B6B6-4D8C-4CB3-97E2-588A8966C4F4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/auth-environment-variables/src/SeedAuthEnvironmentVariables.sln
+++ b/seed/csharp-sdk/auth-environment-variables/src/SeedAuthEnvironmentVariables.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAuthEnvironmentVariables", "SeedAuthEnvironmentVariables\SeedAuthEnvironmentVariables.csproj", "{A3A9E2AD-444E-4C12-A48A-3E6A89F80B78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedAuthEnvironmentVariables.Test", "SeedAuthEnvironmentVariables.Test\SeedAuthEnvironmentVariables.Test.csproj", "{62947B1E-3E38-440C-BF16-191249C8E966}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A3A9E2AD-444E-4C12-A48A-3E6A89F80B78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3A9E2AD-444E-4C12-A48A-3E6A89F80B78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3A9E2AD-444E-4C12-A48A-3E6A89F80B78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3A9E2AD-444E-4C12-A48A-3E6A89F80B78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62947B1E-3E38-440C-BF16-191249C8E966}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62947B1E-3E38-440C-BF16-191249C8E966}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62947B1E-3E38-440C-BF16-191249C8E966}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62947B1E-3E38-440C-BF16-191249C8E966}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.sln
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBasicAuth", "SeedBasicAuth\SeedBasicAuth.csproj", "{0581B64D-FAC9-479F-BEFF-7B34083751E3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBasicAuth.Test", "SeedBasicAuth.Test\SeedBasicAuth.Test.csproj", "{6F45A04B-92DA-46B9-ADC9-BE88F0126A34}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0581B64D-FAC9-479F-BEFF-7B34083751E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0581B64D-FAC9-479F-BEFF-7B34083751E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0581B64D-FAC9-479F-BEFF-7B34083751E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0581B64D-FAC9-479F-BEFF-7B34083751E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F45A04B-92DA-46B9-ADC9-BE88F0126A34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F45A04B-92DA-46B9-ADC9-BE88F0126A34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F45A04B-92DA-46B9-ADC9-BE88F0126A34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F45A04B-92DA-46B9-ADC9-BE88F0126A34}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.sln
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBearerTokenEnvironmentVariable", "SeedBearerTokenEnvironmentVariable\SeedBearerTokenEnvironmentVariable.csproj", "{92ACFDB8-9341-4F7A-869D-955842C9C742}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBearerTokenEnvironmentVariable.Test", "SeedBearerTokenEnvironmentVariable.Test\SeedBearerTokenEnvironmentVariable.Test.csproj", "{8C5EFEC1-E7F5-4357-A478-8FC195C2AF65}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{92ACFDB8-9341-4F7A-869D-955842C9C742}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92ACFDB8-9341-4F7A-869D-955842C9C742}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92ACFDB8-9341-4F7A-869D-955842C9C742}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92ACFDB8-9341-4F7A-869D-955842C9C742}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C5EFEC1-E7F5-4357-A478-8FC195C2AF65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C5EFEC1-E7F5-4357-A478-8FC195C2AF65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C5EFEC1-E7F5-4357-A478-8FC195C2AF65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C5EFEC1-E7F5-4357-A478-8FC195C2AF65}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/bytes/src/SeedBytes.sln
+++ b/seed/csharp-sdk/bytes/src/SeedBytes.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBytes", "SeedBytes\SeedBytes.csproj", "{29BF6142-3542-4D5F-A4E4-732F7132DDA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedBytes.Test", "SeedBytes.Test\SeedBytes.Test.csproj", "{36A7ED85-0FA5-40BA-B493-5C1F60492FE5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29BF6142-3542-4D5F-A4E4-732F7132DDA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29BF6142-3542-4D5F-A4E4-732F7132DDA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29BF6142-3542-4D5F-A4E4-732F7132DDA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29BF6142-3542-4D5F-A4E4-732F7132DDA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36A7ED85-0FA5-40BA-B493-5C1F60492FE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36A7ED85-0FA5-40BA-B493-5C1F60492FE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36A7ED85-0FA5-40BA-B493-5C1F60492FE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36A7ED85-0FA5-40BA-B493-5C1F60492FE5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.sln
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{32DD5C8D-164D-4615-AF48-9BC86C3BA3C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{EFD7F9E1-F549-432B-A005-B17B535131E5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{32DD5C8D-164D-4615-AF48-9BC86C3BA3C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32DD5C8D-164D-4615-AF48-9BC86C3BA3C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32DD5C8D-164D-4615-AF48-9BC86C3BA3C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32DD5C8D-164D-4615-AF48-9BC86C3BA3C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFD7F9E1-F549-432B-A005-B17B535131E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFD7F9E1-F549-432B-A005-B17B535131E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFD7F9E1-F549-432B-A005-B17B535131E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFD7F9E1-F549-432B-A005-B17B535131E5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/circular-references/src/SeedApi.sln
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{7C08985A-DA47-410A-BE38-CCD83FCA668E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{574D5B58-81B7-44CB-9AB7-02212D3ED508}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7C08985A-DA47-410A-BE38-CCD83FCA668E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C08985A-DA47-410A-BE38-CCD83FCA668E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C08985A-DA47-410A-BE38-CCD83FCA668E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C08985A-DA47-410A-BE38-CCD83FCA668E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{574D5B58-81B7-44CB-9AB7-02212D3ED508}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{574D5B58-81B7-44CB-9AB7-02212D3ED508}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{574D5B58-81B7-44CB-9AB7-02212D3ED508}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{574D5B58-81B7-44CB-9AB7-02212D3ED508}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/code-samples/src/SeedCodeSamples.sln
+++ b/seed/csharp-sdk/code-samples/src/SeedCodeSamples.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCodeSamples", "SeedCodeSamples\SeedCodeSamples.csproj", "{84319111-02C5-4C39-B853-7C9A8AE4CF51}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCodeSamples.Test", "SeedCodeSamples.Test\SeedCodeSamples.Test.csproj", "{9A0D842F-A525-425A-B966-4DFC46AAF39D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84319111-02C5-4C39-B853-7C9A8AE4CF51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84319111-02C5-4C39-B853-7C9A8AE4CF51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84319111-02C5-4C39-B853-7C9A8AE4CF51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84319111-02C5-4C39-B853-7C9A8AE4CF51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A0D842F-A525-425A-B966-4DFC46AAF39D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A0D842F-A525-425A-B966-4DFC46AAF39D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A0D842F-A525-425A-B966-4DFC46AAF39D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A0D842F-A525-425A-B966-4DFC46AAF39D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/custom-auth/src/SeedCustomAuth.sln
+++ b/seed/csharp-sdk/custom-auth/src/SeedCustomAuth.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCustomAuth", "SeedCustomAuth\SeedCustomAuth.csproj", "{023DBFEA-7983-4462-B937-4801C75FA80A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedCustomAuth.Test", "SeedCustomAuth.Test\SeedCustomAuth.Test.csproj", "{E56814B8-DEEA-40B6-BC42-5BF7E1CBFF0E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{023DBFEA-7983-4462-B937-4801C75FA80A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{023DBFEA-7983-4462-B937-4801C75FA80A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{023DBFEA-7983-4462-B937-4801C75FA80A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{023DBFEA-7983-4462-B937-4801C75FA80A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E56814B8-DEEA-40B6-BC42-5BF7E1CBFF0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E56814B8-DEEA-40B6-BC42-5BF7E1CBFF0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E56814B8-DEEA-40B6-BC42-5BF7E1CBFF0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E56814B8-DEEA-40B6-BC42-5BF7E1CBFF0E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/enum/src/SeedEnum.sln
+++ b/seed/csharp-sdk/enum/src/SeedEnum.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedEnum", "SeedEnum\SeedEnum.csproj", "{86620818-4742-4C2B-931A-E8598404F3BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedEnum.Test", "SeedEnum.Test\SeedEnum.Test.csproj", "{858BD627-1F2B-4FE9-B699-82C8EB668517}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{86620818-4742-4C2B-931A-E8598404F3BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86620818-4742-4C2B-931A-E8598404F3BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86620818-4742-4C2B-931A-E8598404F3BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86620818-4742-4C2B-931A-E8598404F3BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{858BD627-1F2B-4FE9-B699-82C8EB668517}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{858BD627-1F2B-4FE9-B699-82C8EB668517}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{858BD627-1F2B-4FE9-B699-82C8EB668517}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{858BD627-1F2B-4FE9-B699-82C8EB668517}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.sln
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedErrorProperty", "SeedErrorProperty\SeedErrorProperty.csproj", "{00E1145B-5A14-4F64-8FB6-6BB4B661306A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedErrorProperty.Test", "SeedErrorProperty.Test\SeedErrorProperty.Test.csproj", "{CA11490D-9865-4365-B66E-10D111763D97}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{00E1145B-5A14-4F64-8FB6-6BB4B661306A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00E1145B-5A14-4F64-8FB6-6BB4B661306A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00E1145B-5A14-4F64-8FB6-6BB4B661306A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00E1145B-5A14-4F64-8FB6-6BB4B661306A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA11490D-9865-4365-B66E-10D111763D97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA11490D-9865-4365-B66E-10D111763D97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA11490D-9865-4365-B66E-10D111763D97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA11490D-9865-4365-B66E-10D111763D97}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/examples/src/SeedExamples.sln
+++ b/seed/csharp-sdk/examples/src/SeedExamples.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExamples", "SeedExamples\SeedExamples.csproj", "{B2AF3230-7191-40B5-BF6E-45CCD41B59B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExamples.Test", "SeedExamples.Test\SeedExamples.Test.csproj", "{65360FA7-31A4-4375-9CD7-A44519AE562D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2AF3230-7191-40B5-BF6E-45CCD41B59B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2AF3230-7191-40B5-BF6E-45CCD41B59B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2AF3230-7191-40B5-BF6E-45CCD41B59B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2AF3230-7191-40B5-BF6E-45CCD41B59B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65360FA7-31A4-4375-9CD7-A44519AE562D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65360FA7-31A4-4375-9CD7-A44519AE562D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65360FA7-31A4-4375-9CD7-A44519AE562D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65360FA7-31A4-4375-9CD7-A44519AE562D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/exhaustive/src/SeedExhaustive.sln
+++ b/seed/csharp-sdk/exhaustive/src/SeedExhaustive.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExhaustive", "SeedExhaustive\SeedExhaustive.csproj", "{C4655DE0-8DC6-4B0A-947D-2359B8D10FC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExhaustive.Test", "SeedExhaustive.Test\SeedExhaustive.Test.csproj", "{848B3363-321D-41EA-81B8-AFF52382D69B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C4655DE0-8DC6-4B0A-947D-2359B8D10FC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4655DE0-8DC6-4B0A-947D-2359B8D10FC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4655DE0-8DC6-4B0A-947D-2359B8D10FC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4655DE0-8DC6-4B0A-947D-2359B8D10FC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{848B3363-321D-41EA-81B8-AFF52382D69B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{848B3363-321D-41EA-81B8-AFF52382D69B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{848B3363-321D-41EA-81B8-AFF52382D69B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{848B3363-321D-41EA-81B8-AFF52382D69B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/extends/src/SeedExtends.sln
+++ b/seed/csharp-sdk/extends/src/SeedExtends.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExtends", "SeedExtends\SeedExtends.csproj", "{5F674022-9604-43FD-8454-A9F00702D5CE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedExtends.Test", "SeedExtends.Test\SeedExtends.Test.csproj", "{9F077D09-0B6B-43E8-9DE3-3A4D50D4114B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5F674022-9604-43FD-8454-A9F00702D5CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F674022-9604-43FD-8454-A9F00702D5CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F674022-9604-43FD-8454-A9F00702D5CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F674022-9604-43FD-8454-A9F00702D5CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F077D09-0B6B-43E8-9DE3-3A4D50D4114B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F077D09-0B6B-43E8-9DE3-3A4D50D4114B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F077D09-0B6B-43E8-9DE3-3A4D50D4114B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F077D09-0B6B-43E8-9DE3-3A4D50D4114B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.sln
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileDownload", "SeedFileDownload\SeedFileDownload.csproj", "{7A43655C-E8AF-41A3-9BB6-751625587A0D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileDownload.Test", "SeedFileDownload.Test\SeedFileDownload.Test.csproj", "{B5B1AFFF-E16F-4073-9628-051902178995}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7A43655C-E8AF-41A3-9BB6-751625587A0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A43655C-E8AF-41A3-9BB6-751625587A0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A43655C-E8AF-41A3-9BB6-751625587A0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A43655C-E8AF-41A3-9BB6-751625587A0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5B1AFFF-E16F-4073-9628-051902178995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5B1AFFF-E16F-4073-9628-051902178995}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5B1AFFF-E16F-4073-9628-051902178995}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5B1AFFF-E16F-4073-9628-051902178995}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.sln
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileUpload", "SeedFileUpload\SeedFileUpload.csproj", "{ACD9C23D-92D5-42A4-B8D6-C4CE4BCD2E8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedFileUpload.Test", "SeedFileUpload.Test\SeedFileUpload.Test.csproj", "{19C5FDB3-60B9-4E52-9A49-B278BFD55776}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ACD9C23D-92D5-42A4-B8D6-C4CE4BCD2E8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACD9C23D-92D5-42A4-B8D6-C4CE4BCD2E8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACD9C23D-92D5-42A4-B8D6-C4CE4BCD2E8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACD9C23D-92D5-42A4-B8D6-C4CE4BCD2E8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19C5FDB3-60B9-4E52-9A49-B278BFD55776}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19C5FDB3-60B9-4E52-9A49-B278BFD55776}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19C5FDB3-60B9-4E52-9A49-B278BFD55776}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19C5FDB3-60B9-4E52-9A49-B278BFD55776}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/folders/src/SeedApi.sln
+++ b/seed/csharp-sdk/folders/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{2C4F32F9-4848-4AC0-90AE-3CCD009F1A16}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{07BF90EE-7EED-4790-B57C-83F6F72A8F27}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2C4F32F9-4848-4AC0-90AE-3CCD009F1A16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C4F32F9-4848-4AC0-90AE-3CCD009F1A16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C4F32F9-4848-4AC0-90AE-3CCD009F1A16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C4F32F9-4848-4AC0-90AE-3CCD009F1A16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07BF90EE-7EED-4790-B57C-83F6F72A8F27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07BF90EE-7EED-4790-B57C-83F6F72A8F27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07BF90EE-7EED-4790-B57C-83F6F72A8F27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07BF90EE-7EED-4790-B57C-83F6F72A8F27}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.sln
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedIdempotencyHeaders", "SeedIdempotencyHeaders\SeedIdempotencyHeaders.csproj", "{548FCC54-ACF6-4B58-BD7E-BFA01E0F8BAD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedIdempotencyHeaders.Test", "SeedIdempotencyHeaders.Test\SeedIdempotencyHeaders.Test.csproj", "{75E71968-ADDE-4A45-91F5-A75028BEA381}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{548FCC54-ACF6-4B58-BD7E-BFA01E0F8BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{548FCC54-ACF6-4B58-BD7E-BFA01E0F8BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{548FCC54-ACF6-4B58-BD7E-BFA01E0F8BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{548FCC54-ACF6-4B58-BD7E-BFA01E0F8BAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75E71968-ADDE-4A45-91F5-A75028BEA381}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75E71968-ADDE-4A45-91F5-A75028BEA381}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75E71968-ADDE-4A45-91F5-A75028BEA381}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75E71968-ADDE-4A45-91F5-A75028BEA381}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/imdb/src/SeedApi.sln
+++ b/seed/csharp-sdk/imdb/src/SeedApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi", "SeedApi\SeedApi.csproj", "{E0556B25-DB99-4C3A-A649-595712FC8D64}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedApi.Test", "SeedApi.Test\SeedApi.Test.csproj", "{592821B8-40AC-4BBB-8AB5-3A6AB04E8D95}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E0556B25-DB99-4C3A-A649-595712FC8D64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0556B25-DB99-4C3A-A649-595712FC8D64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0556B25-DB99-4C3A-A649-595712FC8D64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0556B25-DB99-4C3A-A649-595712FC8D64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{592821B8-40AC-4BBB-8AB5-3A6AB04E8D95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{592821B8-40AC-4BBB-8AB5-3A6AB04E8D95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{592821B8-40AC-4BBB-8AB5-3A6AB04E8D95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{592821B8-40AC-4BBB-8AB5-3A6AB04E8D95}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/literal/src/SeedLiteral.sln
+++ b/seed/csharp-sdk/literal/src/SeedLiteral.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedLiteral", "SeedLiteral\SeedLiteral.csproj", "{29E9BAB0-A91D-4ED0-AFB4-2600A6BDA1DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedLiteral.Test", "SeedLiteral.Test\SeedLiteral.Test.csproj", "{D46191A3-92B8-42A6-9CF0-C2A4FC759473}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29E9BAB0-A91D-4ED0-AFB4-2600A6BDA1DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29E9BAB0-A91D-4ED0-AFB4-2600A6BDA1DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29E9BAB0-A91D-4ED0-AFB4-2600A6BDA1DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29E9BAB0-A91D-4ED0-AFB4-2600A6BDA1DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D46191A3-92B8-42A6-9CF0-C2A4FC759473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D46191A3-92B8-42A6-9CF0-C2A4FC759473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D46191A3-92B8-42A6-9CF0-C2A4FC759473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D46191A3-92B8-42A6-9CF0-C2A4FC759473}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/multi-url-environment/src/SeedMultiUrlEnvironment.sln
+++ b/seed/csharp-sdk/multi-url-environment/src/SeedMultiUrlEnvironment.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedMultiUrlEnvironment", "SeedMultiUrlEnvironment\SeedMultiUrlEnvironment.csproj", "{6C350EEF-111C-42A8-B7E1-F9DCAEE001BF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedMultiUrlEnvironment.Test", "SeedMultiUrlEnvironment.Test\SeedMultiUrlEnvironment.Test.csproj", "{2B932E91-A519-4E6A-BB6C-AE2859C4B6A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6C350EEF-111C-42A8-B7E1-F9DCAEE001BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C350EEF-111C-42A8-B7E1-F9DCAEE001BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C350EEF-111C-42A8-B7E1-F9DCAEE001BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C350EEF-111C-42A8-B7E1-F9DCAEE001BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B932E91-A519-4E6A-BB6C-AE2859C4B6A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B932E91-A519-4E6A-BB6C-AE2859C4B6A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B932E91-A519-4E6A-BB6C-AE2859C4B6A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B932E91-A519-4E6A-BB6C-AE2859C4B6A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.sln
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNoEnvironment", "SeedNoEnvironment\SeedNoEnvironment.csproj", "{7C055BA0-0734-4246-ACF3-35BD0857F5B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNoEnvironment.Test", "SeedNoEnvironment.Test\SeedNoEnvironment.Test.csproj", "{D09F439C-8C50-41D5-B396-9A8AD90B0FE6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7C055BA0-0734-4246-ACF3-35BD0857F5B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C055BA0-0734-4246-ACF3-35BD0857F5B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C055BA0-0734-4246-ACF3-35BD0857F5B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C055BA0-0734-4246-ACF3-35BD0857F5B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D09F439C-8C50-41D5-B396-9A8AD90B0FE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D09F439C-8C50-41D5-B396-9A8AD90B0FE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D09F439C-8C50-41D5-B396-9A8AD90B0FE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D09F439C-8C50-41D5-B396-9A8AD90B0FE6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/object/src/SeedObject.sln
+++ b/seed/csharp-sdk/object/src/SeedObject.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObject", "SeedObject\SeedObject.csproj", "{60E908DA-82E4-4372-87FA-FC825DD8699A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObject.Test", "SeedObject.Test\SeedObject.Test.csproj", "{E8698148-3155-4F92-A7CC-5545C2A7D9F2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{60E908DA-82E4-4372-87FA-FC825DD8699A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60E908DA-82E4-4372-87FA-FC825DD8699A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60E908DA-82E4-4372-87FA-FC825DD8699A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60E908DA-82E4-4372-87FA-FC825DD8699A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8698148-3155-4F92-A7CC-5545C2A7D9F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8698148-3155-4F92-A7CC-5545C2A7D9F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8698148-3155-4F92-A7CC-5545C2A7D9F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8698148-3155-4F92-A7CC-5545C2A7D9F2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.sln
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports", "SeedObjectsWithImports\SeedObjectsWithImports.csproj", "{CF48DB66-D6DB-4AC3-A22D-3563D0847C8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports.Test", "SeedObjectsWithImports.Test\SeedObjectsWithImports.Test.csproj", "{F001AC40-267F-42CE-AC7F-6AA7AF5DA281}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF48DB66-D6DB-4AC3-A22D-3563D0847C8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF48DB66-D6DB-4AC3-A22D-3563D0847C8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF48DB66-D6DB-4AC3-A22D-3563D0847C8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF48DB66-D6DB-4AC3-A22D-3563D0847C8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F001AC40-267F-42CE-AC7F-6AA7AF5DA281}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F001AC40-267F-42CE-AC7F-6AA7AF5DA281}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F001AC40-267F-42CE-AC7F-6AA7AF5DA281}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F001AC40-267F-42CE-AC7F-6AA7AF5DA281}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/optional/src/SeedObjectsWithImports.sln
+++ b/seed/csharp-sdk/optional/src/SeedObjectsWithImports.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports", "SeedObjectsWithImports\SeedObjectsWithImports.csproj", "{7FD7CDAC-EF83-4258-A82A-4E5508726D73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedObjectsWithImports.Test", "SeedObjectsWithImports.Test\SeedObjectsWithImports.Test.csproj", "{00A1D5CB-8A51-498E-99AD-44B5D5EABFFD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7FD7CDAC-EF83-4258-A82A-4E5508726D73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FD7CDAC-EF83-4258-A82A-4E5508726D73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FD7CDAC-EF83-4258-A82A-4E5508726D73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FD7CDAC-EF83-4258-A82A-4E5508726D73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00A1D5CB-8A51-498E-99AD-44B5D5EABFFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00A1D5CB-8A51-498E-99AD-44B5D5EABFFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00A1D5CB-8A51-498E-99AD-44B5D5EABFFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00A1D5CB-8A51-498E-99AD-44B5D5EABFFD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.sln
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPackageYml", "SeedPackageYml\SeedPackageYml.csproj", "{5A1FF2CA-3286-4AF4-8355-6E9468010CCF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPackageYml.Test", "SeedPackageYml.Test\SeedPackageYml.Test.csproj", "{ACD248BA-B675-4990-A9AC-A26953E46A62}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5A1FF2CA-3286-4AF4-8355-6E9468010CCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A1FF2CA-3286-4AF4-8355-6E9468010CCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A1FF2CA-3286-4AF4-8355-6E9468010CCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A1FF2CA-3286-4AF4-8355-6E9468010CCF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACD248BA-B675-4990-A9AC-A26953E46A62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACD248BA-B675-4990-A9AC-A26953E46A62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACD248BA-B675-4990-A9AC-A26953E46A62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACD248BA-B675-4990-A9AC-A26953E46A62}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.sln
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPlainText", "SeedPlainText\SeedPlainText.csproj", "{F344A425-3C79-4F91-B43D-39040C1158CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedPlainText.Test", "SeedPlainText.Test\SeedPlainText.Test.csproj", "{83683F96-4400-4EE8-ABA5-B670F80C39C1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F344A425-3C79-4F91-B43D-39040C1158CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F344A425-3C79-4F91-B43D-39040C1158CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F344A425-3C79-4F91-B43D-39040C1158CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F344A425-3C79-4F91-B43D-39040C1158CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83683F96-4400-4EE8-ABA5-B670F80C39C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83683F96-4400-4EE8-ABA5-B670F80C39C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83683F96-4400-4EE8-ABA5-B670F80C39C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83683F96-4400-4EE8-ABA5-B670F80C39C1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.sln
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedQueryParameters", "SeedQueryParameters\SeedQueryParameters.csproj", "{EAB5FFE0-0CFB-49BC-BBEE-02849F4BBBEC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedQueryParameters.Test", "SeedQueryParameters.Test\SeedQueryParameters.Test.csproj", "{CFAB54B0-6347-47A1-9921-AE3E80781185}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EAB5FFE0-0CFB-49BC-BBEE-02849F4BBBEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAB5FFE0-0CFB-49BC-BBEE-02849F4BBBEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAB5FFE0-0CFB-49BC-BBEE-02849F4BBBEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAB5FFE0-0CFB-49BC-BBEE-02849F4BBBEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFAB54B0-6347-47A1-9921-AE3E80781185}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFAB54B0-6347-47A1-9921-AE3E80781185}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFAB54B0-6347-47A1-9921-AE3E80781185}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFAB54B0-6347-47A1-9921-AE3E80781185}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.sln
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNurseryApi", "SeedNurseryApi\SeedNurseryApi.csproj", "{4B7B1608-9125-4112-AD29-DB27650F3709}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedNurseryApi.Test", "SeedNurseryApi.Test\SeedNurseryApi.Test.csproj", "{429F0C86-EAF1-40CC-9327-79C9864D19CB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4B7B1608-9125-4112-AD29-DB27650F3709}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B7B1608-9125-4112-AD29-DB27650F3709}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B7B1608-9125-4112-AD29-DB27650F3709}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B7B1608-9125-4112-AD29-DB27650F3709}.Release|Any CPU.Build.0 = Release|Any CPU
+		{429F0C86-EAF1-40CC-9327-79C9864D19CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{429F0C86-EAF1-40CC-9327-79C9864D19CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{429F0C86-EAF1-40CC-9327-79C9864D19CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{429F0C86-EAF1-40CC-9327-79C9864D19CB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.sln
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedResponseProperty", "SeedResponseProperty\SeedResponseProperty.csproj", "{65DBD202-D756-44F9-8F3B-1F923749BB54}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedResponseProperty.Test", "SeedResponseProperty.Test\SeedResponseProperty.Test.csproj", "{15053761-76B6-486A-A421-FBF799499F67}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{65DBD202-D756-44F9-8F3B-1F923749BB54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65DBD202-D756-44F9-8F3B-1F923749BB54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65DBD202-D756-44F9-8F3B-1F923749BB54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65DBD202-D756-44F9-8F3B-1F923749BB54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15053761-76B6-486A-A421-FBF799499F67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15053761-76B6-486A-A421-FBF799499F67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15053761-76B6-486A-A421-FBF799499F67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15053761-76B6-486A-A421-FBF799499F67}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.sln
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentDefault", "SeedSingleUrlEnvironmentDefault\SeedSingleUrlEnvironmentDefault.csproj", "{92B86DB3-A959-402A-B165-21106801B0C5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentDefault.Test", "SeedSingleUrlEnvironmentDefault.Test\SeedSingleUrlEnvironmentDefault.Test.csproj", "{DA9F7218-8743-49A8-8191-D6021273BF1E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{92B86DB3-A959-402A-B165-21106801B0C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92B86DB3-A959-402A-B165-21106801B0C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92B86DB3-A959-402A-B165-21106801B0C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92B86DB3-A959-402A-B165-21106801B0C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA9F7218-8743-49A8-8191-D6021273BF1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA9F7218-8743-49A8-8191-D6021273BF1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA9F7218-8743-49A8-8191-D6021273BF1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA9F7218-8743-49A8-8191-D6021273BF1E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.sln
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentNoDefault", "SeedSingleUrlEnvironmentNoDefault\SeedSingleUrlEnvironmentNoDefault.csproj", "{12496FBE-5FC1-4D9E-91A4-DB4BD2668746}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedSingleUrlEnvironmentNoDefault.Test", "SeedSingleUrlEnvironmentNoDefault.Test\SeedSingleUrlEnvironmentNoDefault.Test.csproj", "{94BF2D7F-B8A5-4764-B0E3-1834E0D99B71}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{12496FBE-5FC1-4D9E-91A4-DB4BD2668746}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12496FBE-5FC1-4D9E-91A4-DB4BD2668746}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12496FBE-5FC1-4D9E-91A4-DB4BD2668746}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12496FBE-5FC1-4D9E-91A4-DB4BD2668746}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94BF2D7F-B8A5-4764-B0E3-1834E0D99B71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94BF2D7F-B8A5-4764-B0E3-1834E0D99B71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94BF2D7F-B8A5-4764-B0E3-1834E0D99B71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94BF2D7F-B8A5-4764-B0E3-1834E0D99B71}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/streaming/src/SeedStreaming.sln
+++ b/seed/csharp-sdk/streaming/src/SeedStreaming.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedStreaming", "SeedStreaming\SeedStreaming.csproj", "{FDB7F878-F051-4EFD-8F10-11E068A711DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedStreaming.Test", "SeedStreaming.Test\SeedStreaming.Test.csproj", "{8A97E249-6540-4F39-8D74-E60E34079806}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDB7F878-F051-4EFD-8F10-11E068A711DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDB7F878-F051-4EFD-8F10-11E068A711DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDB7F878-F051-4EFD-8F10-11E068A711DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDB7F878-F051-4EFD-8F10-11E068A711DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A97E249-6540-4F39-8D74-E60E34079806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A97E249-6540-4F39-8D74-E60E34079806}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A97E249-6540-4F39-8D74-E60E34079806}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A97E249-6540-4F39-8D74-E60E34079806}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/trace/src/SeedTrace.sln
+++ b/seed/csharp-sdk/trace/src/SeedTrace.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedTrace", "SeedTrace\SeedTrace.csproj", "{CDF6321C-560F-4D38-AF42-6E99016D4B9F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedTrace.Test", "SeedTrace.Test\SeedTrace.Test.csproj", "{7671454E-69CB-4CDC-A623-8AE6D7904399}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CDF6321C-560F-4D38-AF42-6E99016D4B9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDF6321C-560F-4D38-AF42-6E99016D4B9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDF6321C-560F-4D38-AF42-6E99016D4B9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDF6321C-560F-4D38-AF42-6E99016D4B9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7671454E-69CB-4CDC-A623-8AE6D7904399}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7671454E-69CB-4CDC-A623-8AE6D7904399}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7671454E-69CB-4CDC-A623-8AE6D7904399}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7671454E-69CB-4CDC-A623-8AE6D7904399}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/undiscriminated-unions/src/SeedUndiscriminatedUnions.sln
+++ b/seed/csharp-sdk/undiscriminated-unions/src/SeedUndiscriminatedUnions.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUndiscriminatedUnions", "SeedUndiscriminatedUnions\SeedUndiscriminatedUnions.csproj", "{07F3A711-E336-4C7F-A5A7-356F325676E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUndiscriminatedUnions.Test", "SeedUndiscriminatedUnions.Test\SeedUndiscriminatedUnions.Test.csproj", "{C82CD073-7CCD-457E-94FE-E3636904B437}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{07F3A711-E336-4C7F-A5A7-356F325676E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07F3A711-E336-4C7F-A5A7-356F325676E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07F3A711-E336-4C7F-A5A7-356F325676E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07F3A711-E336-4C7F-A5A7-356F325676E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C82CD073-7CCD-457E-94FE-E3636904B437}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C82CD073-7CCD-457E-94FE-E3636904B437}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C82CD073-7CCD-457E-94FE-E3636904B437}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C82CD073-7CCD-457E-94FE-E3636904B437}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/unions/src/SeedUnions.sln
+++ b/seed/csharp-sdk/unions/src/SeedUnions.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnions", "SeedUnions\SeedUnions.csproj", "{6A70228C-EEC5-46D3-A198-964C909A5B22}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnions.Test", "SeedUnions.Test\SeedUnions.Test.csproj", "{D501C4E4-77F5-47A7-A3EC-AADE3BE7EA9F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6A70228C-EEC5-46D3-A198-964C909A5B22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A70228C-EEC5-46D3-A198-964C909A5B22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A70228C-EEC5-46D3-A198-964C909A5B22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A70228C-EEC5-46D3-A198-964C909A5B22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D501C4E4-77F5-47A7-A3EC-AADE3BE7EA9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D501C4E4-77F5-47A7-A3EC-AADE3BE7EA9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D501C4E4-77F5-47A7-A3EC-AADE3BE7EA9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D501C4E4-77F5-47A7-A3EC-AADE3BE7EA9F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.sln
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnknownAsAny", "SeedUnknownAsAny\SeedUnknownAsAny.csproj", "{CA214055-86EA-4B93-846F-48F3CEE970C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedUnknownAsAny.Test", "SeedUnknownAsAny.Test\SeedUnknownAsAny.Test.csproj", "{CFA2E8B2-2760-487E-B8E4-C0D49BEAEE74}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA214055-86EA-4B93-846F-48F3CEE970C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA214055-86EA-4B93-846F-48F3CEE970C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA214055-86EA-4B93-846F-48F3CEE970C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA214055-86EA-4B93-846F-48F3CEE970C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFA2E8B2-2760-487E-B8E4-C0D49BEAEE74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFA2E8B2-2760-487E-B8E4-C0D49BEAEE74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFA2E8B2-2760-487E-B8E4-C0D49BEAEE74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFA2E8B2-2760-487E-B8E4-C0D49BEAEE74}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/variables/src/SeedVariables.sln
+++ b/seed/csharp-sdk/variables/src/SeedVariables.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedVariables", "SeedVariables\SeedVariables.csproj", "{72FBA236-D849-40E0-B0AD-2E26C84E8AFB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedVariables.Test", "SeedVariables.Test\SeedVariables.Test.csproj", "{DBFB3314-D220-4313-B2AA-5F2C9F1C1228}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{72FBA236-D849-40E0-B0AD-2E26C84E8AFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72FBA236-D849-40E0-B0AD-2E26C84E8AFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72FBA236-D849-40E0-B0AD-2E26C84E8AFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72FBA236-D849-40E0-B0AD-2E26C84E8AFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBFB3314-D220-4313-B2AA-5F2C9F1C1228}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBFB3314-D220-4313-B2AA-5F2C9F1C1228}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBFB3314-D220-4313-B2AA-5F2C9F1C1228}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBFB3314-D220-4313-B2AA-5F2C9F1C1228}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/seed/csharp-sdk/websocket/src/SeedWebsocket.sln
+++ b/seed/csharp-sdk/websocket/src/SeedWebsocket.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedWebsocket", "SeedWebsocket\SeedWebsocket.csproj", "{8C6ED371-AED1-4DD3-96B8-48C2EA581AC7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeedWebsocket.Test", "SeedWebsocket.Test\SeedWebsocket.Test.csproj", "{B97A71A1-0780-4A83-9433-2F88139DD80D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8C6ED371-AED1-4DD3-96B8-48C2EA581AC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C6ED371-AED1-4DD3-96B8-48C2EA581AC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C6ED371-AED1-4DD3-96B8-48C2EA581AC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C6ED371-AED1-4DD3-96B8-48C2EA581AC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B97A71A1-0780-4A83-9433-2F88139DD80D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B97A71A1-0780-4A83-9433-2F88139DD80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B97A71A1-0780-4A83-9433-2F88139DD80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B97A71A1-0780-4A83-9433-2F88139DD80D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR starts to propose a new layout for the docs. Note that there are some feature requests that we'll need to prioritize in order to make the docs look visually appealing, but this takes a stab at putting the right content in the right hierarchy. 

A preview URL is [here](https://fern-preview-2cf52780-0075-4624-9b3f-f6d4b679accb.docs.buildwithfern.com/home/introduction)

### Goals
1. **Professsional**: Our docs look professional and reflect our engineering quality
2. **Self-serve docs**: We are increasingly seeing users that want to get started using the docs product on their own 
3. **Credit for SDK Features**:  Our SDKs do a lot but most folks only understand the features once they schedule a call. 

### Features Required 
- Horizontal Tab Layout: https://docs.stripe.com/. The horizontal tabs will be `Home`,  `SDKs`, `Docs`, `Configuration`, and `Changelog`. 
- Section toggles are towards the end of the nav: https://nextra.site/docs/docs-theme. This will allow sections that contain single pages and nested sections will be aligned which will feel more natural. 
- Icons next to pages: https://linear.app/docs. This will make our docs jump out more  + allow us to signal paid from free in the SDK features section 

