### PR TITLE
feat(typescript): Add support for filesystem output mode

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-04.mdx
+++ b/fern/pages/changelogs/cli/2025-06-04.mdx
@@ -1,0 +1,4 @@
+## 0.63.30
+**`(feat):`** Support endpoint-level servers in OpenRPC.
+
+

--- a/fern/pages/changelogs/ts-express/2025-06-03.mdx
+++ b/fern/pages/changelogs/ts-express/2025-06-03.mdx
@@ -1,3 +1,3 @@
-## 0.18.0
+## 0.18.1
 **`(internal):`** Update the IR to v58.
 

--- a/fern/pages/changelogs/ts-sdk/2025-06-03.mdx
+++ b/fern/pages/changelogs/ts-sdk/2025-06-03.mdx
@@ -1,4 +1,4 @@
-## 1.2.3
+## 1.2.4
 **`(feat):`** Generate tests to verify the SDK sends and receives HTTP requests as expected.
 You can turn of these tests by setting `generateWireTests` to `false` in the `config` of your generator configuration.
 

--- a/fern/pages/changelogs/ts-sdk/2025-06-03.mdx
+++ b/fern/pages/changelogs/ts-sdk/2025-06-03.mdx
@@ -1,4 +1,4 @@
-## 1.2.0
+## 1.2.3
 **`(feat):`** Generate tests to verify the SDK sends and receives HTTP requests as expected.
 You can turn of these tests by setting `generateWireTests` to `false` in the `config` of your generator configuration.
 

--- a/fern/pages/changelogs/ts-sdk/2025-06-04.mdx
+++ b/fern/pages/changelogs/ts-sdk/2025-06-04.mdx
@@ -1,3 +1,6 @@
+## 1.3.0
+**`(feat):`** Add support for generating the full project when using the filesystem output mode.
+
 ## 1.1.1
 **`(fix):`** Fix an issue where attempting to access a property with an invalid property name would lead to a broken output SDK.
 

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -104,7 +104,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             intermediateRepresentation,
             context: generatorContext,
             npmPackage,
-            generateJestTests: config.output.mode.type === "github",
+            generateJestTests: this.shouldGenerateJestTests({ ir: intermediateRepresentation, config }),
             rawConfig: config,
             config: {
                 runScripts: !customConfig.noScripts,
@@ -216,7 +216,27 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
               ? "dev"
               : "prod";
     }
+
     private customConfigWithOverrides(customConfig: SdkCustomConfig): SdkCustomConfig {
         return { ...customConfig, ...this.configOverrides };
+    }
+
+    private shouldGenerateJestTests({
+        ir,
+        config
+    }: {
+        ir: IntermediateRepresentation;
+        config: FernGeneratorExec.GeneratorConfig;
+    }): boolean {
+        const hasGitHubOutputMode = config.output.mode.type === "github";
+        const publishConfig = ir.publishConfig;
+        switch (publishConfig?.type) {
+            case "filesystem":
+                return publishConfig.generateFullProject || hasGitHubOutputMode;
+            case "github":
+            case "direct":
+            default:
+                return hasGitHubOutputMode;
+        }
     }
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 1.3.0
+  changelogEntry:
+    - summary: Add support for generating the full project when using the filesystem output mode.
+      type: feat
+  createdAt: '2025-06-04'
+  irVersion: 58
+
 - version: 1.2.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -26,6 +26,7 @@
     "depcheck": "depcheck"
   },
   "dependencies": {
+    "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/logger": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4465,6 +4465,9 @@ importers:
       '@fern-api/base-generator':
         specifier: workspace:*
         version: link:../../../base
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../../../../packages/commons/core-utils
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../../packages/commons/fs-utils


### PR DESCRIPTION
This updates the TypeScript SDK generator to support writing the top-level files (e.g. `package.json`, `tsconfig.json`, `README.md`, etc) in `filesystem` output mode.

