### PR TITLE
feat: support multipart form data encoding

### DIFF
--- a/packages/cli/generation/ir-generator/src/converters/services/convertHttpRequestBody.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertHttpRequestBody.ts
@@ -51,7 +51,8 @@ export function convertHttpRequestBody({
                                     wireValue: property.key,
                                     name: property.key
                                 }),
-                                isOptional: property.isOptional
+                                isOptional: property.isOptional,
+                                contentType: property.contentType
                             })
                         );
                     } else {
@@ -61,7 +62,8 @@ export function convertHttpRequestBody({
                                     wireValue: property.key,
                                     name: property.key
                                 }),
-                                isOptional: property.isOptional
+                                isOptional: property.isOptional,
+                                contentType: property.contentType
                             })
                         );
                     }
@@ -147,6 +149,7 @@ function convertInlinedRequestProperty({
             wireValue: propertyKey,
             name: getPropertyName({ propertyKey, property: propertyDefinition }).name
         }),
-        valueType: file.parseTypeReference(propertyDefinition)
+        valueType: file.parseTypeReference(propertyDefinition),
+        contentType: typeof propertyDefinition !== "string" ? propertyDefinition["content-type"] : undefined
     };
 }

--- a/packages/cli/openapi-ir-sdk/fern/definition/finalIr.yml
+++ b/packages/cli/openapi-ir-sdk/fern/definition/finalIr.yml
@@ -320,6 +320,7 @@ types:
     properties:
       key: string
       schema: MultipartSchema
+      contentType: optional<string>
 
   FileSchema:
     properties:

--- a/packages/cli/openapi-ir-sdk/src/sdk/api/resources/finalIr/types/MultipartRequestProperty.ts
+++ b/packages/cli/openapi-ir-sdk/src/sdk/api/resources/finalIr/types/MultipartRequestProperty.ts
@@ -7,4 +7,5 @@ import * as FernOpenapiIr from "../../..";
 export interface MultipartRequestProperty extends FernOpenapiIr.WithDescription {
     key: string;
     schema: FernOpenapiIr.MultipartSchema;
+    contentType: string | undefined;
 }

--- a/packages/cli/openapi-ir-sdk/src/sdk/serialization/resources/finalIr/types/MultipartRequestProperty.ts
+++ b/packages/cli/openapi-ir-sdk/src/sdk/serialization/resources/finalIr/types/MultipartRequestProperty.ts
@@ -13,6 +13,7 @@ export const MultipartRequestProperty: core.serialization.ObjectSchema<
     .objectWithoutOptionalProperties({
         key: core.serialization.string(),
         schema: core.serialization.lazy(async () => (await import("../../..")).MultipartSchema),
+        contentType: core.serialization.string().optional(),
     })
     .extend(core.serialization.lazyObject(async () => (await import("../../..")).WithDescription));
 
