### PR TITLE
fix: global headers are only required if the underlying type is required

### DIFF
--- a/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/axle.test.ts.snap
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/axle.test.ts.snap
@@ -711,12 +711,12 @@ Auth codes are ephemeral and expire after 10 minutes, while accessTokens do not 
       "x-client-id": {
         "docs": "Your client ID. This will be shared with you during onboarding.",
         "name": "clientId",
-        "type": "string",
+        "type": "optional<string>",
       },
       "x-client-secret": {
         "docs": "Your secret API key. This will be shared with you during onboarding and should be considered sensitive - it’s a password after all!",
         "name": "clientSecret",
-        "type": "string",
+        "type": "optional<string>",
       },
     },
     "name": "api",
@@ -1435,12 +1435,12 @@ Auth codes are ephemeral and expire after 10 minutes, while accessTokens do not 
       "x-client-id": {
         "docs": "Your client ID. This will be shared with you during onboarding.",
         "name": "clientId",
-        "type": "string",
+        "type": "optional<string>",
       },
       "x-client-secret": {
         "docs": "Your secret API key. This will be shared with you during onboarding and should be considered sensitive - it’s a password after all!",
         "name": "clientSecret",
-        "type": "string",
+        "type": "optional<string>",
       },
     },
     "name": "api",

--- a/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/x-fern-global-headers.test.ts.snap
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/x-fern-global-headers.test.ts.snap
@@ -154,7 +154,7 @@ exports[`x-fern-global-headers x-fern-global-headers docs 1`] = `
       },
       "x-api-key": {
         "name": "apiKey",
-        "type": "string",
+        "type": "optional<string>",
       },
     },
     "name": "api",
@@ -324,7 +324,7 @@ exports[`x-fern-global-headers x-fern-global-headers simple 1`] = `
       },
       "x-api-key": {
         "name": "apiKey",
-        "type": "string",
+        "type": "optional<string>",
       },
     },
     "name": "api",

--- a/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/x-fern-parameter-name.test.ts.snap
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/x-fern-parameter-name.test.ts.snap
@@ -50,7 +50,7 @@ exports[`x-fern-parameter-name x-fern-parameter-name docs 1`] = `
     "headers": {
       "X-API-Version": {
         "name": "version",
-        "type": "string",
+        "type": "optional<string>",
       },
     },
     "name": "api",
@@ -108,7 +108,7 @@ exports[`x-fern-parameter-name x-fern-parameter-name simple 1`] = `
     "headers": {
       "X-API-Version": {
         "name": "version",
-        "type": "string",
+        "type": "optional<string>",
       },
     },
     "name": "api",


### PR DESCRIPTION
This PR makes it so that:
1. if a header is required on some endpoints and optional on others then it cannot be a global header
2. if a header is optional on every endpoint, it's an optional global header (previously it would be considered required, regardless of the underlying type)
3. a global header is only required if it's required on every endpoint