### PR TITLE
chore(python): IR uses Pydantic generator v1.4.7 and version=both

### DIFF
--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -49,7 +49,7 @@ groups:
   python:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.4.2
+        version: 1.4.7
         output:
           location: pypi
           url: pypi.buildwithfern.com
@@ -58,7 +58,7 @@ groups:
           # wrapped_aliases: true
           include_union_utils: true
           frozen: true
-          version: v2
+          version: both
           enum_type: python_enums
   go:
     generators:


### PR DESCRIPTION
## Description
Update the generated Fern IR package to use the v1.4.7 (latest published) version of the Pydantic generator. Additionally, modify the value of the `version` flag when generating the Fern IR from `v2` to `both` to work around an issue documented in https://github.com/fern-api/fern/pull/7123.

## Testing
* [x] `mypy` no longer encounters the `INTERNAL ERROR` when using a development build of the new Fern IR package at https://github.com/fern-api/fern/pull/7135.