### PR TITLE
feat(cli): openapi support assigning servers to an environment

### DIFF
--- a/packages/cli/openapi-ir-sdk/fern/definition/commons.yml
+++ b/packages/cli/openapi-ir-sdk/fern/definition/commons.yml
@@ -118,6 +118,9 @@ types:
         docs: Populated by `X-Server-Name`
       url: string
       audiences: optional<list<string>>
+      environment:
+        type: optional<string>
+        docs: Populated by `X-Server-Environment`
 
   SdkGroupName:
     type: list<string>

--- a/packages/cli/openapi-ir-sdk/fern/definition/finalIr.yml
+++ b/packages/cli/openapi-ir-sdk/fern/definition/finalIr.yml
@@ -15,6 +15,7 @@ types:
       description: optional<string>
       basePath: optional<string>
       servers: list<commons.Server>
+      defaultEnvironment: optional<string>
       groups:
         docs: |
           Top level group information populated through `x-fern-groups`.

--- a/packages/cli/openapi-ir-sdk/src/sdk/api/resources/commons/types/Server.ts
+++ b/packages/cli/openapi-ir-sdk/src/sdk/api/resources/commons/types/Server.ts
@@ -9,4 +9,6 @@ export interface Server extends FernOpenapiIr.WithDescription {
     name: string | undefined;
     url: string;
     audiences: string[] | undefined;
+    /** Populated by `X-Server-Environment` */
+    environment: string | undefined;
 }

--- a/packages/cli/openapi-ir-sdk/src/sdk/api/resources/finalIr/types/OpenApiIntermediateRepresentation.ts
+++ b/packages/cli/openapi-ir-sdk/src/sdk/api/resources/finalIr/types/OpenApiIntermediateRepresentation.ts
@@ -15,6 +15,7 @@ export interface OpenApiIntermediateRepresentation {
     description: string | undefined;
     basePath: string | undefined;
     servers: FernOpenapiIr.Server[];
+    defaultEnvironment: string | undefined;
     /** Top level group information populated through `x-fern-groups`. */
     groups: Record<string, FernOpenapiIr.SdkGroupInfo>;
     tags: FernOpenapiIr.Tags;

--- a/packages/cli/openapi-ir-sdk/src/sdk/serialization/resources/commons/types/Server.ts
+++ b/packages/cli/openapi-ir-sdk/src/sdk/serialization/resources/commons/types/Server.ts
@@ -12,6 +12,7 @@ export const Server: core.serialization.ObjectSchema<serializers.Server.Raw, Fer
         name: core.serialization.string().optional(),
         url: core.serialization.string(),
         audiences: core.serialization.list(core.serialization.string()).optional(),
+        environment: core.serialization.string().optional(),
     })
     .extend(WithDescription);
 
@@ -20,5 +21,6 @@ export declare namespace Server {
         name?: string | null;
         url: string;
         audiences?: string[] | null;
+        environment?: string | null;
     }
 }

--- a/packages/cli/openapi-ir-sdk/src/sdk/serialization/resources/finalIr/types/OpenApiIntermediateRepresentation.ts
+++ b/packages/cli/openapi-ir-sdk/src/sdk/serialization/resources/finalIr/types/OpenApiIntermediateRepresentation.ts
@@ -27,6 +27,7 @@ export const OpenApiIntermediateRepresentation: core.serialization.ObjectSchema<
     description: core.serialization.string().optional(),
     basePath: core.serialization.string().optional(),
     servers: core.serialization.list(Server),
+    defaultEnvironment: core.serialization.string().optional(),
     groups: core.serialization.record(core.serialization.string(), SdkGroupInfo),
     tags: Tags,
     hasEndpointsMarkedInternal: core.serialization.boolean(),
