### PR TITLE
chore(ci): Use git log instead of HEAD

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -34,7 +34,17 @@ jobs:
       - name: Get version from file
         id: get_version
         run: |
-          git show HEAD~1:packages/cli/cli/versions.yml > tmp_cli_previous_versions.yml
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- packages/cli/cli/versions.yml | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- packages/cli/cli/versions.yml)
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:packages/cli/cli/versions.yml > tmp_cli_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_cli_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head packages/cli/cli/versions.yml
 
           pnpm seed:local latest cli -o "version.txt"  --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml
 

--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/csharp/model/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator csharp-model --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/csharp/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator csharp-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-go-fiber.yml
+++ b/.github/workflows/publish-generator-go-fiber.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/go/fiber/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator go-fiber --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/go/model/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator go-model --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/go/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator go-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/java/model/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator java-model --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/java/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator java-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-java-spring.yml
+++ b/.github/workflows/publish-generator-java-spring.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/java/spring/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator java-spring --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/openapi/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator openapi --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/php/model/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator php-model --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/php/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator php-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-postman.yml
+++ b/.github/workflows/publish-generator-postman.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/postman/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator postman --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-python-fastapi.yml
+++ b/.github/workflows/publish-generator-python-fastapi.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/python/fastapi/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator fastapi --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/python/pydantic/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator pydantic --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/python/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator python-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-ruby-model.yml
+++ b/.github/workflows/publish-generator-ruby-model.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/ruby/model/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator ruby-model --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/ruby/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator ruby-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-ts-express.yml
+++ b/.github/workflows/publish-generator-ts-express.yml
@@ -47,7 +47,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/typescript/express/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator ts-express --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -41,7 +41,18 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
         run: |
           VERSIONS_FILE="generators/typescript/sdk/versions.yml"
-          git show HEAD~1:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
+          current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
+          
+          # Get the previous version of the file using the specific commit that last changed it
+          git show ${previous_commit}:${VERSIONS_FILE} > tmp_previous_versions.yml
+          
+          echo "Preview of the previous file (${previous_commit})"
+          head tmp_previous_versions.yml
+
+          echo "Preview of the current file (${current_commit})"
+          head ${VERSIONS_FILE}
 
           if [ $? -eq 0 ]; then
             pnpm seed:local publish generator ts-sdk --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug


### PR DESCRIPTION
## Description
As more folks are contributing to the fern repo we are seeing race conditions related to the publishing the Fern CLI.

## Changes Made
- Used git log instead, following the patter from @dsinghvi's PR [here](https://github.com/fern-api/fern/commit/d4137a33c931eb375bbea3bc26ea2eeffa4c6655). 

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

