### PR TITLE
[WIP] Address Form-Data Issues

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8969,7 +8969,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["eslint", "npm:8.56.0"],\
             ["form-data", "npm:4.0.0"],\
             ["form-data-encoder", "npm:4.0.2"],\
-            ["formdata-node", "npm:6.0.3"],\
             ["jest", "virtual:816fb67d993b0978271f762d4ccbec7209ef2546c234ca6e241662d44336c8e32c1c3c07189cfe14b67974a4840e1ed140408a7403bf9deb68c1953445072efe#npm:29.7.0"],\
             ["jest-environment-jsdom", "virtual:7be63f1ee9eb34cb62254a57273a43b86b8b7753aa555eb261c4195c28af56c1d0f4f9ed3a307dac6e859be2fc2f1dac6612f92db051061f91f1ec4982afe62a#npm:29.7.0"],\
             ["jest-fetch-mock", "npm:3.0.3"],\

--- a/generators/typescript/utils/core-utilities/fetcher/package.json
+++ b/generators/typescript/utils/core-utilities/fetcher/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "form-data": "4.0.0",
     "form-data-encoder": "^4.0.2",
-    "formdata-node": "^6.0.3",
     "jest-fetch-mock": "^3.0.3",
     "node-fetch": "2.7.0",
     "qs": "6.12.1"

