### PR TITLE
feat(internal): remove posthog from docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -688,6 +688,7 @@ layout:
 analytics:
   posthog:
     api-key: ${POSTHOG_API_KEY}
+    endpoint: https://buildwithfern.com/learn/api/fern-docs/analytics/posthog
   gtm:
     container-id: GTM-55W3VNDW
 


### PR DESCRIPTION
## Description

We already have a reverse proxy set up (via middleware), so this instructs posthog to go through the reverse proxy.

without the reverse proxy, browsers will often block posthog requests

![image](https://github.com/user-attachments/assets/13b2df00-653e-4260-8ff1-264d9f5b9ec0)

## Changes Made

Add posthog `endpoint` to docs.yml