### PR TITLE
feat(cli): add generic type to types documentation

### DIFF
--- a/fern/pages/api-definition/fern-definition/types.mdx
+++ b/fern/pages/api-definition/fern-definition/types.mdx
@@ -223,7 +223,16 @@ MyGenericAppliedType:
   type: MyGenericType<SomeOtherType, number>
 ```
 
-You can now freely use this type as if it were any other type!
+You can now freely use this type as if it were any other type! The output
+type will resolve to:
+
+```yaml
+MyGenericAppliedType:
+  properties:
+    foo: SomeOtherType,
+    bar: number,
+    baz: string
+```
 
 ### Documenting types
 

--- a/fern/pages/api-definition/fern-definition/types.mdx
+++ b/fern/pages/api-definition/fern-definition/types.mdx
@@ -203,6 +203,29 @@ MyUnion:
     - integer
 ```
 
+### Generics
+
+Fern supports shallow generic objects, to minimize code duplication. Note, 
+as of now, generics only can be instantiated as type aliases. You can define a 
+generic for reuse like so:
+
+```yaml
+MyGenericType<T, U>:
+  properties:
+    foo: T,
+    bar: U,
+    baz: string
+```
+
+Now, you can instantiate generic types like:
+
+```yaml
+MyGenericAppliedType:
+  type: MyGenericType<SomeOtherType, number>
+```
+
+You can now freely use this type as if it were any other type!
+
 ### Documenting types
 
 You can add documentation for types. These docs are passed into the compiler,

--- a/fern/pages/api-definition/fern-definition/types.mdx
+++ b/fern/pages/api-definition/fern-definition/types.mdx
@@ -205,9 +205,8 @@ MyUnion:
 
 ### Generics
 
-Fern supports shallow generic objects, to minimize code duplication. Note, 
-as of now, generics only can be instantiated as type aliases. You can define a 
-generic for reuse like so:
+Fern supports shallow generic objects, to minimize code duplication. You can 
+define a generic for reuse like so:
 
 ```yaml
 MyGenericType<T, U>:
@@ -217,7 +216,7 @@ MyGenericType<T, U>:
     baz: string
 ```
 
-Now, you can instantiate generic types like:
+Now, you can instantiate generic types as a type alias:
 
 ```yaml
 MyGenericAppliedType:


### PR DESCRIPTION
Adds documentation for shallow generics, as added in https://github.com/fern-api/fern/pull/4512.