### PR TITLE
fix(python): Fix snippet formatting in tests

### DIFF
--- a/generators/python/tests/sdk/test_root_client_generator.py
+++ b/generators/python/tests/sdk/test_root_client_generator.py
@@ -58,7 +58,11 @@ def test_generated_root_client_builder() -> None:
         """\
         from acme.client import Acme
         from acme.environments import AcmeEnvironments
-        client = Acme(base_url="acme.io", environment=AcmeEnvironments.PRODUCTION, )
+
+        client = Acme(
+            base_url="acme.io",
+            environment=AcmeEnvironments.PRODUCTION,
+        )
         """
     )
 
@@ -68,6 +72,10 @@ def test_generated_root_client_builder() -> None:
         """\
         from acme.client import AcmeAsync
         from acme.environments import AcmeEnvironments
-        client = AcmeAsync(base_url="acme.io", environment=AcmeEnvironments.PRODUCTION, )
+
+        client = AcmeAsync(
+            base_url="acme.io",
+            environment=AcmeEnvironments.PRODUCTION,
+        )
         """
     )

--- a/generators/python/tests/snippet_generator/test_snippet_generator.py
+++ b/generators/python/tests/snippet_generator/test_snippet_generator.py
@@ -5,4 +5,4 @@ from fern_python.source_file_factory import SourceFileFactory
 def test_snippet_generator() -> None:
     snippet = SourceFileFactory(should_format=True).create_snippet()
     snippet.add_arbitrary_code(AST.CodeWriter("x = 42"))
-    assert snippet.to_str() == "x = 42"
+    assert snippet.to_str() == "x = 42\n"


### PR DESCRIPTION
This updates the formatting used in the snippet test cases to resolve the Python generator test failures.
