### PR TITLE
Fix: 404 on `Access via API` Snippets API link

### DIFF
--- a/fern/pages/docs/api-references/sdk-snippets.mdx
+++ b/fern/pages/docs/api-references/sdk-snippets.mdx
@@ -104,7 +104,7 @@ navigation:
 
 ## Access via API
 
-If you'd like to bring SDK snippets into your own documentation, you can use the [Snippets API](/learn/cli-api/api-reference/snippets/get). API access requires a [SDK Business plan](https://buildwithfern.com/pricing) or above.
+If you'd like to bring SDK snippets into your own documentation, you can use the [Snippets API](/learn/api-reference/snippets/get). API access requires a [SDK Business plan](https://buildwithfern.com/pricing) or above.
 
 Merge.dev is an example of a Fern customer that uses the Snippets API to bring Python code samples [into their API Reference](https://docs.merge.dev/hris/employees/#employees_list).
 


### PR DESCRIPTION
## Description
The Snippets API link in https://buildwithfern.com/learn/docs/api-references/sdk-snippets#access-via-api was leading to a 404 not found page (https://buildwithfern.com/learn/cli-reference/api-reference/snippets/get)

<img width="805" alt="Screenshot 2025-05-05 at 11 08 21" src="https://github.com/user-attachments/assets/61a14ffe-e187-4851-8a6b-c682292dab9f" />


## Changes Made
- Updated link to https://buildwithfern.com/learn/api-reference/snippets/get 

