### PR TITLE
fix(python): Resolve a bug in the ws client connect method.

### DIFF
--- a/fern/pages/changelogs/python-sdk/2025-06-04.mdx
+++ b/fern/pages/changelogs/python-sdk/2025-06-04.mdx
@@ -1,0 +1,4 @@
+## 4.21.3
+**`(fix):`** Fix an issue where the websocket connect method did not correctly yield the websocket client.
+
+

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.21.3
+  changelogEntry:
+    - summary: |
+        Fix an issue where the websocket connect method did not correctly yield the websocket client.
+      type: fix
+  createdAt: '2025-06-04'
+  irVersion: 58
+
 - version: 4.21.2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/external_dependencies/websockets.py
+++ b/generators/python/src/fern_python/external_dependencies/websockets.py
@@ -1,5 +1,6 @@
 from fern_python.codegen import AST
-from fern_python.codegen.ast.dependency.dependency import DependencyCompatibility
+from fern_python.codegen.ast.dependency.dependency import \
+    DependencyCompatibility
 
 WEBSOCKETS_MODULE = AST.Module.external(
     module_path=("websockets",),
@@ -69,27 +70,25 @@ class Websockets:
     @staticmethod
     def async_connect(url: str, headers: str) -> AST.Expression:
         def write(writer: AST.NodeWriter) -> None:
-            writer.write("async with ")
             writer.write_reference(
                 AST.Reference(
                     import_=AST.ReferenceImport(module=WEBSOCKETS_MODULE),
                     qualified_name_excluding_import=("connect",),
                 )
             )
-            writer.write(f"({url}, extra_headers={headers}) as protocol:")
+            writer.write(f"({url}, extra_headers={headers})")
 
         return AST.Expression(AST.CodeWriter(write))
 
     @staticmethod
     def sync_connect(url: str, headers: str) -> AST.Expression:
         def write(writer: AST.NodeWriter) -> None:
-            writer.write("with ")
             writer.write_reference(
                 AST.Reference(
                     import_=AST.ReferenceImport(module=WEBSOCKETS_SYNC_CLIENT_MODULE, alias="websockets_sync_client"),
                     qualified_name_excluding_import=("connect",),
                 )
             )
-            writer.write(f"({url}, additional_headers={headers}) as protocol:")
+            writer.write(f"({url}, additional_headers={headers})")
 
         return AST.Expression(AST.CodeWriter(write))


### PR DESCRIPTION
## Description
Previously, the connect method could break and yield:

```
async with websockets.connect(ws_url, extra_headers=headers) as protocol:yield AsyncSttSocketClient(websocket = protocol)
```

This fix ensures that we correctly construct the WithStatement and YieldStatement using our AST nodes.

## Changes Made
- Update the `with` and `yield` statement to correctly leverage our Python AST nodes.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