@@ -51,6 +52,7 @@ export declare namespace OpenApiIntermediateRepresentation {
         description?: string | null;
         basePath?: string | null;
         servers: Server.Raw[];
+        defaultEnvironment?: string | null;
         groups: Record<string, SdkGroupInfo.Raw>;
         tags: Tags.Raw;
         hasEndpointsMarkedInternal: boolean;

--- a/packages/cli/openapi-ir-to-fern/src/__test__/FernDefinitionBuilder.test.ts
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/FernDefinitionBuilder.test.ts
@@ -24,7 +24,8 @@ describe("Fern Definition Builder", () => {
                 globalHeaders: [],
                 idempotencyHeaders: [],
                 groups: {},
-                channel: []
+                channel: [],
+                defaultEnvironment: undefined
             },
             true,
             false

--- a/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/x-fern-servers.test.ts.snap
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/__snapshots__/x-fern-servers.test.ts.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`x-fern-servers x-fern-servers docs 1`] = `
+{
+  "definitionFiles": {
+    "transcripts.yml": {
+      "types": {
+        "SpeechModel": {
+          "docs": "The speech model to use for the transcription.",
+          "type": "string",
+        },
+      },
+    },
+  },
+  "packageMarkerFile": {},
+  "rootApiFile": {
+    "default-environment": "Production",
+    "display-name": "Test extension \`x-fern-enum\` for enums",
+    "environments": {
+      "Production": {
+        "urls": {
+          "api": "https://api.example.com",
+          "auth": "https://auth.example.com",
+        },
+      },
+      "Sandbox": {
+        "urls": {
+          "api": "https://api-sandbox.example.com",
+          "auth": "https://auth-sandbox.example.com",
+        },
+      },
+    },
+    "error-discrimination": {
+      "strategy": "status-code",
+    },
+    "name": "api",
+  },
+}
+`;
+
+exports[`x-fern-servers x-fern-servers simple 1`] = `
+{
+  "definitionFiles": {
+    "transcripts.yml": {
+      "types": {
+        "SpeechModel": {
+          "docs": "The speech model to use for the transcription.",
+          "type": "string",
+        },
+      },
+    },
+  },
+  "packageMarkerFile": {},
+  "rootApiFile": {
+    "default-environment": "Production",
+    "display-name": "Test extension \`x-fern-enum\` for enums",
+    "environments": {
+      "Production": {
+        "urls": {
+          "api": "https://api.example.com",
+          "auth": "https://auth.example.com",
+        },
+      },
+      "Sandbox": {
+        "urls": {
+          "api": "https://api-sandbox.example.com",
+          "auth": "https://auth-sandbox.example.com",
+        },
+      },
+    },
+    "error-discrimination": {
+      "strategy": "status-code",
+    },
+    "name": "api",
+  },
+}
+`;

--- a/packages/cli/openapi-ir-to-fern/src/__test__/fixtures/x-fern-servers/openapi.yml
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/fixtures/x-fern-servers/openapi.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Test extension `x-fern-enum` for enums
+  version: 1.0.0
+paths: {}
+servers:
+  - url: https://api.example.com
+    x-fern-server-name: api
+    x-fern-environment: Production
+  - url: https://auth.example.com
+    x-fern-server-name: auth
+    x-fern-environment: Production
+  - url: https://api-sandbox.example.com
+    x-fern-server-name: api
+    x-fern-environment: Sandbox
+  - url: https://auth-sandbox.example.com
+    x-fern-server-name: auth
+    x-fern-environment: Sandbox
+
+components: 
+  schemas: 
+    SpeechModel:
+      type: string
+      description: The speech model to use for the transcription.
+      x-fern-sdk-group-name: transcripts

--- a/packages/cli/openapi-ir-to-fern/src/__test__/fixtures/x-fern-servers/openapi.yml
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/fixtures/x-fern-servers/openapi.yml
@@ -5,17 +5,21 @@ info:
 paths: {}
 servers:
   - url: https://api.example.com
-    x-fern-server-name: api
-    x-fern-environment: Production
+    x-fern-server: 
+      name: api
+      environment: Production
   - url: https://auth.example.com
-    x-fern-server-name: auth
-    x-fern-environment: Production
+    x-fern-server: 
+      name: auth
+      environment: Production
   - url: https://api-sandbox.example.com
-    x-fern-server-name: api
-    x-fern-environment: Sandbox
+    x-fern-server: 
+      name: api
+      environment: Sandbox
   - url: https://auth-sandbox.example.com
-    x-fern-server-name: auth
-    x-fern-environment: Sandbox
+    x-fern-server: 
+      name: auth
+      environment: Sandbox
 
 components: 
   schemas: 

--- a/packages/cli/openapi-ir-to-fern/src/__test__/x-fern-servers.test.ts
+++ b/packages/cli/openapi-ir-to-fern/src/__test__/x-fern-servers.test.ts
@@ -1,0 +1,5 @@
+import { testConvertOpenAPI } from "./testConvertOpenApi";
+
+describe("x-fern-servers", () => {
+    testConvertOpenAPI("x-fern-servers", "openapi.yml");
+});

--- a/packages/cli/openapi-ir-to-fern/src/buildEnvironments.ts
+++ b/packages/cli/openapi-ir-to-fern/src/buildEnvironments.ts
@@ -21,6 +21,49 @@ function extractUrlsFromEnvironmentSchema(
 }
 
 export function buildEnvironments(context: OpenApiIrConverterContext): void {
+    const fullEnvironments: Record<string, Record<string, string>> = {};
+    for (const server of context.ir.servers) {
+        if (server.name != null && server.environment != null) {
+            const environment = fullEnvironments[server.environment] ?? {};
+            environment[server.name] = server.url;
+            fullEnvironments[server.environment] = environment;
+        }
+    }
+
+    // If the environments are valid (e.g. the keys across environments are the same), add them to the builder
+    // and return, otherwise then you want to go down the original path of adding the environments to the builder.
+    if (Object.keys(fullEnvironments).length > 0) {
+        const firstEnvironmentName = Object.keys(fullEnvironments)[0];
+        const firstEnvironment = Object.values(fullEnvironments)[0];
+
+        if (firstEnvironment != null) {
+            const maybeEnvironmentUrls = firstEnvironment != null ? Object.values(firstEnvironment) : [];
+            // If any of the environments aren't valid, don't respect the lists
+            const environmentsAreValid = Object.values(fullEnvironments).every((environment) => {
+                const theseEnvUrls = Object.keys(environment);
+                const firstEnvUrls = Object.keys(firstEnvironment);
+                if (theseEnvUrls.length !== firstEnvUrls.length) {
+                    return false;
+                }
+
+                return theseEnvUrls.every((value, index) => value === firstEnvUrls[index]);
+            });
+
+            if (maybeEnvironmentUrls.length > 0 && environmentsAreValid) {
+                for (const [environmentName, urls] of Object.entries(fullEnvironments)) {
+                    context.builder.addEnvironment({
+                        name: environmentName,
+                        schema: { urls }
+                    });
+                }
+                // Set the first environment as the default environment this should
+                // be a safe check since we've already validated the length of the Record.
+                context.builder.setDefaultEnvironment(firstEnvironmentName!);
+                return;
+            }
+        }
+    }
+
     const topLevelServersWithName: Record<string, RawSchemas.EnvironmentSchema> = {};
     const topLevelSkippedServers = [];
     for (const server of context.ir.servers) {

--- a/packages/cli/openapi-ir-to-fern/src/buildEnvironments.ts
+++ b/packages/cli/openapi-ir-to-fern/src/buildEnvironments.ts
@@ -58,6 +58,7 @@ export function buildEnvironments(context: OpenApiIrConverterContext): void {
                 }
                 // Set the first environment as the default environment this should
                 // be a safe check since we've already validated the length of the Record.
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 context.builder.setDefaultEnvironment(firstEnvironmentName!);
                 return;
             }

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/anyOf.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/anyOf.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > anyOf > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/apiture.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/apiture.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > apiture > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "APIs for digital banking client applications.
 
 ## Customer Accounts
@@ -18600,6 +18601,7 @@ For recurring transfer schedules, \`endsOn\`, \`count\`, and \`amountLimit\` are
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://api.apiture.com/banking",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/application-pdf.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/application-pdf.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > application-pdf-content-type > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/aries.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/aries.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > aries > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -113384,6 +113385,7 @@ exports[`open api parser > aries > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "/",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/assembly.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/assembly.test.ts.snap
@@ -370,6 +370,7 @@ The parameter should map to a JSON encoded list of strings.
       "summary": null,
     },
   ],
