### PR TITLE
chore(cli): stop logging upgrade to stdout when it's a fern bot command

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -157,8 +157,20 @@ async function tryRunCli(cliContext: CliContext) {
     });
 
     // CLI V2 Sanctioned Commands
-    addGetOrganizationCommand(cli, cliContext);
-    addGeneratorCommands(cli, cliContext);
+    addGetOrganizationCommand({
+        cli,
+        cliContext,
+        onRun: () => {
+            cliContext.suppressUpgradeMessage();
+        }
+    });
+    addGeneratorCommands({
+        cli,
+        cliContext,
+        onRun: () => {
+            cliContext.suppressUpgradeMessage();
+        }
+    });
 
     cli.middleware(async (argv) => {
         cliContext.setLogLevel(argv["log-level"]);

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -8,7 +8,15 @@ import { getGeneratorMetadata } from "./commands/generator-metadata/getGenerator
 import { getOrganziation } from "./commands/organization/getOrganization";
 import { upgradeGenerator } from "./commands/upgrade/upgradeGenerator";
 
-export function addGetOrganizationCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext): void {
+export function addGetOrganizationCommand({
+    cli,
+    cliContext,
+    onRun
+}: {
+    cli: Argv<GlobalCliOptions>;
+    cliContext: CliContext;
+    onRun: () => void;
+}): void {
     cli.command(
         "organization",
         // Hides the command from the help message
@@ -34,11 +42,20 @@ export function addGetOrganizationCommand(cli: Argv<GlobalCliOptions>, cliContex
                 context: cliContext,
                 outputLocation: argv.output
             });
+            onRun();
         }
     );
 }
 
-export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: CliContext): void {
+export function addGeneratorCommands({
+    cli,
+    cliContext,
+    onRun
+}: {
+    cli: Argv<GlobalCliOptions>;
+    cliContext: CliContext;
+    onRun: () => void;
+}): void {
     cli.command("generator", "Operate on the generators within your Fern configuration", (yargs) => {
         yargs
             .command(
@@ -96,6 +113,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         cliContext,
                         outputLocation: argv.output
                     });
+                    onRun();
                 }
             )
             .command(
@@ -150,6 +168,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         includeMajor: argv.includeMajor,
                         channel: argv.channel
                     });
+                    onRun();
                 }
             )
             .command(
@@ -203,10 +222,12 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         cliContext.failAndThrow(
                             `Generator ${argv.generator}, in group ${argv.group}${maybeApiFilter} was not found.`
                         );
+                        return;
                     }
                     if (argv.version) {
                         process.stdout.write(generator.version);
                     }
+                    onRun();
                 }
             );
     });

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,11 @@
 - changelog_entry:
+  - summary: Silence the upgrade message for fern-bot CLI commands, to clean stdout.
+    type: internal
+  created_at: '2024-09-02'
+  ir_version: 53
+  version: 0.40.3
+
+- changelog_entry:
   - summary: Now `fern generator upgrade` respects  the `--group` flag and only upgrades generators within a particular group.
     type: fix
   created_at: '2024-09-02'


### PR DESCRIPTION
This PR passes in the `suppressUpgradeMessage` to the fern-bot commands to stop polluting stdout
Idea here is that this log is unnecessary for these commands, and also makes reading in the stdout much more difficult, so opting to remove them