### PR TITLE
feat(cli): allow fern to push generated code to a sub directory

### DIFF
--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -86,6 +86,9 @@ types:
       repository: string
       license: optional<license.GithubLicenseSchema>
       mode: optional<GithubCommitAndReleaseMode>
+      path:
+        type: optional<string>
+        docs: The relative path in the GitHub repository where the generated code should be committed
       # Add properties for commit and release configuration
   
   GithubCommitAndReleaseMode:
@@ -100,6 +103,9 @@ types:
       license: optional<license.GithubLicenseSchema>
       mode: literal<"pull-request">
       reviewers: optional<reviewers.ReviewersSchema>
+      path:
+        type: optional<string>
+        docs: The relative path in the GitHub repository where the generated code should be committed
       # Add properties for pull request configuration
 
   GithubPushSchema:
@@ -108,6 +114,9 @@ types:
       license: optional<license.GithubLicenseSchema>
       mode: literal<"push">
       branch: optional<string>
+      path:
+        type: optional<string>
+        docs: The relative path in the GitHub repository where the generated code should be committed
       # Add properties for push configuration
   
   NpmOutputLocationSchema:

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -76,7 +76,7 @@
     "@fern-api/task-context": "workspace:*",
     "@fern-api/venus-api-sdk": "0.10.2",
     "@fern-api/workspace-loader": "workspace:*",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "@fern-fern/generators-sdk": "0.114.0-5745f9e74",
     "@fern-typescript/fetcher": "workspace:*",
     "@inquirer/prompts": "^7.1.0",

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,21 @@
 - changelogEntry:
     - summary: |
+        Added support for specifying a subdirectory path in GitHub repositories via the `path` 
+        key under `github` configuration in generators.yml. This allows generating SDKs into specific subdirectories:
+
+        ```yml
+        generators:
+          - name: fernapi/fern-typescript-sdk
+            github:
+              repository: owner/repo
+              path: packages/typescript # SDK will be generated in this subdirectory
+        ```
+      type: feat
+  irVersion: 55
+  version: 0.51.3
+
+- changelogEntry:
+    - summary: |
         Improved error messages when docs.yml doesn't match schema by showing more specific 
         validation errors and including the path where the error occurred.
       type: fix

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -33,7 +33,7 @@
     "@fern-api/task-context": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-fern/fdr-cjs-sdk": "0.127.5-72dd47f6f",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "@fern-fern/generators-sdk": "0.114.0-5745f9e74",
     "find-up": "^6.3.0",
     "js-yaml": "^4.1.0",

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -545,6 +545,7 @@ async function convertOutputMode({
                   })
                 : undefined;
         const mode = generator.github.mode ?? "release";
+        const path = generator.github.path;
         switch (mode) {
             case "commit":
             case "release":
@@ -554,7 +555,8 @@ async function convertOutputMode({
                         repo,
                         license,
                         publishInfo,
-                        downloadSnippets
+                        downloadSnippets,
+                        directory: path
                     })
                 );
             case "pull-request": {
@@ -570,7 +572,8 @@ async function convertOutputMode({
                         license,
                         publishInfo,
                         downloadSnippets,
-                        reviewers
+                        reviewers,
+                        directory: path
                     })
                 );
             }
