### PR TITLE
chore(cli): use new releases API for fern upgrade

### DIFF
--- a/packages/cli/cli/src/cli-context/upgrade-utils/getLatestVersionOfCli.ts
+++ b/packages/cli/cli/src/cli-context/upgrade-utils/getLatestVersionOfCli.ts
@@ -1,4 +1,4 @@
-import latestVersion from "latest-version";
+import { FernRegistry, FernRegistryClient as GeneratorsClient } from "@fern-fern/generators-sdk";
 import { CliEnvironment } from "../CliEnvironment";
 
 export async function getLatestVersionOfCli({
@@ -13,7 +13,18 @@ export async function getLatestVersionOfCli({
     if (cliEnvironment.packageVersion === "0.0.0") {
         return cliEnvironment.packageVersion;
     }
-    return latestVersion(cliEnvironment.packageName, {
-        version: includePreReleases ? "prerelease" : "latest"
+    const client = new GeneratorsClient({
+        environment: process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com"
     });
+
+    const latestReleaseResponse = await client.generators.cli.getLatestCliRelease({
+        releaseTypes: [
+            includePreReleases ? FernRegistry.generators.ReleaseType.Rc : FernRegistry.generators.ReleaseType.Ga
+        ]
+    });
+
+    if (latestReleaseResponse.ok) {
+        return latestReleaseResponse.body.version;
+    }
+    throw new Error(`Failed to get latest version of CLI: ${JSON.stringify(latestReleaseResponse.error)}`);
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -35,7 +35,6 @@ import { testOutput } from "./commands/test/testOutput";
 import { generateToken } from "./commands/token/token";
 import { updateApiSpec } from "./commands/upgrade/updateApiSpec";
 import { upgrade } from "./commands/upgrade/upgrade";
-import { upgradeGenerator } from "./commands/upgrade/upgradeGenerator";
 import { validateWorkspaces } from "./commands/validate/validateWorkspaces";
 import { writeDefinitionForWorkspaces } from "./commands/write-definition/writeDefinitionForWorkspaces";
 import { FERN_CWD_ENV_VAR } from "./cwd";

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 - changelogEntry:
   - summary: |
+      `fern upgrade` command now leverages new releases API, tracking pulled versions, and additional release channels.
+    type: internal
+  irVersion: 53
+  version: 0.42.0
+
+- changelogEntry:
+  - summary: |
       The Fern generators.yml configuration now supports a new format for namespacing APIs for additional flexibility:
 
       ```yml


### PR DESCRIPTION
Fixes FER-3203

<!-- begin-generated-description -->

This pull request introduces changes to the `fern upgrade` command, leveraging the new releases API to track pulled versions and additional release channels.

## Summary
The `fern upgrade` command has been updated to use the new releases API, which provides additional functionality for tracking pulled versions and release channels. This change is reflected in the `changelogEntry` in `versions.yml`, which now includes a summary of the new features.

The implementation of this new functionality involves importing the `FernRegistry` and `FernRegistryClient` from `@fern-fern/generators-sdk` and using them to fetch the latest CLI release information. The code then checks if the latest release is available and, if so, returns the latest version. If the latest release is not available, an error is thrown.

## Changes
- **New imports**: The `FernRegistry` and `FernRegistryClient` are imported from `@fern-fern/generators-sdk` in `getLatestVersionOfCli.ts`.
- **Updated `getLatestVersionOfCli` function**: The function now uses the `FernRegistryClient` to fetch the latest CLI release information, check its availability, and return the latest version or throw an error.
- **Removed `upgradeGenerator` import**: The `upgradeGenerator` import is no longer needed and has been removed from `cli.ts`.
- **Modified `upgrade` function**: The `upgrade` function in `upgrade.ts` has been updated to use the new releases API. It now includes a check for the previous version and runs migrations accordingly.
- **Updated `changelogEntry`**: The `changelogEntry` in `versions.yml` has been updated to reflect the changes in the `fern upgrade` command, including the new features and the version number.

<!-- end-generated-description -->
