### PR TITLE
(chore): add stackblitz badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![Discord](https://img.shields.io/badge/Join%20Our%20Community-black?logo=discord)](https://discord.com/invite/JkkXumPzcG)
 [![Documentation](https://img.shields.io/badge/Read%20our%20Documentation-black?logo=book)](https://buildwithfern.com/learn/home?utm_source=fern-api/fern/readme-read-our-documentation)
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/fern-api/fern)
+
 </div>
 
 Fern is a toolkit that allows you to input your API Definition and output SDKs and API documentation. Fern is compatible with the OpenAPI specification (formerly Swagger).


### PR DESCRIPTION
Adds one-click link to open `fern-api/fern` repo in StackBlitz. 