### PR TITLE
fix(cli): support fdr url override

### DIFF
--- a/packages/core/src/services/fdr.ts
+++ b/packages/core/src/services/fdr.ts
@@ -8,8 +8,9 @@ export function createFdrService({
     environment?: string;
     token: (() => string) | string;
 }): FdrClient {
+    const overrideEnvironment = process.env.OVERRIDE_FDR_ORIGIN;
     return new FdrClient({
-        environment,
+        environment: overrideEnvironment ?? environment,
         token
     });
 }


### PR DESCRIPTION
## Description

We need our PROD CLI to be able to optionally hit our local FDR server instead of our prod server. Today we have this env variable called `DEFAULT_FDR_ORIGIN` that gets set in `build.local.cjs`, `build.dev.cjs` and `build.prod.cjs`. This variable however cannot be overriden at run time so for example if you try `DEFAULT_FDR_ORIGIN=http://localhost:8080/ fern generate --docs` the CLI will ALWAYS use whatever value DEFAULT_FDR_ORIGIN has build time (from `build.prod.cjs`) and will ignore the value you are trying to use at runtime.

The best way i see to get around this for now is to just introduce a new env variable called `OVERRIDE_FDR_ORIGIN` that doesn't get used in our tsup build script.

## Changes Made

Updated CLI code to hit FDR server at `OVERRIDE_FDR_ORIGIN` if this env variable is passed in at runtime.

## Testing

I tested building the CLI with `pnpm fern:build` and then running `OVERRIDE_FDR_ORIGIN=http://localhost:8080 node /Users/ariel/fern-code/fern/packages/cli/cli/dist/prod/cli.cjs generate --docs` to see if we hit PROD or my local FDR server
