### PR TITLE
chore(cli): Update dynamic-ir-sdk generator version

### DIFF
--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -16,7 +16,7 @@ groups:
       - dynamic
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.38.6
+        version: 0.45.1
         output:
           location: npm
           package-name: "@fern-api/dynamic-ir-sdk"


### PR DESCRIPTION
This updates the `@fern-api/dynamic-ir-sdk` generator version to attempt to resolve  the issues found in the release workflow (e.g. [job](https://github.com/fern-api/fern/actions/runs/15332544110/job/43142556372)).
