### PR TITLE
fix: small random openapi parser fixes

### DIFF
--- a/packages/cli/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -273,17 +273,33 @@ function getRequest({
             resolvedSchema.type !== "object" ||
             (maybeSchemaId != null && nonRequestReferencedSchemas.includes(maybeSchemaId))
         ) {
-            const requestTypeReference = buildTypeReference({
-                schema: request.schema,
-                fileContainingReference: declarationFile,
-                context
-            });
-            const convertedRequest: ConvertedRequest = {
-                schemaIdsToExclude: [],
-                value: {
-                    body: requestTypeReference
-                }
-            };
+            let requestTypeReference;
+            let convertedRequest: ConvertedRequest;
+            if (maybeSchemaId === generatedRequestName && !nonRequestReferencedSchemas.includes(maybeSchemaId)) {
+                requestTypeReference = buildTypeReference({
+                    schema: resolvedSchema,
+                    fileContainingReference: declarationFile,
+                    context
+                });
+                convertedRequest = {
+                    schemaIdsToExclude: [maybeSchemaId],
+                    value: {
+                        body: requestTypeReference
+                    }
+                };
+            } else {
+                requestTypeReference = buildTypeReference({
+                    schema: request.schema,
+                    fileContainingReference: declarationFile,
+                    context
+                });
+                convertedRequest = {
+                    schemaIdsToExclude: [],
+                    value: {
+                        body: requestTypeReference
+                    }
+                };
+            }
 
             const hasQueryParams = Object.keys(queryParameters ?? {}).length > 0;
             const hasHeaders = Object.keys(headers ?? {}).length > 0;

--- a/packages/cli/openapi-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/openapi-parser/src/schema/convertSchemas.ts
@@ -23,9 +23,9 @@ import { convertObject } from "./convertObject";
 import { convertUndiscriminatedOneOf } from "./convertUndiscriminatedOneOf";
 import { getExampleAsBoolean, getExampleAsNumber, getExamplesString } from "./examples/getExample";
 import { SchemaParserContext } from "./SchemaParserContext";
+import { getBreadcrumbsFromReference } from "./utils/getBreadcrumbsFromReference";
 import { getGeneratedTypeName } from "./utils/getSchemaName";
 import { isReferenceObject } from "./utils/isReferenceObject";
-import { getBreadcrumbsFromReference } from "./utils/getBreadcrumbsFromReference";
 
 export const SCHEMA_REFERENCE_PREFIX = "#/components/schemas/";
 export const SCHEMA_INLINE_REFERENCE_PREFIX = "#/components/responses/";

--- a/packages/cli/yaml/validator/src/ComplexQueryParamTypeDetector.ts
+++ b/packages/cli/yaml/validator/src/ComplexQueryParamTypeDetector.ts
@@ -94,16 +94,22 @@ export class ComplexQueryParamTypeDetector {
                 return false;
             case "map":
                 return (
-                    this.isResolvedReferenceComplex({
+                    (this.isResolvedReferenceComplex({
                         type: type.keyType,
                         file,
                         visited
                     }) ||
-                    this.isResolvedReferenceComplex({
-                        type: type.valueType,
-                        file,
-                        visited
-                    })
+                        this.isResolvedReferenceComplex({
+                            type: type.valueType,
+                            file,
+                            visited
+                        })) &&
+                    // This is how we denote generic objects, which we should allow to pass through.
+                    !(
+                        type.keyType._type === "primitive" &&
+                        type.keyType.primitive === "STRING" &&
+                        type.valueType._type === "unknown"
+                    )
                 );
             case "optional":
                 return this.isResolvedReferenceComplex({


### PR DESCRIPTION
the first fixes inlining objects that are only used in one request
the second allows generic objects to be used in query parameters