### PR TITLE
fix(cli): code component with props now works

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,19 @@
 - changelogEntry:
+    - summary: | 
+        The `<Code>` component now supports more flexible prop ordering and additional properties. You can now specify `maxLines` and `focus` props in any order relative to the `src` prop. For example:
+
+        ```mdx
+        <Code src="../snippets/example.ts" maxLines={20} focus={1-18} />
+        <Code maxLines={20} focus={1-18} src="../snippets/example.ts" />
+        ```
+
+        Both formats will work the same way, preserving the specified properties in the generated markdown. The component will automatically detect and include any additional props in the code block's metastring.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-05-28"
+  version: 0.63.15
+
+- changelogEntry:
     - summary: Fix duplicate properties in example IR generation.
       type: fix
   irVersion: 58

--- a/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
@@ -31,11 +31,11 @@ describe("replaceReferencedCode", () => {
         });
 
         expect(result).toBe(`
-            \`\`\`py title="test.py"
+            \`\`\`py title={"test.py"}
             test content
             \`\`\`
 
-            \`\`\`ts title="test.ts"
+            \`\`\`ts title={"test.ts"}
             test2 content
             with multiple lines
             \`\`\`
@@ -66,11 +66,46 @@ describe("replaceReferencedCode", () => {
         });
 
         expect(result).toBe(`
-            \`\`\`py title="test.py" maxLines={20} focus={1-18}
+            \`\`\`py title={"test.py"} maxLines={20} focus={1-18}
             test content
             \`\`\`
 
-            \`\`\`ts title="test.ts" maxLines={20} focus={1-18}
+            \`\`\`ts title={"test.ts"} maxLines={20} focus={1-18}
+            test2 content
+            with multiple lines
+            \`\`\`
+
+        `);
+    });
+
+    it("should preserve maxLines and focus attributes when they appear before src", async () => {
+        const markdown = `
+            <Code maxLines={20} focus={1-18} src="../snippets/test.py" />
+            <Code maxLines="20" focus={1-18} src="../snippets/test.ts" />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.py")) {
+                    return "test content";
+                }
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.ts")) {
+                    return "test2 content\nwith multiple lines";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`py title={"test.py"} maxLines={20} focus={1-18}
+            test content
+            \`\`\`
+
+            \`\`\`ts title={"test.ts"} maxLines={20} focus={1-18}
             test2 content
             with multiple lines
             \`\`\`

--- a/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
@@ -28,7 +28,7 @@ export async function replaceReferencedCode({
         return markdown;
     }
 
-    const regex = /([ \t]*)<Code\s+src={?['"]([^'"]+)['"](?! \+)}?((?:\s+[^>]*)?)\/>/g;
+    const regex = /([ \t]*)<Code(?:\s+[^>]*?)?\s+src={?['"]([^'"]+)['"](?! \+)}?((?:\s+[^>]*)?)\/>/g;
 
     let newMarkdown = markdown;
 
@@ -57,9 +57,10 @@ export async function replaceReferencedCode({
             }
             const title = filepath.split("/").pop();
             if (title != null) {
-                metastring += ` title="${title}"`;
+                metastring += ` title={"${title}"}`;
             }
-            // Extract additional props from the Code component
+            
+            // Extract 
             const additionalProps = match[3]?.trim() || "";
             if (additionalProps) {
                 // Parse and add any additional props to the metastring
@@ -74,6 +75,20 @@ export async function replaceReferencedCode({
                 }
             }
 
+            // Extract props before src
+            const beforeSrcProps = matchString?.split("src=")[0]?.trim() ?? "";
+            if (beforeSrcProps) {
+                const beforePropsRegex = /(\w+)=(?:{([^}]+)}|"([^"]+)")/g;
+                let beforePropMatch;
+                while ((beforePropMatch = beforePropsRegex.exec(beforeSrcProps)) !== null) {
+                    const propName = beforePropMatch[1];
+                    const propValue = beforePropMatch[2] || beforePropMatch[3];
+                    if (propName && propValue && propName !== "src") {
+                        metastring += ` ${propName}=${propValue.includes("{") ? propValue : `{${propValue}}`}`;
+                    }
+                }
+            }
+
             // TODO: if the code content includes ```, add more backticks to avoid conflicts
             replacement = `\`\`\`${metastring}\n${replacement}\n\`\`\``;
             replacement = replacement
@@ -82,6 +97,8 @@ export async function replaceReferencedCode({
                 .join("\n");
             replacement = replacement + "\n"; // add newline after the code block
             newMarkdown = newMarkdown.replace(matchString, replacement);
+
+            context.logger.error(`Generated markdown:\n${newMarkdown}`);
         } catch (e) {
             context.logger.warn(`Failed to read markdown file "${src}" referenced in ${absolutePathToMarkdownFile}`);
             break;

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -20,7 +20,7 @@ import { Project } from "@fern-api/project-loader";
 import { convertIrToFdrApi } from "@fern-api/register";
 import { TaskContext } from "@fern-api/task-context";
 
-import { replaceImagePathsAndUrls, replaceReferencedMarkdown } from "../../docs-markdown-utils/src";
+import { replaceImagePathsAndUrls, replaceReferencedCode, replaceReferencedMarkdown } from "../../docs-markdown-utils/src";
 import { FernWorkspace } from "../../workspace/loader/src";
 
 export async function getPreviewDocsDefinition({
@@ -69,7 +69,7 @@ export async function getPreviewDocsDefinition({
             );
 
             // Then replace image paths with file IDs
-            const finalMarkdown = replaceImagePathsAndUrls(
+            let finalMarkdown = replaceImagePathsAndUrls(
                 processedMarkdown,
                 fileIdsMap,
                 {}, // markdownFilesToPathName - empty object since we don't need it for images
@@ -79,6 +79,13 @@ export async function getPreviewDocsDefinition({
                 },
                 context
             );
+
+            finalMarkdown = await replaceReferencedCode({
+                markdown: finalMarkdown,
+                absolutePathToFernFolder: docsWorkspace.absoluteFilePath,
+                absolutePathToMarkdownFile: absoluteFilePath,
+                context
+            });
 
             previousDocsDefinition.pages[FdrAPI.PageId(relativePath)] = {
                 markdown: finalMarkdown,


### PR DESCRIPTION
## Description
See the updated description.

## Changes Made
- Fixes the actual replacingCodeReference.ts
- Fixes preview to load the updated references

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