@@ -582,7 +585,8 @@ async function convertOutputMode({
                         branch: generator.github.mode === "push" ? generator.github.branch : undefined,
                         license,
                         publishInfo,
-                        downloadSnippets
+                        downloadSnippets,
+                        directory: path
                     })
                 );
             default:

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -31,7 +31,7 @@
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-fern/fdr-cjs-sdk": "0.127.5-72dd47f6f",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "zod": "^3.22.3"
   },
   "devDependencies": {

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubCommitAndReleaseSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubCommitAndReleaseSchema.ts
@@ -8,4 +8,6 @@ export interface GithubCommitAndReleaseSchema {
     repository: string;
     license?: FernDefinition.GithubLicenseSchema;
     mode?: FernDefinition.GithubCommitAndReleaseMode;
+    /** The relative path in the GitHub repository where the generated code should be committed */
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPullRequestSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPullRequestSchema.ts
@@ -10,4 +10,6 @@ export interface GithubPullRequestSchema {
     license?: FernDefinition.GithubLicenseSchema;
     mode: "pull-request";
     reviewers?: FernDefinition.ReviewersSchema;
+    /** The relative path in the GitHub repository where the generated code should be committed */
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPushSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPushSchema.ts
@@ -9,4 +9,6 @@ export interface GithubPushSchema {
     license?: FernDefinition.GithubLicenseSchema;
     mode: "push";
     branch?: string;
+    /** The relative path in the GitHub repository where the generated code should be committed */
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubCommitAndReleaseSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubCommitAndReleaseSchema.ts
@@ -15,6 +15,7 @@ export const GithubCommitAndReleaseSchema: core.serialization.ObjectSchema<
     repository: core.serialization.string(),
     license: GithubLicenseSchema.optional(),
     mode: GithubCommitAndReleaseMode.optional(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubCommitAndReleaseSchema {
@@ -22,5 +23,6 @@ export declare namespace GithubCommitAndReleaseSchema {
         repository: string;
         license?: GithubLicenseSchema.Raw | null;
         mode?: GithubCommitAndReleaseMode.Raw | null;
+        path?: string | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPullRequestSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPullRequestSchema.ts
@@ -17,6 +17,7 @@ export const GithubPullRequestSchema: core.serialization.ObjectSchema<
     license: GithubLicenseSchema.optional(),
     mode: core.serialization.stringLiteral("pull-request"),
     reviewers: ReviewersSchema.optional(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubPullRequestSchema {
@@ -26,5 +27,6 @@ export declare namespace GithubPullRequestSchema {
         license?: GithubLicenseSchema.Raw | null;
         mode: "pull-request";
         reviewers?: ReviewersSchema.Raw | null;
+        path?: string | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPushSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPushSchema.ts
@@ -15,6 +15,7 @@ export const GithubPushSchema: core.serialization.ObjectSchema<
     license: GithubLicenseSchema.optional(),
     mode: core.serialization.stringLiteral("push"),
     branch: core.serialization.string().optional(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubPushSchema {
@@ -23,5 +24,6 @@ export declare namespace GithubPushSchema {
         license?: GithubLicenseSchema.Raw | null;
         mode: "push";
         branch?: string | null;
+        path?: string | null;
     }
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -42,7 +42,7 @@
     "@fern-api/task-context": "workspace:*",
     "@fern-api/typescript-dynamic-snippets": "workspace:*",
     "@fern-api/workspace-loader": "workspace:*",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "@fern-fern/generator-exec-sdk": "^0.0.898",
     "chalk": "^5.3.0",
     "decompress": "^4.2.1",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -43,7 +43,7 @@
     "@fern-api/register": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "@fern-api/workspace-loader": "workspace:*",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "axios": "^1.7.7",
     "chalk": "^5.3.0",
     "decompress": "^4.2.1",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -41,7 +41,7 @@
     "@fern-api/openapi-ir-parser": "workspace:*",
     "@fern-api/semver-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "@redocly/openapi-core": "^1.4.1",
     "@types/uuid": "^9.0.8",
     "axios": "^1.7.7",

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -49,7 +49,7 @@
     "typescript": "5.7.2",
     "vitest": "^2.1.8",
     "@fern-api/workspace-loader": "workspace:*",
-    "@fern-fern/fiddle-sdk": "0.0.584",
+    "@fern-fern/fiddle-sdk": "0.0.610",
     "@fern-fern/generator-exec-sdk": "^0.0.898",
     "@fern-fern/generators-sdk": "0.114.0-5745f9e74",
     "@types/find-up": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4345,8 +4345,8 @@ importers:
         specifier: workspace:*
         version: link:../workspace/loader
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       '@fern-fern/generators-sdk':
         specifier: 0.114.0-5745f9e74
         version: 0.114.0-5745f9e74
@@ -4645,8 +4645,8 @@ importers:
         specifier: 0.127.5-72dd47f6f
         version: 0.127.5-72dd47f6f
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       zod:
         specifier: ^3.22.3
         version: 3.23.8
@@ -4700,8 +4700,8 @@ importers:
         specifier: 0.127.5-72dd47f6f
         version: 0.127.5-72dd47f6f
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       '@fern-fern/generators-sdk':
         specifier: 0.114.0-5745f9e74
         version: 0.114.0-5745f9e74
@@ -5996,8 +5996,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.898
         version: 0.0.898
@@ -6108,8 +6108,8 @@ importers:
         specifier: 0.127.5-72dd47f6f
         version: 0.127.5-72dd47f6f
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -6883,8 +6883,8 @@ importers:
         specifier: workspace:*
         version: link:../../task-context
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       '@redocly/openapi-core':
         specifier: ^1.4.1
         version: 1.4.1
@@ -7684,8 +7684,8 @@ importers:
         specifier: workspace:*
         version: link:../cli/workspace/loader
       '@fern-fern/fiddle-sdk':
-        specifier: 0.0.584
-        version: 0.0.584
+        specifier: 0.0.610
+        version: 0.0.610
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.898
         version: 0.0.898
@@ -8881,6 +8881,9 @@ packages:
 
   '@fern-fern/fiddle-sdk@0.0.584':
     resolution: {integrity: sha512-92z/Pwo7EDV7PCLwNdxtZiTQpaUpbeXCqKWSLUQwTwFAQEAp+8QKYAA6VJXVQtHLrZg0NqPTXEnE5XF8NbluYA==}
+
+  '@fern-fern/fiddle-sdk@0.0.610':
+    resolution: {integrity: sha512-qnp0Lu3tbwIGjZkB4fRatsdPF8sBvW8YZd1mOI7dnS248DZPJrc3Yen8F+yt1qN1RnfcjGflz3hnZ9abZ0NG+w==}
 
   '@fern-fern/generator-cli-sdk@0.0.17':
     resolution: {integrity: sha512-uu+Oi9b2KrFo3tj5vqmEShi9CH3FKqNboDtm+3wYO8Z1LAuqo9wZIsxew8EI/bpxc9Xi6gpHi7CLKweKPxjz/Q==}
@@ -16359,6 +16362,16 @@ snapshots:
       - encoding
 
   '@fern-fern/fiddle-sdk@0.0.584':
+    dependencies:
+      form-data: 4.0.0
+      js-base64: 3.7.2
+      node-fetch: 2.7.0
+      qs: 6.11.2
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@fern-fern/fiddle-sdk@0.0.610':
     dependencies:
       form-data: 4.0.0
       js-base64: 3.7.2


### PR DESCRIPTION
## Description
  Added support for specifying a subdirectory path in GitHub repositories via the `path` 
  key under `github` configuration in generators.yml. This allows generating SDKs into specific subdirectories:

  ```yml
  generators:
    - name: fernapi/fern-typescript-sdk
      github:
        repository: owner/repo
        path: packages/typescript # SDK will be generated in this subdirectory
  ```

## Changes Made
- Upgraded fiddle SDK
- Introduced a new `path` key in generators.yml

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

