### PR TITLE
fix(typescript): Fix an WS generation error where element access should be used instead of property access.

### DIFF
--- a/fern/pages/changelogs/ts-sdk/2025-06-04.mdx
+++ b/fern/pages/changelogs/ts-sdk/2025-06-04.mdx
@@ -1,0 +1,3 @@
+## 1.1.1
+**`(fix):`** Fix an issue where attempting to access a property with an invalid property name would lead to a broken output SDK.
+

--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -419,11 +419,14 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
     }
 
     private getReferenceToOption(option: string): ts.Expression {
-        return ts.factory.createPropertyAccessExpression(this.getReferenceToOptions(), option);
+        return ts.factory.createElementAccessExpression(
+            this.getReferenceToOptions(),
+            ts.factory.createStringLiteral(option)
+        );
     }
 
     private getReferenceToArg(arg: string): ts.Expression {
-        return ts.factory.createPropertyAccessExpression(this.getReferenceToArgs(), arg);
+        return ts.factory.createElementAccessExpression(this.getReferenceToArgs(), ts.factory.createStringLiteral(arg));
     }
 
     public getSocketTypeNode(context: SdkContext): ts.TypeNode {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,11 +1,19 @@
 
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.1.1
+  changelogEntry:
+    - summary: Fix an issue where attempting to access a property with an invalid property name would lead to a broken output SDK.
+      type: fix
+  createdAt: '2025-06-04'
+  irVersion: 58
+
 - version: 1.1.0
   changelogEntry:
     - summary: Add support for HEAD HTTP method.
       type: feat
   createdAt: '2025-06-03'
   irVersion: 58
+
 - version: 1.0.1
   changelogEntry:
     - summary: Fix property lookup in inherited schemas during snippet generation for object schemas.


### PR DESCRIPTION
## Description
This fix ensures that we are properly accessing all properties in `args` when constructing the connectArgs queryParams dict.

## Changes Made
- Update property access nodes to element access nodes.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

