### PR TITLE
fix(cli): dont require nullable properties as required

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,11 @@
 - changelogEntry:
+    - summary: Make nullable properties optional in examples in the Fern Definition.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-05-28"
+  version: 0.63.13
+
+- changelogEntry:
     - summary: Fix parameter name collisions for enums
       type: fix
   irVersion: 58

--- a/packages/cli/generation/ir-generator/src/examples/validateObjectExample.ts
+++ b/packages/cli/generation/ir-generator/src/examples/validateObjectExample.ts
@@ -56,7 +56,7 @@ export function validateObjectExample({
 
     // ensure required properties are present, we treat unknown as optional
     const requiredProperties = allPropertiesForObject.filter(
-        (property) => !property.isOptional && property.resolvedPropertyType._type !== "unknown"
+        (property) => !property.isNullable && !property.isOptional && property.resolvedPropertyType._type !== "unknown"
     );
     for (const requiredProperty of requiredProperties) {
         // don't error on literal properties

--- a/packages/cli/generation/ir-generator/src/utils/getAllPropertiesForObject.ts
+++ b/packages/cli/generation/ir-generator/src/utils/getAllPropertiesForObject.ts
@@ -24,6 +24,7 @@ export interface ObjectPropertyWithPath {
     propertyType: string;
     resolvedPropertyType: ResolvedType;
     isOptional: boolean;
+    isNullable: boolean;
 }
 
 export type ObjectPropertyPath = ObjectPropertyPathPart[];
@@ -101,7 +102,8 @@ export function getAllPropertiesForObject({
                     resolvedPropertyType,
                     isOptional:
                         resolvedPropertyType._type === "container" &&
-                        resolvedPropertyType.container._type === "optional"
+                        resolvedPropertyType.container._type === "optional",
+                    isNullable: resolvedPropertyType._type === "container" && resolvedPropertyType.container._type === "nullable",
                 });
             }
         }


### PR DESCRIPTION
## Description
This PR removes the requirement that nullable properties should be checked as required in the fern definition. 

## Changes Made
- Skip required check for `isNullable`

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

