### PR TITLE
fix(typescript): Bypass HTTP requests not matched by MSW predicates

### DIFF
--- a/fern/pages/changelogs/ts-sdk/2025-06-05.mdx
+++ b/fern/pages/changelogs/ts-sdk/2025-06-05.mdx
@@ -1,0 +1,6 @@
+## 1.3.1
+**`(fix):`** MSW is used for generated wire tests, but inadvertently also captures real HTTP request, for example in integration tests.
+When the HTTP request does not match any of the configured predicates, it would throw an error, including in the unrelated integration tests.
+In this version MSW is configured to bypass instead of throw an error when HTTP requests do not match the configured predicates.
+
+

--- a/generators/typescript/asIs/tests/mock-server/MockServerPool.ts
+++ b/generators/typescript/asIs/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error"
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.3.1
+  changelogEntry:
+    - summary: |
+        MSW is used for generated wire tests, but inadvertently also captures real HTTP request, for example in integration tests.
+        When the HTTP request does not match any of the configured predicates, it would throw an error, including in the unrelated integration tests.
+        In this version MSW is configured to bypass instead of throw an error when HTTP requests do not match the configured predicates.
+      type: fix
+  createdAt: '2025-06-05'
+  irVersion: 58
+
 - version: 1.3.0
   changelogEntry:
     - summary: Add support for generating the full project when using the filesystem output mode.

--- a/seed/ts-sdk/accept-header/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/accept-header/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/alias-extends/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/alias-extends/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/alias/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/alias/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/any-auth/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/any-auth/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/api-wide-base-path/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/audiences/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/auth-environment-variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/auth-environment-variables/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
@@ -216,7 +216,7 @@ export class BasicAuth {
         }
 
         return core.BasicAuth.toAuthorizationHeader({
-            username,
+            username: username,
             password: accessToken,
         });
     }

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/basic-auth/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/basic-auth/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/circular-references-advanced/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/circular-references/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/circular-references/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/content-type/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/content-type/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/cross-package-type-names/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/cross-package-type-names/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/custom-auth/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/custom-auth/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/enum/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/enum/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/error-property/union-utils/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/examples/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/bigint/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/bundle/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/bundle/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/custom-package-json/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/dev-dependencies/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/jsr/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/extends/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/extends/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/extra-properties/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/extra-properties/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/file-download/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/file-upload/inline/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/file-upload/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/folders/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/folders/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/http-head/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/http-head/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/idempotency-headers/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/imdb/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/imdb/noScripts/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error"
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/imdb/omit-undefined/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/license/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/license/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/literal/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/literal/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/mixed-file-directory/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/multi-line-docs/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/multi-url-environment/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/no-environment/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/no-environment/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/nullable/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/nullable/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/oauth-client-credentials/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/object/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/object/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/objects-with-imports/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/optional/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/optional/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/package-yml/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/package-yml/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/pagination-custom/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/pagination-custom/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/pagination/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/pagination/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/path-parameters/default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/default/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/plain-text/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/plain-text/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/public-object/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/public-object/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/query-parameters/serde-layer-query/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/reserved-keywords/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/response-property/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/response-property/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/server-sent-event-examples/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/server-sent-events/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/server-sent-events/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/simple-fhir/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-fhir/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/single-url-environment-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/single-url-environment-no-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/streaming-parameter/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/streaming/no-serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/trace/exhaustive/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/trace/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/trace/serde-trace/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/serde-trace/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/ts-express-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/ts-inline-types/inline/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/unions/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unions/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/unknown/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/validation/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/validation/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/variables/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/version-no-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/version-no-default/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/version/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/version/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/websocket/websocket-base/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket/websocket-base/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/websocket/websocket-serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket/websocket-serde/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {

--- a/seed/ts-sdk/websocket/websocket-with-serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket/websocket-with-serde/tests/mock-server/MockServerPool.ts
@@ -76,9 +76,8 @@ class MockServerPool {
     }
 
     public listen(): void {
-        mswServer.listen({
-            onUnhandledRequest: "error",
-        });
+        const onUnhandledRequest = process.env.LOG_LEVEL === "debug" ? "warn" : "bypass";
+        mswServer.listen({ onUnhandledRequest });
 
         if (process.env.LOG_LEVEL === "debug") {
             mswServer.events.on("request:start", async ({ request, requestId }) => {


### PR DESCRIPTION
## Description
Bypass HTTP requests not matched by MSW predicates; otherwise, HTTP requests would be captured and an error thrown for hand-written integration tests.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

