### PR TITLE
chore(cli): download local preview tar bundle

### DIFF
--- a/packages/cli/cli/build.dev.cjs
+++ b/packages/cli/cli/build.dev.cjs
@@ -22,6 +22,7 @@ async function main() {
             POSTHOG_API_KEY: null,
             DOCS_DOMAIN_SUFFIX: "docs.dev.buildwithfern.com",
             DOCS_PREVIEW_BUCKET: 'https://dev2-local-preview-bundle2.s3.amazonaws.com/',
+            APP_DOCS_TAR_PREVIEW_BUCKET: 'https://dev2-local-preview-bundle4.s3.amazonaws.com/',
             APP_DOCS_PREVIEW_BUCKET: 'https://dev2-local-preview-bundle3.s3.amazonaws.com/',
             CLI_NAME: "fern-dev",
             CLI_VERSION: process.argv[2] || packageJson.version,

--- a/packages/cli/cli/build.local.cjs
+++ b/packages/cli/cli/build.local.cjs
@@ -22,6 +22,7 @@ async function main() {
             POSTHOG_API_KEY: null,
             DOCS_DOMAIN_SUFFIX: "docs.dev.buildwithfern.com",
             DOCS_PREVIEW_BUCKET: 'https://dev2-local-preview-bundle2.s3.amazonaws.com/',
+            APP_DOCS_TAR_PREVIEW_BUCKET: 'https://dev2-local-preview-bundle4.s3.amazonaws.com/',
             APP_DOCS_PREVIEW_BUCKET: 'https://dev2-local-preview-bundle3.s3.amazonaws.com/',
             CLI_NAME: "fern-local",
             CLI_VERSION: process.argv[2] || packageJson.version,

--- a/packages/cli/cli/build.prod.cjs
+++ b/packages/cli/cli/build.prod.cjs
@@ -22,6 +22,7 @@ async function main() {
             POSTHOG_API_KEY: process.env.POSTHOG_API_KEY,
             DOCS_DOMAIN_SUFFIX: "docs.buildwithfern.com",
             DOCS_PREVIEW_BUCKET: 'https://prod-local-preview-bundle2.s3.amazonaws.com/',
+            APP_DOCS_TAR_PREVIEW_BUCKET: 'https://prod-local-preview-bundle4.s3.amazonaws.com/',
             APP_DOCS_PREVIEW_BUCKET: 'https://prod-local-preview-bundle3.s3.amazonaws.com/',
             CLI_NAME: "fern",
             CLI_VERSION: process.argv[2] || packageJson.version,

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -62,12 +62,14 @@ export async function downloadBundle({
     bucketUrl,
     logger,
     preferCached,
-    app = false
+    app = false,
+    tryTar = false
 }: {
     bucketUrl: string;
     logger: Logger;
     preferCached: boolean;
     app?: boolean;
+    tryTar?: boolean;
 }): Promise<DownloadLocalBundle.Result> {
     logger.debug("Setting up docs preview bundle...");
     const response = await fetcher<string>({
@@ -140,7 +142,7 @@ export async function downloadBundle({
             type: "failure"
         };
     }
-    const outputZipPath = join(absoluteDirectoryToTmpDir, RelativeFilePath.of("output.zip"));
+    const outputZipPath = join(absoluteDirectoryToTmpDir, RelativeFilePath.of(tryTar ? "output.tar.gz" : "output.zip"));
 
     const contents = docsBundleZipResponse.body;
     if (contents == null) {
@@ -152,7 +154,7 @@ export async function downloadBundle({
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     const nodeBuffer = Buffer.from(contents as any);
     await writeFile(outputZipPath, new Uint8Array(nodeBuffer));
-    logger.debug(`Wrote output.zip to ${outputZipPath}`);
+    logger.debug(`Wrote ${tryTar ? "output.tar.gz" : "output.zip"} to ${outputZipPath}`);
 
     const absolutePathToPreviewFolder = getPathToPreviewFolder({ app });
     if (await doesPathExist(absolutePathToPreviewFolder)) {

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -91,6 +91,7 @@ export async function runAppPreviewServer({
         } catch (err) {
             if (err instanceof Error) {
                 context.logger.debug(`Failed to download latest docs bundle: ${(err as Error).message}`);
+                context.logger.error("Failed to unzip .tar.gz bundle. Please report to support@buildwithfern.com");
             }
 
             context.logger.debug("Falling back to .zip bundle");

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -78,7 +78,7 @@ export async function runPreviewServer({
                     "Failed to connect to the docs preview server. Please contact support@buildwithfern.com"
                 );
             }
-            await downloadBundle({ bucketUrl: url, logger: context.logger, preferCached: true });
+            await downloadBundle({ bucketUrl: url, logger: context.logger, preferCached: true, tryTar: false });
         } catch (err) {
             const pathToBundle = getPathToBundleFolder({});
             if (err instanceof Error) {


### PR DESCRIPTION
update the download of the local preview bundle to point at the S3 bucket storing the tar zip. should fallback to using the zip bundle if this fails. 
