### PR TITLE
chore(deps): Allow users to specify SDK output path in generators.yml

### DIFF
--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -74,6 +74,7 @@ types:
     properties: 
       uri: string
       token: string
+      path: optional<string>
 
   GeneratorSnippetsSchema:
     properties:
@@ -109,6 +110,7 @@ types:
       license: optional<license.GithubLicenseSchema>
       mode: literal<"pull-request">
       reviewers: optional<reviewers.ReviewersSchema>
+      path: optional<string>
       # Add properties for pull request configuration
 
   GithubPushSchema:
@@ -117,6 +119,7 @@ types:
       license: optional<license.GithubLicenseSchema>
       mode: literal<"push">
       branch: optional<string>
+      path: optional<string>
       # Add properties for push configuration
   
   NpmOutputLocationSchema:

--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -94,6 +94,7 @@ types:
       repository: string
       license: optional<license.GithubLicenseSchema>
       mode: optional<GithubCommitAndReleaseMode>
+      path: optional<string>
       # Add properties for commit and release configuration
   
   GithubCommitAndReleaseMode:

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -2426,6 +2426,16 @@
         },
         "token": {
           "type": "string"
+        },
+        "path": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -2594,6 +2604,16 @@
               "type": "null"
             }
           ]
+        },
+        "path": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -2622,6 +2642,16 @@
           "const": "push"
         },
         "branch": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
           "oneOf": [
             {
               "type": "string"

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -2496,7 +2496,7 @@
             }
           ]
         },
-        "sdk-output-path": {
+        "path": {
           "oneOf": [
             {
               "type": "string"

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -2495,6 +2495,16 @@
               "type": "null"
             }
           ]
+        },
+        "sdk-output-path": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubCommitAndReleaseSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubCommitAndReleaseSchema.ts
@@ -8,4 +8,5 @@ export interface GithubCommitAndReleaseSchema {
     repository: string;
     license?: FernDefinition.GithubLicenseSchema;
     mode?: FernDefinition.GithubCommitAndReleaseMode;
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPullRequestSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPullRequestSchema.ts
@@ -10,4 +10,5 @@ export interface GithubPullRequestSchema {
     license?: FernDefinition.GithubLicenseSchema;
     mode: "pull-request";
     reviewers?: FernDefinition.ReviewersSchema;
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPushSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubPushSchema.ts
@@ -9,4 +9,5 @@ export interface GithubPushSchema {
     license?: FernDefinition.GithubLicenseSchema;
     mode: "push";
     branch?: string;
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubSelfhostedSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubSelfhostedSchema.ts
@@ -5,4 +5,5 @@
 export interface GithubSelfhostedSchema {
     uri: string;
     token: string;
+    path?: string;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubCommitAndReleaseSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubCommitAndReleaseSchema.ts
@@ -15,6 +15,7 @@ export const GithubCommitAndReleaseSchema: core.serialization.ObjectSchema<
     repository: core.serialization.string(),
     license: GithubLicenseSchema.optional(),
     mode: GithubCommitAndReleaseMode.optional(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubCommitAndReleaseSchema {
@@ -22,5 +23,6 @@ export declare namespace GithubCommitAndReleaseSchema {
         repository: string;
         license?: GithubLicenseSchema.Raw | null;
         mode?: GithubCommitAndReleaseMode.Raw | null;
+        path?: string | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPullRequestSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPullRequestSchema.ts
@@ -17,6 +17,7 @@ export const GithubPullRequestSchema: core.serialization.ObjectSchema<
     license: GithubLicenseSchema.optional(),
     mode: core.serialization.stringLiteral("pull-request"),
     reviewers: ReviewersSchema.optional(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubPullRequestSchema {
@@ -26,5 +27,6 @@ export declare namespace GithubPullRequestSchema {
         license?: GithubLicenseSchema.Raw | null;
         mode: "pull-request";
         reviewers?: ReviewersSchema.Raw | null;
+        path?: string | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPushSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubPushSchema.ts
@@ -15,6 +15,7 @@ export const GithubPushSchema: core.serialization.ObjectSchema<
     license: GithubLicenseSchema.optional(),
     mode: core.serialization.stringLiteral("push"),
     branch: core.serialization.string().optional(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubPushSchema {
@@ -23,5 +24,6 @@ export declare namespace GithubPushSchema {
         license?: GithubLicenseSchema.Raw | null;
         mode: "push";
         branch?: string | null;
+        path?: string | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubSelfhostedSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubSelfhostedSchema.ts
@@ -12,11 +12,13 @@ export const GithubSelfhostedSchema: core.serialization.ObjectSchema<
 > = core.serialization.object({
     uri: core.serialization.string(),
     token: core.serialization.string(),
+    path: core.serialization.string().optional(),
 });
 
 export declare namespace GithubSelfhostedSchema {
     export interface Raw {
         uri: string;
         token: string;
+        path?: string | null;
     }
 }


### PR DESCRIPTION
## Description
Update the `generators.yml` file to let users specify the output path for the SDK + test files. The readme + all other root files will continue being generated in the root folder.

## Changes Made
Updated `generators.yml` file
