### PR TITLE
fix(cli): handle windows filepaths when replacing referenced mdx

### DIFF
--- a/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
@@ -1,6 +1,7 @@
 import { readFile } from "fs/promises";
+import path from "path";
 
-import { AbsoluteFilePath, RelativeFilePath, dirname, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, dirname, resolve } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 
 async function defaultFileLoader(filepath: AbsoluteFilePath): Promise<string> {
@@ -45,8 +46,8 @@ export async function replaceReferencedCode({
         }
 
         const filepath = resolve(
-            src.startsWith("/") ? absolutePathToFernFolder : dirname(absolutePathToMarkdownFile),
-            RelativeFilePath.of(src.replace(/^\//, ""))
+            path.isAbsolute(src) ? absolutePathToFernFolder : dirname(absolutePathToMarkdownFile),
+            path.normalize(src)
         );
 
         try {

--- a/packages/cli/docs-markdown-utils/src/replaceReferencedMarkdown.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedMarkdown.ts
@@ -1,7 +1,8 @@
 import { readFile } from "fs/promises";
 import grayMatter from "gray-matter";
+import path from "path";
 
-import { AbsoluteFilePath, RelativeFilePath, dirname, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, dirname, resolve } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 
 async function defaultMarkdownLoader(filepath: AbsoluteFilePath) {
@@ -45,8 +46,8 @@ export async function replaceReferencedMarkdown({
         }
 
         const filepath = resolve(
-            src.startsWith("/") ? absolutePathToFernFolder : dirname(absolutePathToMarkdownFile),
-            RelativeFilePath.of(src.replace(/^\//, ""))
+            path.isAbsolute(src) ? absolutePathToFernFolder : dirname(absolutePathToMarkdownFile),
+            path.normalize(src)
         );
 
         try {


### PR DESCRIPTION
## Description
Updates code in `replaceReferencedCode.ts` and `replaceReferencedMarkdown.ts` to be compatible with windows and mac. 

## Changes Made
- Use cross platform `path` utilities instead of trying to do regex based operations for filepaths 

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

