### PR TITLE
fix(docs): fixed no op for missing docs.yml file

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -25,6 +25,7 @@ export async function generateDocsWorkspace({
 }): Promise<void> {
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
+        cliContext.failAndThrow("No docs.yml file found. Please make sure your project has one.");
         return;
     }
     const shouldSkipAuth = process.env["FERN_SELF_HOSTED"] === "true";

--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -102,6 +102,14 @@ describe("fern generate", () => {
         });
         expect(stdout).toContain("ferndevtest.docs.dev.buildwithfern.com Started.");
     }, 180_000);
+
+    it("generate docs with no docs.yml file fails", async () => {
+        const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("basic")),
+            reject: false
+        });
+        expect(stdout).toContain("No docs.yml file found. Please make sure your project has one.");
+    }, 180_000);
 });
 
 function extractFilepath(logLine: string): string | null {

--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -104,7 +104,7 @@ describe("fern generate", () => {
     }, 180_000);
 
     it("generate docs with no docs.yml file fails", async () => {
-        const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
+        const { stdout } = await runFernCli(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("basic")),
             reject: false
         });


### PR DESCRIPTION
## Description
Discovered that if you don't have a docs.yml file in your fern fold today and run `fern generate --docs` we just silently fail to generate docs with no indication to the end user as to why.

## Changes Made
Now if a user runs `fern generate --docs` on a set of files that are missing a docs.yml file we let them know on their terminal.

## Testing
Tested this on a local folder i had without a docs.yml file:

<img width="1078" alt="Screenshot 2025-05-30 at 3 55 47 PM" src="https://github.com/user-attachments/assets/9f685fbc-15ae-417f-8bb6-ad763414dbae" />
