### PR TITLE
feat(cli): introduce request encoding to fern definition

### DIFF
--- a/packages/cli/fern-definition/schema/src/schemas/HttpInlineRequestBodySchema.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/HttpInlineRequestBodySchema.ts
@@ -2,15 +2,18 @@ import { z } from "zod";
 import { ObjectExtendsSchema } from "./ObjectExtendsSchema";
 import { ObjectPropertySchema } from "./ObjectPropertySchema";
 import { HttpInlineRequestBodyPropertySchema } from "./HttpInlineRequestBodyPropertySchema";
+import { HttpInlineRequestEncoding } from "./HttpInlineRequestEncoding";
 
 // for inline request schemas, you need either extends/properties (or both).
 export const HttpInlineRequestBodySchema = z.union([
     z.strictObject({
+        encoding: z.optional(HttpInlineRequestEncoding),
         extends: ObjectExtendsSchema,
         properties: z.optional(z.record(HttpInlineRequestBodyPropertySchema)),
         ["extra-properties"]: z.optional(z.boolean())
     }),
     z.strictObject({
+        encoding: z.optional(HttpInlineRequestEncoding),
         extends: z.optional(ObjectExtendsSchema),
         properties: z.record(HttpInlineRequestBodyPropertySchema),
         ["extra-properties"]: z.optional(z.boolean())

--- a/packages/cli/fern-definition/schema/src/schemas/HttpInlineRequestEncoding.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/HttpInlineRequestEncoding.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const HttpInlineRequestEncoding = z.enum([
+    "json",
+    "multipart",
+    "url"
+    // TODO(dsinghvi): should we add proto here?
+]);
+
+export type HttpInlineRequestEncoding = z.infer<typeof HttpInlineRequestEncoding>;

--- a/packages/cli/fern-definition/schema/src/schemas/index.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/index.ts
@@ -22,6 +22,7 @@ export { ErrorDiscriminationSchema } from "./ErrorDiscriminationSchema";
 export { ErrorReferenceSchema } from "./ErrorReferenceSchema";
 export { ExampleCodeSampleSchema, SupportedSdkLanguageSchema } from "./ExampleCodeSampleSchema";
 export { ExampleEndpointCallArraySchema, ExampleEndpointCallSchema } from "./ExampleEndpointCallSchema";
+export { HttpInlineRequestEncoding } from "./HttpInlineRequestEncoding";
 export {
     ExampleBodyResponseSchema,
     ExampleResponseSchema,


### PR DESCRIPTION
## Summary

This PR introduces an `encoding` field to inlined request bodies. The encoding field will help us encode whether the data is being sent as `json`, `multipart` or `url-encoded`. 

## Details

By default, if there is no encoding, then we will assume `json`

```yml
request: 
  body: 
    # encoding: json  json is assumed
    properties: 
      foo: string
      bar: Bar
```

If any of the inlined body properties have a `file` keyword, then we assume `multipart` encoding

```yml
request: 
  body: 
    # encoding: multipart  multipart is assumed
    properties: 
      foo: string
      bar: file
```

If the user wants to specify url encoding, then they need to explicitly note it down

```yml
request: 
  body: 
    encoding: url
    properties: 
      foo: string
```