### PR TITLE
(chore): adding hidden docs for publishing

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -123,6 +123,10 @@ navigation:
           - page: Registry publishing
             path: ./pages/sdks/features/publish-to-registries.mdx
             icon: pro
+          - page: Publish to Private Registries
+            hidden: true
+            path: ./pages/sdks/features/publish-to-private-registries.mdx
+            icon: pro
           - page: Auto-Pagination
             path: ./pages/sdks/features/auto-pagination.mdx
             icon: pro

--- a/fern/pages/sdks/features/publish-to-private-registries.mdx
+++ b/fern/pages/sdks/features/publish-to-private-registries.mdx
@@ -1,0 +1,59 @@
+---
+title: Publishing to Fern's Private Registries
+description: Fern will automatically publish your SDKs to our privately hosted registries. 
+---
+
+In some cases, you may want to publish your SDKs to a private registry. Fern hosts 
+private registries for you at `npm.buildwithfern.com`, `pypi.buildwithfern.com`, 
+`maven.buildwithfern.com`, etc. 
+
+To use an internal registry, simply specify the `url` field in your `generators.yml`:
+
+<CodeBlocks>
+  <CodeBlock title="TypeScript">
+  ```yaml {5}
+    groups: 
+      ts-sdk: 
+        - name: fernapi/fern-typescript-node-sdk
+          version: 0.13.0
+          url: npm.buildwithfern.com
+          config: 
+            namespaceExport: Imdb
+          output: 
+            location: npm
+            package-name: "@imdb-fern/sdk"
+  ```
+  </CodeBlock>
+  <CodeBlock title="Python">
+  ```yaml {5}
+    groups: 
+      ts-sdk: 
+        - name: fernapi/fern-python-sdk
+          version: 1.0.0
+          url: pypi.buildwithfern.com
+          config: 
+            client_class_name: Imdb
+          output: 
+            location: pypi
+            package-name: "imdb-fern"
+  ```
+  </CodeBlock>
+  <CodeBlock title="Java">
+  ```yaml {5}
+    groups: 
+      ts-sdk: 
+        - name: fernapi/fern-java-sdk
+          version: 0.12.0
+          url: maven.buildwithfern.com
+          config: 
+            client-class-name: Imdb
+          output: 
+            location: maven
+            coordinate: com.imdb.fern:imdb-java
+  ```
+  </CodeBlock>
+</CodeBlocks>
+
+<Note>
+  To use a private registry, you will need to set the `FERN_TOKEN` environment variable.
+</Note>

--- a/fern/pages/sdks/features/publish-to-registries.mdx
+++ b/fern/pages/sdks/features/publish-to-registries.mdx
@@ -78,56 +78,7 @@ about the publishing process.
 
 ### Private registries
 
-In some cases, you may want to publish your SDKs to a private registry. Fern hosts 
-private registries for you at `npm.buildwithfern.com`, `pypi.buildwithfern.com`, 
-`maven.buildwithfern.com`, etc. To use an internal registry, simply specify the
-`url` field in your `generators.yml`:
+<Info>
+  To publish your SDKs using Fern's private registries, [contact the Fern support team](https://buildwithfern.com/contact). 
+</Info>
 
-<CodeBlocks>
-  <CodeBlock title="TypeScript">
-  ```yaml {5}
-    groups: 
-      ts-sdk: 
-        - name: fernapi/fern-typescript-node-sdk
-          version: 0.13.0
-          url: npm.buildwithfern.com
-          config: 
-            namespaceExport: Imdb
-          output: 
-            location: npm
-            package-name: "@imdb-fern/sdk"
-  ```
-  </CodeBlock>
-  <CodeBlock title="Python">
-  ```yaml {5}
-    groups: 
-      ts-sdk: 
-        - name: fernapi/fern-python-sdk
-          version: 1.0.0
-          url: pypi.buildwithfern.com
-          config: 
-            client_class_name: Imdb
-          output: 
-            location: pypi
-            package-name: "imdb-fern"
-  ```
-  </CodeBlock>
-  <CodeBlock title="Java">
-  ```yaml {5}
-    groups: 
-      ts-sdk: 
-        - name: fernapi/fern-java-sdk
-          version: 0.12.0
-          url: maven.buildwithfern.com
-          config: 
-            client-class-name: Imdb
-          output: 
-            location: maven
-            coordinate: com.imdb.fern:imdb-java
-  ```
-  </CodeBlock>
-</CodeBlocks>
-
-<Note>
-  To use a private registry, you will need to set the `FERN_TOKEN` environment variable.
-</Note>


### PR DESCRIPTION
This PR separates the documentation for publishing to Fern's private registries into two pages: public-facing and private. 