### PR TITLE
(codegen): support sending custom status code in express code generation

### DIFF
--- a/seed/ts-express/imdb/no-custom-config/core/express/index.ts
+++ b/seed/ts-express/imdb/no-custom-config/core/express/index.ts
@@ -1,0 +1,1 @@
+export { type Response } from "./response";

--- a/seed/ts-express/imdb/no-custom-config/core/express/response.ts
+++ b/seed/ts-express/imdb/no-custom-config/core/express/response.ts
@@ -1,0 +1,8 @@
+import express from "express";
+
+export interface Response<T> {
+    status: (code: number) => Response<T>;
+    send: (responseBody: T) => Promise<void>;
+    cookie: (cookie: string, value: string, options?: express.CookieOptions) => void;
+    locals: any;
+}

--- a/seed/ts-express/imdb/no-custom-config/core/index.ts
+++ b/seed/ts-express/imdb/no-custom-config/core/index.ts
@@ -1,1 +1,2 @@
 export * as serialization from "./schemas";
+export * as express from "./express";


### PR DESCRIPTION
This PR shows what the code generation would look like to support sending custom status codes. The API is similar to express but just type-safe: 

```ts
(req, res):  => {
  // to send 201, just do res.status(201)
  res.status(200).send(....);
}
```