### PR TITLE
fix(python): Pydantic V2 models extend UniversalRootModel, not pydantic.RootModel

### DIFF
--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,4 +1,14 @@
 # For unreleased changes, use unreleased.yml
+- version: 1.7.0
+  irVersion: 57
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add support for generating proper Pydantic models that contain forward references wrapped in containers (e.g. list, optional, etc.)
+    - type: fix
+      summary: |
+        Pydantic V2 models extend `UniversalRootModel` and not `pydantic.BaseModel` in order to silence mypy warnings.
+
 - version: 1.6.4
   irVersion: 57
   changelogEntry:

--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,4 +1,16 @@
 # For unreleased changes, use unreleased.yml
+- version: 1.5.0
+  irVersion: 57
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add support for generating proper Pydantic models that contain forward references wrapped in containers (e.g. list, optional, etc.)
+    - type: fix
+      summary: |
+        Pydantic V2 models extend `UniversalRootModel` and not `pydantic.BaseModel` in order to silence mypy warnings.
+  createdAt: '2025-05-13'
+  irVersion: 57
+
 - version: 1.4.8
   irVersion: 57
   changelogEntry:

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,4 +1,13 @@
 # For unreleased changes, use unreleased.yml
+- version: 4.20.3
+  irVersion: 57
+  changelogEntry:
+    - type: fix
+      summary: |
+        Pydantic V2 models extend `UniversalRootModel` and not `pydantic.BaseModel` in order to silence mypy warnings.
+  createdAt: '2025-05-15'
+  irVersion: 57
+
 - version: 4.20.2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/external_dependencies/pydantic.py
+++ b/generators/python/src/fern_python/external_dependencies/pydantic.py
@@ -70,9 +70,6 @@ class Pydantic:
     def PrivateAttr(self) -> AST.ClassReference:
         return _export(self.version_compatibility, "PrivateAttr")
 
-    def RootModel(self) -> AST.ClassReference:
-        return _export(self.version_compatibility, "RootModel")
-
     def validator(self, pre: bool = False) -> AST.Expression:
         if self.version_compatibility == PydanticVersionCompatibility.V2:
             return AST.Expression(f'validator("*", pre={str(pre).lower()})')

--- a/generators/python/src/fern_python/generators/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/core_utilities/core_utilities.py
@@ -259,14 +259,15 @@ class CoreUtilities:
         )
 
     def get_universal_root_model(self) -> AST.ClassReference:
-        if self._pydantic_compatibility == PydanticVersionCompatibility.Both:
+        if (
+            self._pydantic_compatibility == PydanticVersionCompatibility.Both
+            or self._pydantic_compatibility == PydanticVersionCompatibility.V2
+        ):
             return AST.ClassReference(
                 qualified_name_excluding_import=(),
                 import_=AST.ReferenceImport(
                     module=AST.Module.local(*self._module_path, "pydantic_utilities"), named_import="UniversalRootModel"
                 ),
             )
-        elif self._pydantic_compatibility == PydanticVersionCompatibility.V2:
-            return Pydantic(self._pydantic_compatibility).RootModel()
         else:  # V1 or V1_ON_V2
             return Pydantic(self._pydantic_compatibility).BaseModel()

--- a/seed/fastapi/exhaustive/pydantic-v2/resources/types/resources/union/types/animal.py
+++ b/seed/fastapi/exhaustive/pydantic-v2/resources/types/resources/union/types/animal.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ......core.pydantic_utilities import update_forward_refs
+from ......core.pydantic_utilities import UniversalRootModel, update_forward_refs
 from .cat import Cat as resources_types_resources_union_types_cat_Cat
 from .dog import Dog as resources_types_resources_union_types_dog_Dog
 
@@ -21,7 +21,7 @@ class _Factory:
         return Animal(root=_Animal.Cat(**value.dict(exclude_unset=True), animal="cat"))  # type: ignore
 
 
-class Animal(pydantic.RootModel):
+class Animal(UniversalRootModel):
     factory: typing.ClassVar[_Factory] = _Factory()
 
     root: typing_extensions.Annotated[typing.Union[_Animal.Dog, _Animal.Cat], pydantic.Field(discriminator="animal")]


### PR DESCRIPTION
## Description
Modify the Python generators such that Pydantic models that are generated to extend `pydantic.RootModel` are generated to instead extend `UniversalRootModel` when using Pydantic V2.

This is done because extending `pydantic.RootModel` without providing generic type arguments results in the following mypy error.
```
error: Missing type parameters for generic type "RootModel"  [type-arg]
```

Note that [`UniversalRootModel`](https://github.com/fern-api/fern/blob/fee0e56a169974fdae494edc481ac82a4b8b65db/generators/python/core_utilities/shared/pydantic_utilities.py#L180-L187) already [has these type-ignores defined](https://github.com/fern-api/fern/blob/fee0e56a169974fdae494edc481ac82a4b8b65db/generators/python/core_utilities/shared/pydantic_utilities.py#L182), and also already [handles V2 gating logic](https://github.com/fern-api/fern/blob/fee0e56a169974fdae494edc481ac82a4b8b65db/generators/python/core_utilities/shared/pydantic_utilities.py#L180-L187).

Release these fixes in new versions of the FastAPI, Pydantic, and SDK generators for Python.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Remove support for directly generating `pydantic.RootModel`, and replace it with generating `UniversalRootModel`.
- Release minor versions of the FastAPI and Pydantic generators that includes this fix along with a previous feature.
- Release patch version of the Python SDK generator that includes this fix.