### PR TITLE
(fix): if no apis are specified, `fern generate --docs` should still work

### DIFF
--- a/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`validate docs 1`] = `
-"Missing file: api.yml
-[docs]: Found 3 errors and 0 warnings. Run fern check --warnings to print out the warnings.
+"[docs]: Found 3 errors and 0 warnings. Run fern check --warnings to print out the warnings.
 [docs]: docs.yml -> favicon
         Path favicon.ico does not exist
 [docs]: docs.yml -> logo -> dark

--- a/packages/cli/project-loader/src/loadProject.ts
+++ b/packages/cli/project-loader/src/loadProject.ts
@@ -137,8 +137,10 @@ export async function loadApis({
     });
     if (workspace.didSucceed) {
         return [workspace.workspace];
-    } else {
+    } else if (commandLineApiWorkspace != null) {
         handleFailedWorkspaceParserResult(workspace, context.logger);
         return [];
     }
+
+    return [];
 }


### PR DESCRIPTION
Previously, fern would throw if the documentation included no APIs.