### PR TITLE
feat(cli): release cli 63.28

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-03.mdx
+++ b/fern/pages/changelogs/cli/2025-06-03.mdx
@@ -1,2 +1,8 @@
+## 0.63.28
+**`(feat):`** Add support for overriding FDR server origin via OVERRIDE_FDR_ORIGIN environment variable.
+
+
 ## 0.63.27
 **`(fix):`** Improvements to development server download and shutdown logic.
+
+

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,7 +1,7 @@
 - changelogEntry:
     - summary: |
         Add support for overriding FDR server origin via OVERRIDE_FDR_ORIGIN environment variable.
-      type: fix
+      type: feat
   irVersion: 58
   createdAt: "2025-06-03"
   version: 0.63.28

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,4 @@
-- changeLogEntry:
+- changelogEntry:
     - summary: |
         Add support for locally generating docs with no auth.
       type: fix

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,3 +1,11 @@
+- changeLogEntry:
+    - summary: |
+        Add support for locally generating docs with no auth.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-03"
+  version: 0.63.27
+
 - changelogEntry:
     - summary: |
         Improvements to development server download and shutdown logic.

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,7 +4,7 @@
       type: fix
   irVersion: 58
   createdAt: "2025-06-03"
-  version: 0.63.27
+  version: 0.63.28
 
 - changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,6 @@
 - changelogEntry:
     - summary: |
-        Add support for locally generating docs with no auth.
+        Add support for overriding FDR server origin via OVERRIDE_FDR_ORIGIN environment variable.
       type: fix
   irVersion: 58
   createdAt: "2025-06-03"


### PR DESCRIPTION
## Description
Releases new version of CLI so that this PR i just merged goes live: https://github.com/fern-api/fern/commit/b58e49e0bc7672e45bf4c18963a968564296f111

## Changes Made
Updated CLI code to hit FDR server at OVERRIDE_FDR_ORIGIN if this env variable is passed in at runtime.

## Testing
N/A

