### PR TITLE
chore(cli): delete .git dir when generating locally

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,6 +4,14 @@
       type: internal
   irVersion: 58
   createdAt: "2025-05-27"
+  version: 0.63.9
+
+- changelogEntry:
+    - summary: |
+        Rerelease CLI at 0.63.8-rc1
+      type: internal
+  irVersion: 58
+  createdAt: "2025-05-27"
   version: 0.63.8-rc2
 
 - changelogEntry:

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -116,6 +116,9 @@ export class LocalTaskHandler {
         await this.runGitCommand(["reset", "--", ...fernIgnorePaths], tmpOutputResolutionDir);
         await this.runGitCommand(["restore", "."], tmpOutputResolutionDir);
 
+        // remove .git dir before copying files over
+        await rmdir(join(tmpOutputResolutionDir, RelativeFilePath.of(".git")), { recursive: true });
+
         // Delete local output directory and copy all files from the generated directory
         await rmdir(this.absolutePathToLocalOutput, { recursive: true });
         await cp(tmpOutputResolutionDir, this.absolutePathToLocalOutput, { recursive: true });

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -53,8 +53,7 @@ export async function runLocalGenerationForWorkspace({
                     getBaseOpenAPIWorkspaceSettingsFromGeneratorInvocation(generatorInvocation)
                 );
 
-                let organization;
-                let intermediateRepresentation = generateIntermediateRepresentation({
+                const intermediateRepresentation = generateIntermediateRepresentation({
                     workspace: fernWorkspace,
                     audiences: generatorGroup.audiences,
                     generationLanguage: generatorInvocation.language,
@@ -81,7 +80,9 @@ export async function runLocalGenerationForWorkspace({
                     }
                 }
 
-                organization = await venus.organization.get(FernVenusApi.OrganizationId(projectConfig.organization));
+                const organization = await venus.organization.get(
+                    FernVenusApi.OrganizationId(projectConfig.organization)
+                );
 
                 if (generatorInvocation.absolutePathToLocalOutput == null && !organization.ok) {
                     interactiveTaskContext.failWithoutThrowing(


### PR DESCRIPTION
## Description
This PR releases a version of the CLI that deletes the `.git` dir when copying files over with `.fernignore`

## Changes Made
- Delete `.git` folder from local files

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