--- a/generators/typescript/utils/core-utilities/fetcher/src/fetcher/__test__/getRequestBody.test.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/fetcher/__test__/getRequestBody.test.ts
@@ -8,7 +8,7 @@ if (RUNTIME.type === "browser") {
 describe("Test getRequestBody", () => {
     it("should return FormData as is in Node environment", async () => {
         if (RUNTIME.type === "node") {
-            const formData = new (await import("formdata-node")).FormData();
+            const formData = new (await import("form-data")).default();
             formData.append("key", "value");
             const result = await getRequestBody(formData, "multipart/form-data");
             expect(result).toBe(formData);

--- a/generators/typescript/utils/core-utilities/fetcher/src/fetcher/getRequestBody.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/fetcher/getRequestBody.ts
@@ -1,25 +1,16 @@
-import { RUNTIME } from "../runtime";
-
 export async function getRequestBody(body: any, contentType: string): Promise<BodyInit | undefined> {
     let requestBody: BodyInit;
-    if (RUNTIME.type === "node") {
-        if (body instanceof (await import("formdata-node")).FormData) {
-            // @ts-expect-error
-            requestBody = body;
-        } else if (body instanceof (await import("stream")).Readable) {
-            // @ts-expect-error
-            requestBody = body;
-        } else {
-            requestBody = maybeStringifyBody(body, contentType ?? "");
-        }
+
+    if (body instanceof (await import("form-data")).default) {
+        // @ts-expect-error
+        requestBody = body;
+    } else if (body instanceof (await import("stream")).Readable) {
+        // @ts-expect-error
+        requestBody = body;
     } else {
-        if (body instanceof (await import("form-data")).default) {
-            // @ts-expect-error
-            requestBody = body;
-        } else {
-            requestBody = maybeStringifyBody(body, contentType ?? "");
-        }
+        requestBody = maybeStringifyBody(body, contentType ?? "");
     }
+
     return requestBody;
 }
 

--- a/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/FormDataWrapper.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/FormDataWrapper.ts
@@ -32,7 +32,9 @@ export class FormDataWrapper {
     private fd: CrossPlatformFormData | undefined;
 
     public async append(name: string, value: any): Promise<void> {
-        this.fd = new (await import("form-data")).default();
+        if (!this.fd) {
+            this.fd = new (await import("form-data")).default();
+        }
         this.fd?.append(name, value);
     }
 

--- a/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/FormDataWrapper.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/FormDataWrapper.ts
@@ -13,7 +13,7 @@ class FormDataRequestBody {
      * @returns the multipart form data request
      */
     public async getBody(): Promise<any> {
-        this.fd;
+        return this.fd;
     }
 
     /**

--- a/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/FormDataWrapper.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/FormDataWrapper.ts
@@ -1,50 +1,26 @@
-import { Readable } from "stream";
-import { RUNTIME } from "../runtime";
-
 interface CrossPlatformFormData {
     append(key: string, value: any): void;
 }
 
 class FormDataRequestBody {
     private fd: any;
-    private encoder: any;
 
     constructor(fd: any) {
         this.fd = fd;
-    }
-
-    async setup(): Promise<void> {
-        if (this.encoder == null && RUNTIME.type === "node") {
-            this.encoder = new (await import("form-data-encoder")).FormDataEncoder(this.fd);
-        }
     }
 
     /**
      * @returns the multipart form data request
      */
     public async getBody(): Promise<any> {
-        if (RUNTIME.type !== "node") {
-            return this.fd;
-        } else {
-            if (this.encoder == null) {
-                await this.setup();
-            }
-            return Readable.from(this.encoder);
-        }
+        this.fd;
     }
 
     /**
      * @returns headers that need to be added to the multipart form data request
      */
     public async getHeaders(): Promise<Record<string, string>> {
-        if (RUNTIME.type !== "node") {
-            return {};
-        } else {
-            if (this.encoder == null) {
-                await this.setup();
-            }
-            return this.encoder.headers;
-        }
+        return this.fd.getHeaders();
     }
 }
 
@@ -56,14 +32,8 @@ export class FormDataWrapper {
     private fd: CrossPlatformFormData | undefined;
 
     public async append(name: string, value: any): Promise<void> {
-        if (this.fd == null) {
-            if (RUNTIME.type === "node") {
-                this.fd = new (await import("formdata-node")).FormData();
-            } else {
-                this.fd = new (await import("form-data")).default();
-            }
-        }
-        this.fd.append(name, value);
+        this.fd = new (await import("form-data")).default();
+        this.fd?.append(name, value);
     }
 
     public getRequest(): FormDataRequestBody {

--- a/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/__test__/FormDataWrapper.test.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/__test__/FormDataWrapper.test.ts
@@ -1,0 +1,21 @@
+import { FormDataWrapper } from "../FormDataWrapper";
+
+describe("FormDataWrapper", () => {
+    it("should append data correctly", async () => {
+        const wrapper = new FormDataWrapper();
+        await wrapper.append("key", "value");
+        const request = wrapper.getRequest();
+        const headers = await request.getHeaders();
+
+        expect(headers).toHaveProperty("content-type");
+        expect(headers["content-type"]).toContain("multipart/form-data");
+    });
+
+    it("should return FormData from request and body", async () => {
+        const wrapper = new FormDataWrapper();
+        await wrapper.append("key", "value");
+        const request = wrapper.getRequest();
+
+        expect(await request.getBody()).toBeInstanceOf((await import("form-data")).default);
+    });
+});

--- a/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/__test__/FormDataWrapper.test.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/form-data-utils/__test__/FormDataWrapper.test.ts
@@ -18,4 +18,13 @@ describe("FormDataWrapper", () => {
 
         expect(await request.getBody()).toBeInstanceOf((await import("form-data")).default);
     });
+
+    it("should have two payloads", async () => {
+        const wrapper = new FormDataWrapper();
+        await wrapper.append("key", "value");
+        await wrapper.append("key2", "value2");
+        const request = wrapper.getRequest();
+
+        expect((await request.getBody())._streams.length).toBe(6);
+    });
 });

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -155,7 +155,7 @@ function isExternalUrl(url: string): boolean {
 }
 
 function isDataUrl(url: string): boolean {
-    return /^data:/.test(url);
+    return url.startsWith("data:/");
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5685,7 +5685,6 @@ __metadata:
     eslint: ^8.56.0
     form-data: 4.0.0
     form-data-encoder: ^4.0.2
-    formdata-node: ^6.0.3
     jest: ^29.7.0
     jest-environment-jsdom: ^29.7.0
     jest-fetch-mock: ^3.0.3


### PR DESCRIPTION
## What this does:

- Removes `formdata-node` dependency that causes unprocessable entity errors (422)
- Effectively routes all form-data requests through `form-data` package

## Considerations:

- Eschews all benefits of the more modern, `formdata-node` package
- Probably lightens dependency tree a little bit

## Risks:

- Potential breaking changes -- any foundational change may cause this

## How was this tested:

Using elevenlabs SDK on multipart form data APIs on following environments:
   - Node 16
   - Node 17
   - Node 18
   - Node 20