### PR TITLE
feat(cli): release new version of CLI

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-02.mdx
+++ b/fern/pages/changelogs/cli/2025-06-02.mdx
@@ -1,0 +1,4 @@
+## 0.63.26
+**`(feat):`** Add support for locally generating docs with no auth.
+
+

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,6 @@
 - changelogEntry:
     - summary: |
-        Add support for generating docs with no auth.
+        Add support for locally generating docs with no auth.
       type: feat
   irVersion: 58
   createdAt: "2025-06-02"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 - changelogEntry:
     - summary: |
+        Add support for generating docs with no auth.
+      type: feat
+  irVersion: 58
+  createdAt: "2025-06-02"
+  version: 0.63.26
+
+- changelogEntry:
+    - summary: |
         Remove trailing slashes from base environment URLs if they are not empty.
       type: fix
   irVersion: 58


### PR DESCRIPTION
## Description
I [made some changes to the CLI on friday](https://github.com/fern-api/fern/commit/3ed86b294d7c546d1e23107674e2ec79f8b5e432) but didn't release a new version of the CLI. I'm releasing a new version of the CLI.

## Changes Made
Updated versions.yml for new patch.

## Testing
N/A

