### PR TITLE
fix(docs): fix changelog typo

### DIFF
--- a/fern/pages/changelogs/cli/2024-02-11.mdx
+++ b/fern/pages/changelogs/cli/2024-02-11.mdx
@@ -1,7 +1,7 @@
 ## 0.17.8
 **`(chore):`** ## What's Changed
 * (feature): support whitelabeling SDKs  by @dsinghvi in https://github.com/fern-api/fern/pull/2928
-* (feature): css + js + measure img size by @abvthecity in https://github.com/fern-api/fern/pull/2872api/fern/pull/2937
+* (feature): css + js + measure img size by @abvthecity in https://github.com/fern-api/fern/pull/2872
 
 
 **Full Changelog**: https://github.com/fern-api/fern/compare/0.17.7...0.17.8

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -7470,7 +7470,7 @@
 - changelogEntry:
     - summary: "## What's Changed\r\n* (feature): support whitelabeling SDKs  by @dsinghvi\
         \ in https://github.com/fern-api/fern/pull/2928\r\n* (feature): css + js + measure\
-        \ img size by @abvthecity in https://github.com/fern-api/fern/pull/2872api/fern/pull/2937\r\
+        \ img size by @abvthecity in https://github.com/fern-api/fern/pull/2872\r\
         \n\r\n\r\n**Full Changelog**: https://github.com/fern-api/fern/compare/0.17.7...0.17.8"
       type: chore
   createdAt: "2024-02-11"

--- a/packages/seed/src/__test__/assets/live-test/new.yml
+++ b/packages/seed/src/__test__/assets/live-test/new.yml
@@ -3955,7 +3955,7 @@
 - changelogEntry:
     - summary: "## What's Changed\r\n* (feature): support whitelabeling SDKs  by @dsinghvi\
         \ in https://github.com/fern-api/fern/pull/2928\r\n* (feature): css + js + measure\
-        \ img size by @abvthecity in https://github.com/fern-api/fern/pull/2872api/fern/pull/2937\r\
+        \ img size by @abvthecity in https://github.com/fern-api/fern/pull/2872\r\
         \n\r\n\r\n**Full Changelog**: https://github.com/fern-api/fern/compare/0.17.7...0.17.8"
       type: chore
   createdAt: "2024-02-11"

--- a/packages/seed/src/__test__/assets/live-test/old.yml
+++ b/packages/seed/src/__test__/assets/live-test/old.yml
@@ -3948,7 +3948,7 @@
 - changelogEntry:
     - summary: "## What's Changed\r\n* (feature): support whitelabeling SDKs  by @dsinghvi\
         \ in https://github.com/fern-api/fern/pull/2928\r\n* (feature): css + js + measure\
-        \ img size by @abvthecity in https://github.com/fern-api/fern/pull/2872api/fern/pull/2937\r\
+        \ img size by @abvthecity in https://github.com/fern-api/fern/pull/2872\r\
         \n\r\n\r\n**Full Changelog**: https://github.com/fern-api/fern/compare/0.17.7...0.17.8"
       type: chore
   createdAt: "2024-02-11"


### PR DESCRIPTION
## Description
The link checking action was complaining about an issue on the changelog page
## Changes Made
- Fixed bad path
 

## Testing