@@ -20,5 +21,6 @@ export declare namespace MultipartRequestProperty {
     interface Raw extends serializers.WithDescription.Raw {
         key: string;
         schema: serializers.MultipartSchema.Raw;
+        contentType?: string | null;
     }
 }

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/deel.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/deel.test.ts.snap
@@ -6516,6 +6516,7 @@ exports[`open api parser deel parse open api 1`] = `
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {
@@ -6734,6 +6735,7 @@ exports[`open api parser deel parse open api 1`] = `
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/file-upload.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/file-upload.test.ts.snap
@@ -40,6 +40,7 @@ exports[`file-upload file-upload parse open api 1`] = `
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": "The file to upload",
             "key": "file",
             "schema": {
@@ -49,6 +50,7 @@ exports[`file-upload file-upload parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "maybe_file",
             "schema": {
@@ -58,6 +60,7 @@ exports[`file-upload file-upload parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": "The list of files to upload",
             "key": "file_list",
             "schema": {
@@ -67,6 +70,7 @@ exports[`file-upload file-upload parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "maybe_file_list",
             "schema": {
@@ -76,6 +80,7 @@ exports[`file-upload file-upload parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "maybe_files_allof_list",
             "schema": {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/hathora.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/hathora.test.ts.snap
@@ -2349,6 +2349,7 @@ exports[`open api parser hathora parse open api 1`] = `
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/optional-multipart.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/optional-multipart.test.ts.snap
@@ -92,6 +92,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
         "name": "SpeechBody",
         "properties": [
           {
+            "contentType": null,
             "description": "The audio file.",
             "key": "audio",
             "schema": {
@@ -101,6 +102,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "model_id",
             "schema": {
@@ -127,6 +129,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "voice_settings",
             "schema": {
@@ -278,6 +281,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
         "name": "SpeechBodyStream",
         "properties": [
           {
+            "contentType": null,
             "description": "The audio file.",
             "key": "audio",
             "schema": {
@@ -287,6 +291,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "model_id",
             "schema": {
@@ -313,6 +318,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "voice_settings",
             "schema": {
@@ -339,6 +345,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "my_enum",
             "schema": {
@@ -386,6 +393,7 @@ exports[`optional-multipart optional-multipart parse open api 1`] = `
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "my_ref",
             "schema": {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/squidex.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/squidex.test.ts.snap
@@ -37052,6 +37052,7 @@ You will be assigned as owner of the new team automatically.",
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {
@@ -38291,6 +38292,7 @@ You will be assigned as owner of the new team automatically.",
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {
@@ -39524,6 +39526,7 @@ You will be assigned as owner of the new team automatically.",
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {
@@ -42876,6 +42879,7 @@ The client secret is auto generated on the server and returned. The client does 
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "file",
             "schema": {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/uploadcare.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/uploadcare.test.ts.snap
@@ -836,6 +836,7 @@ Log.d("TAG", file.toString())
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "UPLOADCARE_PUB_KEY",
             "schema": {
@@ -851,6 +852,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "UPLOADCARE_STORE",
             "schema": {
@@ -873,6 +875,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": "File's content",
             "key": "{filename}",
             "schema": {
@@ -882,6 +885,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "metadata[{key}]",
             "schema": {
@@ -904,6 +908,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "signature",
             "schema": {
@@ -926,6 +931,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "expire",
             "schema": {
@@ -1898,6 +1904,7 @@ Log.d("TAG", file.toString())
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "UPLOADCARE_PUB_KEY",
             "schema": {
@@ -1913,6 +1920,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "UPLOADCARE_STORE",
             "schema": {
@@ -1935,6 +1943,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "filename",
             "schema": {
@@ -1954,6 +1963,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "size",
             "schema": {
@@ -1973,6 +1983,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "part_size",
             "schema": {
@@ -2004,6 +2015,7 @@ to us as a value of the \`part_size\` parameter (in bytes).
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "content_type",
             "schema": {
@@ -2023,6 +2035,7 @@ to us as a value of the \`part_size\` parameter (in bytes).
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "metadata[{key}]",
             "schema": {
@@ -2045,6 +2058,7 @@ to us as a value of the \`part_size\` parameter (in bytes).
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "signature",
             "schema": {
@@ -2067,6 +2081,7 @@ to us as a value of the \`part_size\` parameter (in bytes).
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "expire",
             "schema": {
@@ -3314,6 +3329,7 @@ Log.d("TAG", file.toString())
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "UPLOADCARE_PUB_KEY",
             "schema": {
@@ -3329,6 +3345,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "uuid",
             "schema": {
@@ -4944,6 +4961,7 @@ Log.d("TAG", file.toString())
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "pub_key",
             "schema": {
@@ -4959,6 +4977,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "source_url",
             "schema": {
@@ -4981,6 +5000,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "store",
             "schema": {
@@ -5003,6 +5023,7 @@ Log.d("TAG", file.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "filename",
             "schema": {
@@ -5035,6 +5056,7 @@ response headers or the \`source_url\`'s path.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "check_URL_duplicates",
             "schema": {
@@ -5085,6 +5107,7 @@ this request will return information about the already uploaded file.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "save_URL_duplicates",
             "schema": {
@@ -5135,6 +5158,7 @@ to the value of the \`check_URL_duplicates\` parameter.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "metadata[{key}]",
             "schema": {
@@ -5157,6 +5181,7 @@ to the value of the \`check_URL_duplicates\` parameter.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "signature",
             "schema": {
@@ -5179,6 +5204,7 @@ to the value of the \`check_URL_duplicates\` parameter.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "expire",
             "schema": {
@@ -8611,6 +8637,7 @@ Log.d("TAG", group.toString())
         "name": null,
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "pub_key",
             "schema": {
@@ -8626,6 +8653,7 @@ Log.d("TAG", group.toString())
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "files[]",
             "schema": {
@@ -8655,6 +8683,7 @@ processing operations.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "signature",
             "schema": {
@@ -8677,6 +8706,7 @@ processing operations.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "expire",
             "schema": {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/vellum.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/vellum.test.ts.snap
@@ -3452,6 +3452,7 @@ Upload a document to be indexed and used for search.
         "name": "UploadDocumentBodyRequest",
         "properties": [
           {
+            "contentType": null,
             "description": null,
             "key": "add_to_index_names",
             "schema": {
@@ -3492,6 +3493,7 @@ Upload a document to be indexed and used for search.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "external_id",
             "schema": {
@@ -3525,6 +3527,7 @@ Upload a document to be indexed and used for search.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "label",
             "schema": {
@@ -3544,6 +3547,7 @@ Upload a document to be indexed and used for search.
             },
           },
           {
+            "contentType": null,
             "description": "The file contents of the document.",
             "key": "contents",
             "schema": {
@@ -3553,6 +3557,7 @@ Upload a document to be indexed and used for search.
             },
           },
           {
+            "contentType": null,
             "description": null,
             "key": "keywords",
             "schema": {

--- a/packages/cli/yaml/yaml-schema/src/ast/visitors/services/visitHttpService.ts
+++ b/packages/cli/yaml/yaml-schema/src/ast/visitors/services/visitHttpService.ts
@@ -185,7 +185,8 @@ async function visitEndpoint({
                                                     location: TypeReferenceLocation.InlinedRequestProperty
                                                 });
                                             },
-                                            audiences: noop
+                                            audiences: noop,
+                                            "content-type": noop
                                         });
                                     }
                                 }

--- a/packages/cli/yaml/yaml-schema/src/ast/visitors/visitTypeDeclarations.ts
+++ b/packages/cli/yaml/yaml-schema/src/ast/visitors/visitTypeDeclarations.ts
@@ -103,7 +103,8 @@ export async function visitTypeDeclaration({
                                 type: async (type) => {
                                     await visitTypeReference(type, [...nodePathForProperty, "type"]);
                                 },
-                                audiences: noop
+                                audiences: noop,
+                                "content-type": noop
                             });
                         }
                     }

--- a/packages/cli/yaml/yaml-schema/src/ast/visitors/visitWebhooks.ts
+++ b/packages/cli/yaml/yaml-schema/src/ast/visitors/visitWebhooks.ts
@@ -82,7 +82,8 @@ export async function visitWebhooks({
                                         location: TypeReferenceLocation.InlinedRequestProperty
                                     });
                                 },
-                                audiences: noop
+                                audiences: noop,
+                                "content-type": noop
                             });
                         }
                     }

--- a/packages/cli/yaml/yaml-schema/src/schemas/ObjectPropertySchema.ts
+++ b/packages/cli/yaml/yaml-schema/src/schemas/ObjectPropertySchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { TypeReferenceDeclarationWithNameSchema } from "./TypeReferenceSchema";
+import { TypeReferenceDeclarationWithContentType } from "./TypeReferenceSchema";
 
-export const ObjectPropertySchema = TypeReferenceDeclarationWithNameSchema;
+export const ObjectPropertySchema = TypeReferenceDeclarationWithContentType;
 
 export type ObjectPropertySchema = z.infer<typeof ObjectPropertySchema>;

--- a/packages/cli/yaml/yaml-schema/src/schemas/TypeReferenceSchema.ts
+++ b/packages/cli/yaml/yaml-schema/src/schemas/TypeReferenceSchema.ts
@@ -34,3 +34,12 @@ export const TypeReferenceDeclarationWithEnvOverride = extendTypeReferenceSchema
     }).shape
 );
 export type TypeReferenceDeclarationWithEnvOverride = z.infer<typeof TypeReferenceDeclarationWithEnvOverride>;
+
+export const TypeReferenceDeclarationWithContentType = extendTypeReferenceSchema(
+    DeclarationWithNameSchema.extend({
+        ["content-type"]: z.optional(z.string(), {
+            description: "Only applicable for multipart/form-data body properties"
+        })
+    }).shape
+);
+export type TypeReferenceDeclarationWithContentType = z.infer<typeof TypeReferenceDeclarationWithContentType>;

--- a/packages/cli/yaml/yaml-schema/src/utils/parseFileUploadRequest.ts
+++ b/packages/cli/yaml/yaml-schema/src/utils/parseFileUploadRequest.ts
@@ -15,6 +15,7 @@ export declare namespace RawFileUploadRequest {
         isFile: true;
         isOptional: boolean;
         isArray: boolean;
+        contentType: string | undefined;
     }
 
     export interface InlinedRequestBodyProperty extends BaseProperty {
@@ -52,7 +53,8 @@ export function parseFileUploadRequest(request: HttpRequestSchema | string): Raw
                     key,
                     docs,
                     isOptional: maybeParsedFileType.isOptional,
-                    isArray: maybeParsedFileType.isArray
+                    isArray: maybeParsedFileType.isArray,
+                    contentType: typeof propertyType !== "string" ? propertyType["content-type"] : undefined
                 });
             } else {
                 acc.push({ isFile: false, key, propertyType, docs });

--- a/packages/ir-sdk/fern/apis/ir-types-latest/definition/http.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/definition/http.yml
@@ -102,6 +102,7 @@ types:
     properties:
       name: commons.NameAndWireValue
       valueType: types.TypeReference
+      contentType: optional<string>
   FileUploadRequest:
     properties:
       name: commons.Name
@@ -122,10 +123,12 @@ types:
     properties:
       key: commons.NameAndWireValue
       isOptional: boolean
+      contentType: optional<string>
   FilePropertyArray:
     properties:
       key: commons.NameAndWireValue
       isOptional: boolean
+      contentType: optional<string>
   HttpRequestBodyReference:
     extends: commons.WithDocs
     properties:
@@ -185,21 +188,21 @@ types:
     extends: commons.WithDocs
 
   StreamingResponse:
-    union: 
+    union:
       json: JsonStreamChunk
       text: TextStreamChunk
       sse: SseStreamChunk
-    
-  TextStreamChunk: 
+
+  TextStreamChunk:
     extends: commons.WithDocs
     properties: {}
-    
+
   JsonStreamChunk:
     extends: commons.WithDocs
     properties:
       payload: types.TypeReference
       terminator: optional<string>
-  
+
   SseStreamChunk:
     extends: commons.WithDocs
     properties:

--- a/packages/ir-sdk/src/sdk/api/resources/http/types/FilePropertyArray.ts
+++ b/packages/ir-sdk/src/sdk/api/resources/http/types/FilePropertyArray.ts
@@ -7,4 +7,5 @@ import * as FernIr from "../../..";
 export interface FilePropertyArray {
     key: FernIr.NameAndWireValue;
     isOptional: boolean;
+    contentType: string | undefined;
 }

--- a/packages/ir-sdk/src/sdk/api/resources/http/types/FilePropertySingle.ts
+++ b/packages/ir-sdk/src/sdk/api/resources/http/types/FilePropertySingle.ts
@@ -7,4 +7,5 @@ import * as FernIr from "../../..";
 export interface FilePropertySingle {
     key: FernIr.NameAndWireValue;
     isOptional: boolean;
+    contentType: string | undefined;
 }

--- a/packages/ir-sdk/src/sdk/api/resources/http/types/InlinedRequestBodyProperty.ts
+++ b/packages/ir-sdk/src/sdk/api/resources/http/types/InlinedRequestBodyProperty.ts
@@ -7,4 +7,5 @@ import * as FernIr from "../../..";
 export interface InlinedRequestBodyProperty extends FernIr.WithDocs {
     name: FernIr.NameAndWireValue;
     valueType: FernIr.TypeReference;
+    contentType: string | undefined;
 }

--- a/packages/ir-sdk/src/sdk/serialization/resources/http/types/FilePropertyArray.ts
+++ b/packages/ir-sdk/src/sdk/serialization/resources/http/types/FilePropertyArray.ts
@@ -12,11 +12,13 @@ export const FilePropertyArray: core.serialization.ObjectSchema<
 > = core.serialization.objectWithoutOptionalProperties({
     key: core.serialization.lazyObject(async () => (await import("../../..")).NameAndWireValue),
     isOptional: core.serialization.boolean(),
+    contentType: core.serialization.string().optional(),
 });
 
 export declare namespace FilePropertyArray {
     interface Raw {
         key: serializers.NameAndWireValue.Raw;
         isOptional: boolean;
+        contentType?: string | null;
     }
 }

--- a/packages/ir-sdk/src/sdk/serialization/resources/http/types/FilePropertySingle.ts
+++ b/packages/ir-sdk/src/sdk/serialization/resources/http/types/FilePropertySingle.ts
@@ -12,11 +12,13 @@ export const FilePropertySingle: core.serialization.ObjectSchema<
 > = core.serialization.objectWithoutOptionalProperties({
     key: core.serialization.lazyObject(async () => (await import("../../..")).NameAndWireValue),
     isOptional: core.serialization.boolean(),
+    contentType: core.serialization.string().optional(),
 });
 
 export declare namespace FilePropertySingle {
     interface Raw {
         key: serializers.NameAndWireValue.Raw;
         isOptional: boolean;
+        contentType?: string | null;
     }
 }

--- a/packages/ir-sdk/src/sdk/serialization/resources/http/types/InlinedRequestBodyProperty.ts
+++ b/packages/ir-sdk/src/sdk/serialization/resources/http/types/InlinedRequestBodyProperty.ts
@@ -13,6 +13,7 @@ export const InlinedRequestBodyProperty: core.serialization.ObjectSchema<
     .objectWithoutOptionalProperties({
         name: core.serialization.lazyObject(async () => (await import("../../..")).NameAndWireValue),
         valueType: core.serialization.lazy(async () => (await import("../../..")).TypeReference),
+        contentType: core.serialization.string().optional(),
     })
     .extend(core.serialization.lazyObject(async () => (await import("../../..")).WithDocs));
 
@@ -20,5 +21,6 @@ export declare namespace InlinedRequestBodyProperty {
     interface Raw extends serializers.WithDocs.Raw {
         name: serializers.NameAndWireValue.Raw;
         valueType: serializers.TypeReference.Raw;
+        contentType?: string | null;
     }
 }


### PR DESCRIPTION
* parse `encoding` field from openapi
* introduce `content-type` field in openapi-ir, fern yaml-schema, and fern-ir
* plumb through encoding.contentType -> fern-ir
---
remaining steps:
- plumb through in FDR and UI