### PR TITLE
fix(docs): Update customize-api-explorer.mdx to accurately reflext playground config

### DIFF
--- a/fern/pages/docs/api-references/customize-api-explorer.mdx
+++ b/fern/pages/docs/api-references/customize-api-explorer.mdx
@@ -15,7 +15,7 @@ To filter server URLs, add the `environments` property to the `PlaygroundSetting
 
 ```yaml
 navigation:
-  api:
+  - api:
     playground: 
       environments:
         - Staging-A
@@ -31,7 +31,7 @@ To enable OAuth 2.0 Authorization Injection, simply add the `oauth` feature flag
 
 ```yaml
 navigation:
-  api: 
+  - api: 
     playground:
       oauth: true
 ``` 


### PR DESCRIPTION
This page should now be accurate regarding indentation and dashes
