### PR TITLE
fix(cli): Use `x-fern-type-name` value to override request type name

### DIFF
--- a/fern/pages/changelogs/cli/2025-05-29.mdx
+++ b/fern/pages/changelogs/cli/2025-05-29.mdx
@@ -1,3 +1,7 @@
+## 0.63.21
+**`(fix):`** Use `x-fern-type-name` to override the generated request name for endpoints.
+
+
 ## 0.63.20
 **`(fix):`** Implement V3 parser support for streamCondition endpoints.
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -153,6 +153,11 @@ export function convertHttpOperation({
     const availability = getFernAvailability(operation);
     const examples = getExamplesFromExtension(operationContext, operation, context);
     const serverName = getExtension<string>(operation, FernOpenAPIExtension.SERVER_NAME_V2);
+
+    const nameOverride = getExtension<string>(operation, FernOpenAPIExtension.TYPE_NAME);
+    const generatedRequestName =
+        nameOverride ?? getGeneratedTypeName(requestBreadcrumbs, context.options.preserveSchemaIds);
+
     return {
         summary: operation.summary,
         internal: getExtension<boolean>(operation, OpenAPIExtension.INTERNAL),
@@ -169,7 +174,7 @@ export function convertHttpOperation({
         queryParameters: convertedParameters.queryParameters,
         headers: convertedParameters.headers,
         requestNameOverride: requestNameOverride ?? undefined,
-        generatedRequestName: getGeneratedTypeName(requestBreadcrumbs, context.options.preserveSchemaIds),
+        generatedRequestName,
         request: convertedRequest,
         response: convertedResponse.value,
         errors: convertedResponse.errors,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 - changelogEntry:
     - summary: |
+        Use `x-fern-type-name` to override the generated request name for endpoints.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-05-29"
+  version: 0.63.21
+
+- changelogEntry:
+    - summary: |
         Implement V3 parser support for streamCondition endpoints.
       type: fix
   irVersion: 58


### PR DESCRIPTION
## Description
Use the `x-fern-type-name` value as the `generatedRequestName` if it exists

## Testing
Updated seed tests and tested this locally with Auth0's SDK:

```Overrides
paths:
  /actions/actions:
    get:
      x-fern-sdk-group-name:
        - actions
      x-fern-sdk-method-name: list
      x-fern-type-name: MakingThisUp
```

```SDK
/**
 * This file was auto-generated by Fern from our API Definition.
 */

import * as Auth0 from "../../../../index";

/**
 * @example
 *     {}
 */
export interface MakingThisUp {
    /**
     * An actions extensibility point.
     */
    triggerId?: Auth0.ActionTriggerTypeEnum;
    /**
     * The name of the action to retrieve.
     */
    actionName?: string;
    /**
     * Optional filter to only retrieve actions that are deployed.
     */
    deployed?: boolean;
    /**
     * Use this field to request a specific page of the list results.
     */
    page?: number;
    /**
     * The maximum number of results to be returned by the server in single response. 20 by default
     */
    per_page?: number;
    /**
     * Optional. When true, return only installed actions. When false, return only custom actions. Returns all actions by default.
     */
    installed?: boolean;
}
```
