### PR TITLE
chore(internal): Turn off @typescript-eslint/no-non-null-assertion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,7 +111,7 @@ module.exports = {
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-unnecessary-condition": "off",
         "@typescript-eslint/unified-signatures": "off",
-        "@typescript-eslint/no-non-null-assertion": "warn",
+        "@typescript-eslint/no-non-null-assertion": "off",
         // "@typescript-eslint/no-deprecated": "warn",
         "eslint-comments/no-unused-disable": "off",
         "jest/expect-expect": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,6 +111,7 @@ module.exports = {
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-unnecessary-condition": "off",
         "@typescript-eslint/unified-signatures": "off",
+        "@typescript-eslint/no-non-null-assertion": "warn",
         // "@typescript-eslint/no-deprecated": "warn",
         "eslint-comments/no-unused-disable": "off",
         "jest/expect-expect": "off",


### PR DESCRIPTION
## Description
Turn off @typescript-eslint/no-non-null-assertion.

The `!.` operator is supposed to be used when it has already been checked for undefined. It tells TypeScript, "I know this isn't undefined, it's okay".
Rather than checking again for undefined or having to do some type gymnastics, I think we should just allow this.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

