### PR TITLE
fix(cli): add replace call for rid when used as key of a map when parsing conjure specs

### DIFF
--- a/packages/cli/api-importers/conjure/conjure-to-fern/src/utils/listConjureFiles.ts
+++ b/packages/cli/api-importers/conjure/conjure-to-fern/src/utils/listConjureFiles.ts
@@ -37,6 +37,7 @@ async function createConjureFile({
         .replaceAll(/: rid(?:$|\s)/g, ": string\n")
         .replaceAll("<rid>", "<string>")
         .replaceAll("rid>", "string>")
+        .replaceAll("<rid", "<string")
         .replaceAll(": safelong", ": long")
         .replaceAll("<safelong>", "<long>")
         .replaceAll("safelong>", "long>")

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 - changelogEntry:
   - summary: |
+      Fix conjure spec parsing to convert map<rid, ...> to map<string, ...> when generating documentation.
+
+    type: fix
+  irVersion: 57
+  version: 0.57.8
+
+- changelogEntry:
+  - summary: |
       Add support for `anyOf` in the new OpenAPI parser. This allows for undiscriminated unions in the OpenAPI schema, where a type can be one of several possible types without a discriminator field. The parser now handles both `oneOf` and `anyOf` schemas in the same way, converting them to undiscriminated unions in the IR.
         
     type: fix


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->

Simple fix for https://github.com/fern-api/fern/issues/6559.

Essentially, if you mention `map<rid, ...>` (rid as key type for a map), fern fails to parse the conjure spec.
This is solved for all other permutations for `rid` by using regex to replace `rid` with `string`, however, fails to account for the edge case of using a map. This PR adds in an additional case to fix this.