### PR TITLE
feat(cli): enhance markdown processing with snippet detection and add tests

### DIFF
--- a/packages/cli/docs-preview/src/__test__/snippetDetection.test.ts
+++ b/packages/cli/docs-preview/src/__test__/snippetDetection.test.ts
@@ -1,7 +1,7 @@
-import { relative } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, relative } from "@fern-api/fs-utils";
 
 // Test just the snippet detection logic (extracted from our fix)
-function detectSnippetFiles(editedAbsoluteFilepaths: string[], docsWorkspaceAbsolutePath: string): boolean {
+function detectSnippetFiles(editedAbsoluteFilepaths: AbsoluteFilePath[], docsWorkspaceAbsolutePath: AbsoluteFilePath): boolean {
     return editedAbsoluteFilepaths.some((filepath) => {
         const relativePath = relative(docsWorkspaceAbsolutePath, filepath);
         return relativePath.startsWith("snippets/") || relativePath.includes("/snippets/");
@@ -9,40 +9,49 @@ function detectSnippetFiles(editedAbsoluteFilepaths: string[], docsWorkspaceAbso
 }
 
 describe("Snippet Detection Logic", () => {
-    const docsWorkspacePath = "/mock/fern";
+    const docsWorkspacePath = AbsoluteFilePath.of("/mock/fern");
 
     it("should detect snippet files in root snippets directory", () => {
-        const editedFiles = ["/mock/fern/snippets/test-snippet.mdx"];
+        const editedFiles = [AbsoluteFilePath.of("/mock/fern/snippets/test-snippet.mdx")];
         const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
         expect(result).toBe(true);
     });
 
     it("should detect snippet files in nested snippets directory", () => {
-        const editedFiles = ["/mock/fern/docs/snippets/nested/test-snippet.mdx"];
+        const editedFiles = [AbsoluteFilePath.of("/mock/fern/docs/snippets/nested/test-snippet.mdx")];
         const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
         expect(result).toBe(true);
     });
 
     it("should not detect non-snippet files", () => {
-        const editedFiles = ["/mock/fern/pages/some-page.mdx"];
+        const editedFiles = [AbsoluteFilePath.of("/mock/fern/pages/some-page.mdx")];
         const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
         expect(result).toBe(false);
     });
 
     it("should detect snippet files in mixed file list", () => {
-        const editedFiles = ["/mock/fern/pages/some-page.mdx", "/mock/fern/snippets/test-snippet.mdx"];
+        const editedFiles = [
+            AbsoluteFilePath.of("/mock/fern/pages/some-page.mdx"),
+            AbsoluteFilePath.of("/mock/fern/snippets/test-snippet.mdx")
+        ];
         const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
         expect(result).toBe(true);
     });
 
     it("should not detect when no snippet files in mixed list", () => {
-        const editedFiles = ["/mock/fern/pages/some-page.mdx", "/mock/fern/content/another-page.mdx"];
+        const editedFiles = [
+            AbsoluteFilePath.of("/mock/fern/pages/some-page.mdx"),
+            AbsoluteFilePath.of("/mock/fern/content/another-page.mdx")
+        ];
         const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
         expect(result).toBe(false);
     });
 
     it("should handle multiple snippet files", () => {
-        const editedFiles = ["/mock/fern/snippets/snippet1.mdx", "/mock/fern/docs/snippets/snippet2.mdx"];
+        const editedFiles = [
+            AbsoluteFilePath.of("/mock/fern/snippets/snippet1.mdx"),
+            AbsoluteFilePath.of("/mock/fern/docs/snippets/snippet2.mdx")
+        ];
         const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
         expect(result).toBe(true);
     });

--- a/packages/cli/docs-preview/src/__test__/snippetDetection.test.ts
+++ b/packages/cli/docs-preview/src/__test__/snippetDetection.test.ts
@@ -1,7 +1,10 @@
 import { AbsoluteFilePath, relative } from "@fern-api/fs-utils";
 
 // Test just the snippet detection logic (extracted from our fix)
-function detectSnippetFiles(editedAbsoluteFilepaths: AbsoluteFilePath[], docsWorkspaceAbsolutePath: AbsoluteFilePath): boolean {
+function detectSnippetFiles(
+    editedAbsoluteFilepaths: AbsoluteFilePath[],
+    docsWorkspaceAbsolutePath: AbsoluteFilePath
+): boolean {
     return editedAbsoluteFilepaths.some((filepath) => {
         const relativePath = relative(docsWorkspaceAbsolutePath, filepath);
         return relativePath.startsWith("snippets/") || relativePath.includes("/snippets/");

--- a/packages/cli/docs-preview/src/__test__/snippetDetection.test.ts
+++ b/packages/cli/docs-preview/src/__test__/snippetDetection.test.ts
@@ -1,0 +1,49 @@
+import { relative } from "@fern-api/fs-utils";
+
+// Test just the snippet detection logic (extracted from our fix)
+function detectSnippetFiles(editedAbsoluteFilepaths: string[], docsWorkspaceAbsolutePath: string): boolean {
+    return editedAbsoluteFilepaths.some((filepath) => {
+        const relativePath = relative(docsWorkspaceAbsolutePath, filepath);
+        return relativePath.startsWith("snippets/") || relativePath.includes("/snippets/");
+    });
+}
+
+describe("Snippet Detection Logic", () => {
+    const docsWorkspacePath = "/mock/fern";
+
+    it("should detect snippet files in root snippets directory", () => {
+        const editedFiles = ["/mock/fern/snippets/test-snippet.mdx"];
+        const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
+        expect(result).toBe(true);
+    });
+
+    it("should detect snippet files in nested snippets directory", () => {
+        const editedFiles = ["/mock/fern/docs/snippets/nested/test-snippet.mdx"];
+        const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
+        expect(result).toBe(true);
+    });
+
+    it("should not detect non-snippet files", () => {
+        const editedFiles = ["/mock/fern/pages/some-page.mdx"];
+        const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
+        expect(result).toBe(false);
+    });
+
+    it("should detect snippet files in mixed file list", () => {
+        const editedFiles = ["/mock/fern/pages/some-page.mdx", "/mock/fern/snippets/test-snippet.mdx"];
+        const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
+        expect(result).toBe(true);
+    });
+
+    it("should not detect when no snippet files in mixed list", () => {
+        const editedFiles = ["/mock/fern/pages/some-page.mdx", "/mock/fern/content/another-page.mdx"];
+        const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
+        expect(result).toBe(false);
+    });
+
+    it("should handle multiple snippet files", () => {
+        const editedFiles = ["/mock/fern/snippets/snippet1.mdx", "/mock/fern/docs/snippets/snippet2.mdx"];
+        const result = detectSnippetFiles(editedFiles, docsWorkspacePath);
+        expect(result).toBe(true);
+    });
+});

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -83,7 +83,7 @@ export async function getPreviewDocsDefinition({
                 const finalMarkdown = replaceImagePathsAndUrls(
                     processedMarkdown,
                     fileIdsMap,
-                    {}, // markdownFilesToPathName - empty object since we don't need it for images
+                    {},
                     {
                         absolutePathToFernFolder: docsWorkspace.absoluteFilePath,
                         absolutePathToMarkdownFile: absoluteFilePath

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -83,7 +83,7 @@ export async function getPreviewDocsDefinition({
                 const finalMarkdown = replaceImagePathsAndUrls(
                     processedMarkdown,
                     fileIdsMap,
-                    {},
+                    {}, // markdownFilesToPathName - empty object since we don't need it for images
                     {
                         absolutePathToFernFolder: docsWorkspace.absoluteFilePath,
                         absolutePathToMarkdownFile: absoluteFilePath

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -79,6 +79,7 @@ export async function getPreviewDocsDefinition({
                     })
                 );
 
+                // Then replace image paths with file IDs
                 const finalMarkdown = replaceImagePathsAndUrls(
                     processedMarkdown,
                     fileIdsMap,

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -47,7 +47,6 @@ export async function getPreviewDocsDefinition({
             (filepath) => filepath.endsWith(".mdx") || filepath.endsWith(".md")
         );
 
-        // Check if any edited files are snippet files
         const snippetFilesEdited = editedAbsoluteFilepaths.some((filepath) => {
             const relativePath = relative(docsWorkspace.absoluteFilePath, filepath);
             return relativePath.startsWith("snippets/") || relativePath.includes("/snippets/");
@@ -57,7 +56,6 @@ export async function getPreviewDocsDefinition({
             context.logger.info("Snippet files were modified, performing full rebuild to update all references...");
         }
 
-        // Use incremental update only if all files are markdown AND no snippets were edited
         if (allMarkdownFiles && !snippetFilesEdited) {
             for (const absoluteFilePath of editedAbsoluteFilepaths) {
                 const relativePath = relative(docsWorkspace.absoluteFilePath, absoluteFilePath);
@@ -81,11 +79,10 @@ export async function getPreviewDocsDefinition({
                     })
                 );
 
-                // Then replace image paths with file IDs
                 const finalMarkdown = replaceImagePathsAndUrls(
                     processedMarkdown,
                     fileIdsMap,
-                    {}, // markdownFilesToPathName - empty object since we don't need it for images
+                    {},
                     {
                         absolutePathToFernFolder: docsWorkspace.absoluteFilePath,
                         absolutePathToMarkdownFile: absoluteFilePath


### PR DESCRIPTION
- Implemented logic to detect snippet files in edited paths, triggering a full rebuild if snippets are modified.
- Updated markdown processing to handle incremental updates only when all edited files are markdown and no snippets are involved.
- Added unit tests for snippet detection to ensure accurate identification of snippet files in various scenarios.

## Issue Fixed
**GitHub Issue #7266**: Hot reload does not reflect changes in snippets

## Problem
When editing snippet files in `fern/docs/snippets/`, changes weren't reflected in the browser during `fern docs dev` hot reload. Users had to restart the dev server.

## Root Cause
The incremental update logic in `previewDocs.ts` treated snippet files as regular markdown files and only processed them individually, without re-processing the pages that reference those snippets.

## Solution
Enhanced the hot reload logic to detect when snippet files are edited and perform a full rebuild instead of incremental update.