### PR TITLE
chore(docs): fix dead links to api/snippets/get

### DIFF
--- a/fern/pages/docs/api-references/generate-api-ref.mdx
+++ b/fern/pages/docs/api-references/generate-api-ref.mdx
@@ -22,7 +22,7 @@ navigation:
 | `api-name`       | Name of the API we are referencing, if there are [multiple APIs](#include-more-than-one-api-reference)  |
 | `audiences`      | List of [audiences](/learn/api-definition/fern/audiences) to filter the API Reference for               |
 | `display-errors` | Displays error schemas in the API References                                                            |
-| `snippets`       | Enable [generated SDK code snippets](/learn/cli-api/api-reference/snippets/get) in your API Reference            |
+| `snippets`       | Enable [generated SDK code snippets](/learn/api-reference/snippets/get) in your API Reference           |
 | `summary`        | Relative path to the Markdown file; the summary is displayed at the top of the API section              |
 | `layout`         | Customize the order that your API endpoints are displayed in the docs site                              |
 | `icon`           | Icon to display next to the API section in the navigation                                               |

--- a/fern/pages/docs/api-references/sdk-snippets.mdx
+++ b/fern/pages/docs/api-references/sdk-snippets.mdx
@@ -104,7 +104,7 @@ navigation:
 
 ## Access via API
 
-If you'd like to bring SDK snippets into your own documentation, you can use the [Snippets API](/learn/cli-api/api-reference/snippets/get). API access requires a [SDK Business plan](https://buildwithfern.com/pricing) or above.
+If you'd like to bring SDK snippets into your own documentation, you can use the [Snippets API](/learn/api-reference/snippets/get). API access requires a [SDK Business plan](https://buildwithfern.com/pricing) or above.
 
 Merge.dev is an example of a Fern customer that uses the Snippets API to bring Python code samples [into their API Reference](https://docs.merge.dev/hris/employees/#employees_list).
 


### PR DESCRIPTION
## Description
two links to the API reference of "get snippets" were broken. this PR fixes them.