+  "defaultEnvironment": null,
   "description": "AssemblyAI API",
   "endpoints": [
     {
@@ -17947,6 +17948,7 @@ The default value is 'en_us'.
     {
       "audiences": null,
       "description": "AssemblyAI API",
+      "environment": null,
       "name": null,
       "url": "https://api.assemblyai.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/audio-mpeg.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/audio-mpeg.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > audio-mpeg-content-type > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/availability.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/availability.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > availability > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/deel.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/deel.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > deel > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -74052,12 +74053,14 @@ exports[`open api parser > deel > parse open api 1`] = `
     {
       "audiences": null,
       "description": "Production server",
+      "environment": null,
       "name": null,
       "url": "https://api.letsdeel.com/rest/v1",
     },
     {
       "audiences": null,
       "description": "Demo server",
+      "environment": null,
       "name": null,
       "url": "https://api-staging.letsdeel.com/rest/v1",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/default-content.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/default-content.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > default-content > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -101,6 +102,7 @@ exports[`open api parser > default-content > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://ai.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/defaults.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/defaults.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > defaults > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],
@@ -124,6 +125,7 @@ exports[`open api parser > defaults > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://api.apiture.com/banking",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/devrev.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/devrev.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > devrev > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "DevRev's REST API.",
   "endpoints": [
     {
@@ -36327,6 +36328,7 @@ empty.
     {
       "audiences": null,
       "description": "DevRev API endpoint.",
+      "environment": null,
       "name": null,
       "url": "https://api.devrev.ai",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/dopt.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/dopt.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > dopt > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "The Dopt Blocks API",
   "endpoints": [
     {
@@ -4991,6 +4992,7 @@ exports[`open api parser > dopt > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "http://blocks-api:7071",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/enum-casing.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/enum-casing.test.ts.snap
@@ -5,6 +5,7 @@ exports[`examples > enum-casing > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/examples.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/examples.test.ts.snap
@@ -5,6 +5,7 @@ exports[`examples > examples > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/file-upload.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/file-upload.test.ts.snap
@@ -5,6 +5,7 @@ exports[`file-upload > file-upload > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/flagright.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/flagright.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > flagright > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "",
   "endpoints": [
     {
@@ -28707,6 +28708,7 @@ In order to make individual events retrievable, you also need to pass in a uniqu
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://sandbox.api.flagright.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/flexport.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/flexport.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > flexport > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "The Flexport API enables you to programmatically interact with Flexport's freight data.
 
 The API follows modern RESTful conventions and speaks JSON in both directions. As the API uses JSON for both
@@ -102602,6 +102603,7 @@ Other details about this invoice",
     {
       "audiences": null,
       "description": "Flexport API",
+      "environment": null,
       "name": null,
       "url": "https://api.flexport.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/float.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/float.test.ts.snap
@@ -5,6 +5,7 @@ exports[`float > float > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/gen-yml-make-undisc-unions-on.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/gen-yml-make-undisc-unions-on.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > gen-yml-make-undisc-unions > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "The Batch API provides access to Hume models through an asynchronous job-based interface. You can submit a job to have many different files processed in parallel. The status of a job can then be checked with the job ID. Email notifications are available to alert on completed jobs.",
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/gen-yml-use-title-setting-on.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/gen-yml-use-title-setting-on.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > gen-yml-use-title > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/gen-yml-use-title-setting.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/gen-yml-use-title-setting.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > gen-yml-use-title > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/hathora.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/hathora.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > hathora > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -14940,12 +14941,14 @@ exports[`open api parser > hathora > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://api.hathora.dev",
     },
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "/",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/hookdeck.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/hookdeck.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > hookdeck > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -83701,6 +83702,7 @@ exports[`open api parser > hookdeck > parse open api 1`] = `
     {
       "audiences": null,
       "description": "Production API",
+      "environment": null,
       "name": null,
       "url": "https://api.hookdeck.com/2023-01-01",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/hume.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/hume.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > hume > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "The Batch API provides access to Hume models through an asynchronous job-based interface. You can submit a job to have many different files processed in parallel. The status of a job can then be checked with the job ID. Email notifications are available to alert on completed jobs.",
   "endpoints": [
     {
@@ -7015,6 +7016,7 @@ If you wish to supply more than 100 URLs, consider providing them as an archive 
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://api.hume.ai",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/inline-schema-reference.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/inline-schema-reference.test.ts.snap
@@ -5,6 +5,7 @@ exports[`inline-schema-reference > inline-schema-reference > parse open api 1`] 
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/merge.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/merge.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > merge > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "The unified API for building rich integrations with multiple HR Information System platforms.",
   "endpoints": [
     {
@@ -61700,12 +61701,14 @@ Fetch from the \`LIST TimeOffs\` endpoint and filter by \`ID\` to show all time 
     {
       "audiences": null,
       "description": "Production",
+      "environment": null,
       "name": "Production",
       "url": "https://api.merge.dev/api/hris/v1",
     },
     {
       "audiences": null,
       "description": "Sandbox",
+      "environment": null,
       "name": "Sandbox",
       "url": "https://api-sandbox.merge.dev/api/hris/v1",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/non-alphanumeric-characters.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/non-alphanumeric-characters.test.ts.snap
@@ -5,6 +5,7 @@ exports[`non alphanumeric characters > non-alphanumeric-characters > parse open 
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/optional-multipart.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/optional-multipart.test.ts.snap
@@ -5,6 +5,7 @@ exports[`optional-multipart > optional-multipart > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/path.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/path.test.ts.snap
@@ -5,6 +5,7 @@ exports[`path parsing > path > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/polytomic.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/polytomic.test.ts.snap
@@ -5,6 +5,7 @@ exports[`polytomic > polytomic > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -2117,6 +2118,7 @@ exports[`polytomic > polytomic > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://app.polytomic.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/rightbrain.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/rightbrain.test.ts.snap
@@ -5,6 +5,7 @@ exports[`rightbrain > rightbrain > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "
 Brain Core API. 🚀
 ",

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/rules.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/rules.test.ts.snap
@@ -5,6 +5,7 @@ exports[`rules > rules > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/seam.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/seam.test.ts.snap
@@ -5,6 +5,7 @@ exports[`seam > seam > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -89337,6 +89338,7 @@ exports[`seam > seam > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://connect.getseam.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/squidex.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/squidex.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > squidex > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -99224,6 +99225,7 @@ You will retrieve all apps, where you are assigned as a contributor.",
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://localhost:5001",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/streaming.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/streaming.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > streaming > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/suger.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/suger.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > suger > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "CRUD operations on a set of resources, including organizations, products, offers, entitlements, usage record groups for meterting, etc.",
   "endpoints": [
     {
@@ -57849,6 +57850,7 @@ the same customer, dimension, and time, but a different quantity.",
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "//https://api.suger.cloud",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/supertokens.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/supertokens.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > supertokens > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "This is the API exposed by the SuperTokens Core. To be consumed by your backend only.",
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/uint.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/uint.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > uint > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/undiscriminated-enums.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/undiscriminated-enums.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > undiscriminated-enums > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/uploadcare.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/uploadcare.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > uploadcare > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "### Summary
 Upload API provides several ways of uploading files to Uploadcare servers in a
 secure and reliable way.
@@ -15531,6 +15532,7 @@ change the value to \`auto\`.
     {
       "audiences": null,
       "description": "Production server",
+      "environment": null,
       "name": null,
       "url": "https://upload.uploadcare.com",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/vellum.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/vellum.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > vellum > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "
 ## Vellum API Documentation
 
@@ -1319,6 +1320,7 @@ Executes a deployed Workflow and streams back its results.",
         {
           "audiences": null,
           "description": null,
+          "environment": null,
           "name": "Predict",
           "url": "https://predict.vellum.ai",
         },
@@ -1606,6 +1608,7 @@ Generate a completion using a previously defined deployment.
         {
           "audiences": null,
           "description": null,
+          "environment": null,
           "name": "Predict",
           "url": "https://predict.vellum.ai",
         },
@@ -1784,6 +1787,7 @@ Generate a stream of completions using a previously defined deployment.
         {
           "audiences": null,
           "description": null,
+          "environment": null,
           "name": "Predict",
           "url": "https://predict.vellum.ai",
         },
@@ -3447,6 +3451,7 @@ Perform a search against a document index.
         {
           "audiences": null,
           "description": null,
+          "environment": null,
           "name": "Predict",
           "url": "https://predict.vellum.ai",
         },
@@ -3606,6 +3611,7 @@ Used to submit feedback regarding the quality of previously generated completion
         {
           "audiences": null,
           "description": null,
+          "environment": null,
           "name": "Predict",
           "url": "https://predict.vellum.ai",
         },
@@ -4285,6 +4291,7 @@ Upload a document to be indexed and used for search.
         {
           "audiences": null,
           "description": null,
+          "environment": null,
           "name": "Documents",
           "url": "https://documents.vellum.ai",
         },
@@ -16842,6 +16849,7 @@ Upload a document to be indexed and used for search.
     {
       "audiences": null,
       "description": "Default Server",
+      "environment": null,
       "name": "Default",
       "url": "https://api.vellum.ai",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/vocode.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/vocode.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > vocode > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": "
         Vocode's Hosted API helps you automate phone calls in minutes. 🚀
 
@@ -16174,12 +16175,14 @@ exports[`open api parser > vocode > parse open api 1`] = `
     {
       "audiences": null,
       "description": "Production environment",
+      "environment": null,
       "name": null,
       "url": "https://api.vocode.dev",
     },
     {
       "audiences": null,
       "description": "Staging environment",
+      "environment": null,
       "name": null,
       "url": "https://staging.vocode.dev",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/webhooks.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/webhooks.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > webhooks > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-examples.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-examples.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-examples > x-fern-examples > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-header.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-header.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-header > x-fern-header > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-ignore-schema.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-ignore-schema.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-ignore-schema > x-fern-ignore-schema > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-pagination.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-pagination.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-pagination > x-fern-pagination > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-property-name.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-property-name.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-property-name > x-fern-property-name > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-streaming.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-streaming.test.ts.snap
@@ -5,6 +5,7 @@ exports[`open api parser > x-fern-streaming > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {
@@ -3237,6 +3238,7 @@ exports[`open api parser > x-fern-streaming > parse open api 1`] = `
     {
       "audiences": null,
       "description": null,
+      "environment": null,
       "name": null,
       "url": "https://test-ai-api.com/api",
     },

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-token-variable-name.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-token-variable-name.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-token-variable-name > x-fern-token-variable-name > parse open ap
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-type.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-type.test.ts.snap
@@ -5,6 +5,7 @@ exports[`x-fern-type > x-fern-type > parse open api 1`] = `
   "apiVersion": null,
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [],
   "globalHeaders": [],

--- a/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-version.test.ts.snap
+++ b/packages/cli/openapi-parser/src/__test__/__snapshots__/x-fern-version.test.ts.snap
@@ -13,6 +13,7 @@ exports[`x-fern-version > x-fern-version > parse open api 1`] = `
   },
   "basePath": null,
   "channel": [],
+  "defaultEnvironment": null,
   "description": null,
   "endpoints": [
     {

--- a/packages/cli/openapi-parser/src/openapi/v3/converters/convertServer.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/converters/convertServer.ts
@@ -3,13 +3,48 @@ import { OpenAPIV3 } from "openapi-types";
 import { getExtension } from "../../../getExtension";
 import { FernOpenAPIExtension } from "../extensions/fernExtensions";
 
+interface ServerConfig {
+    name: string;
+    environment: string | undefined;
+}
+
 export function convertServer(server: OpenAPIV3.ServerObject): Server {
-    return {
+    const initServer = {
         url: getServerUrl({ url: server.url, variables: server.variables ?? {} }),
+<<<<<<< HEAD
         description: server.description,
         name: getServerName(server),
         audiences: getExtension<string[]>(server, FernOpenAPIExtension.AUDIENCES)
+=======
+        description: server.description
+>>>>>>> c508a0bcfe (improvement: allow specifying multi-environment urls from openapi)
     };
+
+    const maybeFullServerConfig = getFullServerCOnfig(server);
+    if (maybeFullServerConfig != null) {
+        return {
+            ...initServer,
+            ...maybeFullServerConfig
+        };
+    }
+
+    return {
+        ...initServer,
+        name: getServerName(server),
+        environment: getServerEnvironment(server)
+    };
+}
+
+export function getDefaultEnvironmentName(document: OpenAPIV3.Document): string | undefined {
+    return getExtension<string>(document, FernOpenAPIExtension.SERVER_DEFAULT_ENVIRONMENT);
+}
+
+function getFullServerCOnfig(server: OpenAPIV3.ServerObject): ServerConfig | undefined {
+    return getExtension<ServerConfig>(server, FernOpenAPIExtension.SERVER_CONFIG);
+}
+
+function getServerEnvironment(server: OpenAPIV3.ServerObject): string | undefined {
+    return getExtension<string>(server, FernOpenAPIExtension.SERVER_ENVIRONMENT);
 }
 
 function getServerUrl({

--- a/packages/cli/openapi-parser/src/openapi/v3/converters/convertServer.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/converters/convertServer.ts
@@ -17,7 +17,7 @@ export function convertServer(server: OpenAPIV3.ServerObject, context: AbstractO
 >>>>>>> c508a0bcfe (improvement: allow specifying multi-environment urls from openapi)
     };
 
-    const maybeFullServerConfig = getFullServerCOnfig(server, context);
+    const maybeFullServerConfig = getFullServerConfig(server, context);
     if (maybeFullServerConfig != null) {
         return {
             ...initServer,
@@ -37,7 +37,7 @@ export function getDefaultEnvironmentName(document: OpenAPIV3.Document): string 
     return getExtension<string>(document, FernOpenAPIExtension.SERVER_DEFAULT_ENVIRONMENT);
 }
 
-function getFullServerCOnfig(
+function getFullServerConfig(
     server: OpenAPIV3.ServerObject,
     context: AbstractOpenAPIV3ParserContext
 ): ServerConfigSchema | undefined {

--- a/packages/cli/openapi-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -123,7 +123,7 @@ export function convertHttpOperation({
         request: convertedRequest,
         response: convertedResponse.value,
         errors: convertedResponse.errors,
-        server: (operation.servers ?? []).map((server) => convertServer(server)),
+        server: (operation.servers ?? []).map((server) => convertServer(server, context)),
         description: operation.description,
         authed: isEndpointAuthed(operation, document),
         availability,

--- a/packages/cli/openapi-parser/src/openapi/v3/extensions/fernExtensions.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/extensions/fernExtensions.ts
@@ -11,25 +11,7 @@ export const FernOpenAPIExtension = {
     BOOLEAN_LITERAL: "x-fern-boolean-literal",
 
     SERVER_NAME_V1: "x-name",
-    /**
-     * Enables configuring multiple base URLs for different environments.
-     * Note: that if x-fern-environment is used, then so must x-fern-default-environment.
-     *
-     * x-fern-default-environment: Production
-     *
-     * servers:
-     *   - url: https://api.example.com
-     *     x-fern-server-name: api
-     *     x-fern-environment: Production
-     *   - url: https://auth.example.com
-     *     x-fern-server-name: auth
-     *     x-fern-environment: Production
-     * paths:
-     *   /path/to/my/endpoint:
-     */
     SERVER_NAME_V2: "x-fern-server-name",
-    SERVER_ENVIRONMENT: "x-fern-environment",
-    SERVER_DEFAULT_ENVIRONMENT: "x-fern-default-environment",
 
     /**
      * Alternatively, this configuration works as well.
@@ -43,6 +25,7 @@ export const FernOpenAPIExtension = {
      *        environment: Production
      */
     SERVER_CONFIG: "x-fern-server",
+    SERVER_DEFAULT_ENVIRONMENT: "x-fern-default-environment",
 
     /**
      * Prepends the configured base path to all of the endpoint paths.

--- a/packages/cli/openapi-parser/src/openapi/v3/extensions/fernExtensions.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/extensions/fernExtensions.ts
@@ -11,7 +11,38 @@ export const FernOpenAPIExtension = {
     BOOLEAN_LITERAL: "x-fern-boolean-literal",
 
     SERVER_NAME_V1: "x-name",
+    /**
+     * Enables configuring multiple base URLs for different environments.
+     * Note: that if x-fern-environment is used, then so must x-fern-default-environment.
+     *
+     * x-fern-default-environment: Production
+     *
+     * servers:
+     *   - url: https://api.example.com
+     *     x-fern-server-name: api
+     *     x-fern-environment: Production
+     *   - url: https://auth.example.com
+     *     x-fern-server-name: auth
+     *     x-fern-environment: Production
+     * paths:
+     *   /path/to/my/endpoint:
+     */
     SERVER_NAME_V2: "x-fern-server-name",
+    SERVER_ENVIRONMENT: "x-fern-environment",
+    SERVER_DEFAULT_ENVIRONMENT: "x-fern-default-environment",
+
+    /**
+     * Alternatively, this configuration works as well.
+     *
+     * x-fern-default-environment: Production
+     *
+     * servers:
+     *   - url: https://api.example.com
+     *     x-fern-server:
+     *        name: api
+     *        environment: Production
+     */
+    SERVER_CONFIG: "x-fern-server",
 
     /**
      * Prepends the configured base path to all of the endpoint paths.

--- a/packages/cli/openapi-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/generateIr.ts
@@ -299,7 +299,7 @@ export function generateIr({
                 return [key, { summary: value.summary ?? undefined, description: value.description ?? undefined }];
             })
         ),
-        servers: (openApi.servers ?? []).map((server) => convertServer(server)),
+        servers: (openApi.servers ?? []).map((server) => convertServer(server, context)),
         tags: {
             tagsById: Object.fromEntries(
                 (openApi.tags ?? []).map((tag) => {

--- a/packages/cli/openapi-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/generateIr.ts
@@ -29,7 +29,7 @@ import { isReferenceObject } from "../../schema/utils/isReferenceObject";
 import { AbstractOpenAPIV3ParserContext } from "./AbstractOpenAPIV3ParserContext";
 import { convertPathItem, convertPathItemToWebhooks } from "./converters/convertPathItem";
 import { convertSecurityScheme } from "./converters/convertSecurityScheme";
-import { convertServer } from "./converters/convertServer";
+import { convertServer, getDefaultEnvironmentName } from "./converters/convertServer";
 import { ERROR_NAMES } from "./converters/convertToHttpError";
 import { ExampleEndpointFactory } from "./converters/ExampleEndpointFactory";
 import { ConvertedOperation } from "./converters/operation/convertOperation";
@@ -308,6 +308,7 @@ export function generateIr({
             ),
             orderedTagIds: openApi.tags?.map((tag) => tag.name)
         },
+        defaultEnvironment: getDefaultEnvironmentName(context.document),
         endpoints,
         webhooks,
         channel: [],

--- a/packages/cli/openapi-parser/src/openapi/v3/schemas/ServerConfigSchema.ts
+++ b/packages/cli/openapi-parser/src/openapi/v3/schemas/ServerConfigSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const ServerConfigSchema = z.object({
+    name: z.optional(z.string()),
+    environment: z.string()
+});
+
+export type ServerConfigSchema = z.infer<typeof ServerConfigSchema>;

--- a/packages/cli/openapi-parser/src/parse.ts
+++ b/packages/cli/openapi-parser/src/parse.ts
@@ -86,7 +86,8 @@ export async function parse({
         securitySchemes: {},
         globalHeaders: [],
         idempotencyHeaders: [],
-        groups: {}
+        groups: {},
+        defaultEnvironment: undefined
     };
 
     for (const spec of specs) {
@@ -233,7 +234,8 @@ function merge(
         groups: {
             ...ir1.groups,
             ...ir2.groups
-        }
+        },
+        defaultEnvironment: undefined
     };
 }
 

--- a/packages/cli/openapi-parser/src/parse.ts
+++ b/packages/cli/openapi-parser/src/parse.ts
@@ -235,7 +235,7 @@ function merge(
             ...ir1.groups,
             ...ir2.groups
         },
-        defaultEnvironment: undefined
+        defaultEnvironment: ir1.defaultEnvironment ?? ir2.defaultEnvironment
     };
 }
 


### PR DESCRIPTION
Exposes an `x-fern-server` to add both name and env, and any additional config we want in the future
```yaml
 servers:
   - url: https://api.example.com
     x-fern-server:
        name: api
        environment: Production
```