### PR TITLE
(feat): `generators.yml` can link out to fern definition

### DIFF
--- a/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
+++ b/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
@@ -64,11 +64,13 @@ export async function updateApiSpec({
                     if (generatorsYml.isRawProtobufAPIDefinitionSchema(api)) {
                         continue;
                     }
-                    if (typeof api !== "string" && api.origin != null) {
-                        cliContext.logger.info(`Origin found, fetching spec from ${api.origin}`);
+                    const origin = (api as any)?.origin;
+                    const path = (api as any)?.path;
+                    if (typeof api !== "string" && origin != null && path != null) {
+                        cliContext.logger.info(`Origin found, fetching spec from ${origin}`);
                         await fetchAndWriteFile(
-                            api.origin,
-                            join(workspace.absoluteFilepath, RelativeFilePath.of(api.path)),
+                            origin,
+                            join(workspace.absoluteFilepath, RelativeFilePath.of(path)),
                             cliContext.logger
                         );
                     }

--- a/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
+++ b/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
@@ -64,7 +64,9 @@ export async function updateApiSpec({
                     if (generatorsYml.isRawProtobufAPIDefinitionSchema(api)) {
                         continue;
                     }
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     const origin = (api as any)?.origin;
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     const path = (api as any)?.path;
                     if (typeof api !== "string" && origin != null && path != null) {
                         cliContext.logger.info(`Origin found, fetching spec from ${origin}`);

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -38,7 +38,7 @@ export interface APIDefinitionLocation {
     settings: APIDefinitionSettings | undefined;
 }
 
-export type APIDefinitionSchema = ProtoAPIDefinitionSchema | OSSAPIDefinitionSchema;
+export type APIDefinitionSchema = ProtoAPIDefinitionSchema | OSSAPIDefinitionSchema | FernAPIDefinitionSchema;
 
 export interface ProtoAPIDefinitionSchema {
     type: "protobuf";
@@ -49,6 +49,11 @@ export interface ProtoAPIDefinitionSchema {
 
 export interface OSSAPIDefinitionSchema {
     type: "oss";
+    path: string;
+}
+
+export interface FernAPIDefinitionSchema {
+    type: "fern";
     path: string;
 }
 

--- a/packages/cli/configuration/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -12,6 +12,7 @@ import {
     GeneratorInvocation,
     GeneratorsConfiguration
 } from "./GeneratorsConfiguration";
+import { isRawFernAPIDefinitionSchema } from "./isRawFernAPIDefinitionSchema";
 import { isRawProtobufAPIDefinitionSchema } from "./isRawProtobufAPIDefinitionSchema";
 import { GeneratorGroupSchema } from "./schemas/GeneratorGroupSchema";
 import { GeneratorInvocationSchema } from "./schemas/GeneratorInvocationSchema";
@@ -110,6 +111,17 @@ async function parseAPIConfiguration(
                     asyncApiMessageNaming: undefined
                 }
             });
+        } else if (isRawFernAPIDefinitionSchema(apiConfiguration)) {
+            apiDefinitions.push({
+                schema: {
+                    type: "fern",
+                    path: apiConfiguration.fern
+                },
+                origin: undefined,
+                overrides: undefined,
+                audiences: [],
+                settings: undefined
+            });
         } else if (Array.isArray(apiConfiguration)) {
             for (const definition of apiConfiguration) {
                 if (typeof definition === "string") {
@@ -138,11 +150,18 @@ async function parseAPIConfiguration(
                         origin: undefined,
                         overrides: definition.proto.overrides,
                         audiences: [],
-                        settings: {
-                            shouldUseTitleAsName: undefined,
-                            shouldUseUndiscriminatedUnionsWithLiterals: undefined,
-                            asyncApiMessageNaming: undefined
-                        }
+                        settings: undefined
+                    });
+                } else if (isRawFernAPIDefinitionSchema(definition)) {
+                    apiDefinitions.push({
+                        schema: {
+                            type: "fern",
+                            path: definition.fern
+                        },
+                        origin: undefined,
+                        overrides: undefined,
+                        audiences: [],
+                        settings: undefined
                     });
                 } else {
                     apiDefinitions.push({

--- a/packages/cli/configuration/src/generators-yml/index.ts
+++ b/packages/cli/configuration/src/generators-yml/index.ts
@@ -18,7 +18,8 @@ export {
     loadGeneratorsConfiguration,
     loadRawGeneratorsConfiguration
 } from "./loadGeneratorsConfiguration";
-export { type APIConfigurationSchema, type ProtobufAPIDefinitionSchema } from "./schemas/APIConfigurationSchema";
+export { type APIConfigurationSchema } from "./schemas/APIConfigurationSchema";
+export { type ProtobufAPIDefinitionSchema } from "./schemas/apis/ProtobufDefinitionSchema";
 export { type GeneratorInvocationSchema } from "./schemas/GeneratorInvocationSchema";
 export { type GeneratorPublishMetadataSchema } from "./schemas/GeneratorPublishMetadataSchema";
 export {

--- a/packages/cli/configuration/src/generators-yml/isRawFernAPIDefinitionSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/isRawFernAPIDefinitionSchema.ts
@@ -1,0 +1,8 @@
+import { APIConfigurationSchema } from "./schemas/APIConfigurationSchema";
+import { FernDefinitionSchema } from "./schemas/apis/FernDefinitionSchema";
+
+export function isRawFernAPIDefinitionSchema(
+    rawApiConfiguration: APIConfigurationSchema
+): rawApiConfiguration is FernDefinitionSchema {
+    return typeof rawApiConfiguration !== "string" && "fern" in rawApiConfiguration;
+}

--- a/packages/cli/configuration/src/generators-yml/isRawProtobufAPIDefinitionSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/isRawProtobufAPIDefinitionSchema.ts
@@ -1,4 +1,5 @@
-import { APIConfigurationSchema, ProtobufAPIDefinitionSchema } from "./schemas/APIConfigurationSchema";
+import { APIConfigurationSchema } from "./schemas/APIConfigurationSchema";
+import { ProtobufAPIDefinitionSchema } from "./schemas/apis/ProtobufDefinitionSchema";
 
 export function isRawProtobufAPIDefinitionSchema(
     rawApiConfiguration: APIConfigurationSchema

--- a/packages/cli/configuration/src/generators-yml/schemas/APIConfigurationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/APIConfigurationSchema.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { FernDefinitionSchema } from "./apis/FernDefinitionSchema";
+import { ProtobufAPIDefinitionSchema } from "./apis/ProtobufDefinitionSchema";
 
 /**
  * @example
@@ -53,56 +55,29 @@ export const APIDefintionWithOverridesSchema = z.object({
 /**
  * @example
  * api:
- *  proto:
- *    root: proto
- *    target: proto/user/v1/user.proto
- *    local-generation: true
- */
-export const ProtobufDefinitionSchema = z.strictObject({
-    root: z.string().describe("The path to the `.proto` directroy root (e.g. `proto`)."),
-    target: z
-        .string()
-        .describe("The path to the target `.proto` file that defines the API (e.g. `proto/user/v1/user.proto`)."),
-    overrides: z.optional(z.string()).describe("Path to the overrides configuration"),
-    "local-generation": z
-        .optional(z.boolean())
-        .describe("Whether to compile the `.proto` files locally. By default, we generate remotely.")
-});
-
-export type ProtobufDefinitionSchema = z.infer<typeof ProtobufDefinitionSchema>;
-
-/**
- * @example
- * api:
- *  proto:
- *    root: proto
- *    target: proto/user/v1/user.proto
- */
-export const ProtobufAPIDefinitionSchema = z.strictObject({
-    proto: ProtobufDefinitionSchema
-});
-
-export type ProtobufAPIDefinitionSchema = z.infer<typeof ProtobufAPIDefinitionSchema>;
-
-/**
- * @example
- * api:
  *  - path: openapi.yml
  *    overrides: overrides.yml
  *  - openapi.yml
  *  - proto:
  *      root: proto
  *      target: proto/user/v1/user.proto
+ *  - fern: path/to/definition
  */
 export const APIDefinitionList = z.array(
-    z.union([APIDefinitionPathSchema, APIDefintionWithOverridesSchema, ProtobufAPIDefinitionSchema])
+    z.union([
+        APIDefinitionPathSchema,
+        APIDefintionWithOverridesSchema,
+        ProtobufAPIDefinitionSchema,
+        FernDefinitionSchema
+    ])
 );
 
 export const APIConfigurationSchema = z.union([
     APIDefinitionPathSchema,
     APIDefintionWithOverridesSchema,
     APIDefinitionList,
-    ProtobufAPIDefinitionSchema
+    ProtobufAPIDefinitionSchema,
+    FernDefinitionSchema
 ]);
 
 export type APIConfigurationSchema = z.infer<typeof APIConfigurationSchema>;

--- a/packages/cli/configuration/src/generators-yml/schemas/apis/FernDefinitionSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/apis/FernDefinitionSchema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/**
+ * @example
+ * fern: path to definition
+ */
+export const FernDefinitionSchema = z.strictObject({
+    fern: z.string().describe("Path to the fern definition directory.")
+});
+
+export type FernDefinitionSchema = z.infer<typeof FernDefinitionSchema>;

--- a/packages/cli/configuration/src/generators-yml/schemas/apis/ProtobufDefinitionSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/apis/ProtobufDefinitionSchema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * @example
+ * root: proto
+ * target: proto/user/v1/user.proto
+ * local-generation: true
+ */
+export const ProtobufDefinitionSchema = z.strictObject({
+    root: z.string().describe("The path to the `.proto` directroy root (e.g. `proto`)."),
+    target: z
+        .string()
+        .describe("The path to the target `.proto` file that defines the API (e.g. `proto/user/v1/user.proto`)."),
+    overrides: z.optional(z.string()).describe("Path to the overrides configuration"),
+    "local-generation": z
+        .optional(z.boolean())
+        .describe("Whether to compile the `.proto` files locally. By default, we generate remotely.")
+});
+
+export type ProtobufDefinitionSchema = z.infer<typeof ProtobufDefinitionSchema>;
+
+/**
+ * @example
+ * proto:
+ *   root: proto
+ *   target: proto/user/v1/user.proto
+ */
+export const ProtobufAPIDefinitionSchema = z.strictObject({
+    proto: ProtobufDefinitionSchema
+});
+
+export type ProtobufAPIDefinitionSchema = z.infer<typeof ProtobufAPIDefinitionSchema>;

--- a/packages/cli/workspace-loader/src/__test__/fixtures/simple/generators.yml
+++ b/packages/cli/workspace-loader/src/__test__/fixtures/simple/generators.yml
@@ -1,1 +1,2 @@
-{}
+api: 
+  fern: ./definition

--- a/packages/cli/workspace-loader/src/types/Workspace.ts
+++ b/packages/cli/workspace-loader/src/types/Workspace.ts
@@ -16,7 +16,7 @@ export interface DocsWorkspace {
     config: docsYml.RawSchemas.DocsConfiguration;
 }
 
-export type Spec = OpenAPISpec | ProtobufSpec;
+export type Spec = OpenAPISpec | ProtobufSpec | FernDefinitionSpec;
 
 export interface OpenAPISpec {
     type: "openapi";
@@ -33,6 +33,11 @@ export interface ProtobufSpec {
     absoluteFilepathToOverrides: AbsoluteFilePath | undefined;
     generateLocally: boolean;
     settings?: SpecImportSettings;
+}
+
+export interface FernDefinitionSpec {
+    type: "fern";
+    absoluteFilepathToDefinitionDirectory: AbsoluteFilePath;
 }
 
 export type Source = AsyncAPISource | OpenAPISource | ProtobufSource;

--- a/packages/cli/workspace-loader/src/workspaces/OSSWorkspace.ts
+++ b/packages/cli/workspace-loader/src/workspaces/OSSWorkspace.ts
@@ -135,10 +135,16 @@ export class OSSWorkspace extends AbstractAPIWorkspace<OSSWorkspace.Settings> {
         return [
             this.absoluteFilepath,
             ...this.specs
-                .flatMap((spec) => [
-                    spec.type === "protobuf" ? spec.absoluteFilepathToProtobufTarget : spec.absoluteFilepath,
-                    spec.absoluteFilepathToOverrides
-                ])
+                .flatMap((spec) => {
+                    switch (spec.type) {
+                        case "openapi":
+                            return [spec.absoluteFilepath, spec.absoluteFilepathToOverrides];
+                        case "protobuf":
+                            return [spec.absoluteFilepathToProtobufRoot, spec.absoluteFilepathToOverrides];
+                        case "fern":
+                            return [spec.absoluteFilepathToDefinitionDirectory];
+                    }
+                })
                 .filter(isNonNullish)
         ];
     }


### PR DESCRIPTION
`generators.yml` now supports reading a path to the fern definition directory 

```
api: 
  fern: /path/to/fern/definition
```