### PR TITLE
feat(python): TypeReference supports discriminatedUnion and undiscriminatedUnion fields

### DIFF
--- a/generators/python/pyproject.toml
+++ b/generators/python/pyproject.toml
@@ -13,7 +13,7 @@ ordered-set = "^4.1.0"
 pydantic-core = "^2.18.2"
 fern-fern-fdr-sdk = { version = "0.98.20", source = "fern-prod" }
 fern-fern-generator-cli-sdk = { version = "0.0.18", source = "fern-prod" }
-fern_fern_ir_v57 = "57.0.0"
+fern_fern_ir_v57 = "57.2.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- 
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed

