### PR TITLE
initializing new primitive IR types

### DIFF
--- a/packages/cli/yaml/yaml-schema/src/schemas/ValidationTypeSchema.ts
+++ b/packages/cli/yaml/yaml-schema/src/schemas/ValidationTypeSchema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const StringPropertySchema = z.strictObject({
+    minLength: z.number().optional(),
+    maxLength: z.number().optional()
+});
+
+export const NumberPropertySchema = z.strictObject({
+    min: z.number().optional(),
+    max: z.number().optional()
+});
+
+export const ValidationPropertySchema = z.union([StringPropertySchema, NumberPropertySchema]);
+
+export type ValidationPropertySchema = z.infer<typeof ValidationPropertySchema>;

--- a/packages/ir-sdk/fern/apis/ir-types-latest/definition/types.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/definition/types.yml
@@ -151,7 +151,38 @@ types:
     properties:
       keyType: TypeReference
       valueType: TypeReference
+
   PrimitiveType:
+    properties:
+      basic: BasicPrimitiveType
+      wrapped: WrappedPrimitiveType
+
+  WrappedPrimitiveType:
+    union:
+      integer: IntegerType
+      string: StringType
+
+  IntegerType:
+    properties:
+      default: optional<integer>
+      validation: optional<IntegerValidation>
+
+  IntegerValidation:
+    properties:
+      min: optional<integer>
+      max: optional<integer>
+
+  StringType:
+    properties:
+      default: optional<string>
+      validation: optional<StringValidation>
+
+  StringValidation:
+    properties:
+      minLength: optional<integer>
+      maxLength: optional<integer>
+  
+  BasicPrimitiveType:
     enum:
       - INTEGER
       - DOUBLE


### PR DESCRIPTION
### Motivation
We need to introduce new primitive type objects in order to account for strongly typed validations, i.e minimum and maximum for integers, and minLength, maxLength, and regex for Strings. This will allow for more flexibility for handling primitives in defs in the future as well.

### Testing
[TBD]
