### PR TITLE
feat(python): Add support for HEAD method endpoints

### DIFF
--- a/fern/pages/changelogs/python-sdk/2025-06-05.mdx
+++ b/fern/pages/changelogs/python-sdk/2025-06-05.mdx
@@ -1,0 +1,4 @@
+## 4.21.4
+**`(feat):`** Add support for HEAD HTTP method in the generated client.
+
+

--- a/generators/python/core_utilities/shared/force_multipart.py
+++ b/generators/python/core_utilities/shared/force_multipart.py
@@ -1,12 +1,13 @@
 class ForceMultipartDict(dict):
     """
     A dictionary subclass that always evaluates to True in boolean contexts.
-    
+
     This is used to force multipart/form-data encoding in HTTP requests even when
     the dictionary is empty, which would normally evaluate to False.
     """
+
     def __bool__(self):
         return True
 
 
-FORCE_MULTIPART = ForceMultipartDict() 
+FORCE_MULTIPART = ForceMultipartDict()

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -8,13 +8,13 @@ from contextlib import asynccontextmanager, contextmanager
 from random import random
 
 import httpx
-from httpx._types import RequestFiles
 from .file import File, convert_file_dict_to_httpx_tuples
 from .force_multipart import FORCE_MULTIPART
 from .jsonable_encoder import jsonable_encoder
 from .query_encoder import encode_query
 from .remove_none_from_dict import remove_none_from_dict
 from .request_options import RequestOptions
+from httpx._types import RequestFiles
 
 INITIAL_RETRY_DELAY_SECONDS = 0.5
 MAX_RETRY_DELAY_SECONDS = 10
@@ -199,7 +199,7 @@ class HttpClient:
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
-        request_files: typing.Optional[RequestFiles] =  (
+        request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
             if (files is not None and files is not omit and isinstance(files, dict))
             else None
@@ -294,7 +294,7 @@ class HttpClient:
             else self.base_timeout()
         )
 
-        request_files: typing.Optional[RequestFiles] =  (
+        request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
             if (files is not None and files is not omit and isinstance(files, dict))
             else None
@@ -395,7 +395,7 @@ class AsyncHttpClient:
             else self.base_timeout()
         )
 
-        request_files: typing.Optional[RequestFiles] =  (
+        request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
             if (files is not None and files is not omit and isinstance(files, dict))
             else None
@@ -492,7 +492,7 @@ class AsyncHttpClient:
             else self.base_timeout()
         )
 
-        request_files: typing.Optional[RequestFiles] =  (
+        request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
             if (files is not None and files is not omit and isinstance(files, dict))
             else None

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.21.4
+  changelogEntry:
+    - summary: |
+        Add support for HEAD HTTP method in the generated client.
+      type: feat
+  createdAt: '2025-06-05'
+  irVersion: 58
+
 - version: 4.21.3
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -39,9 +39,9 @@ class AbstractGenerator(ABC):
             ),
             github=lambda github_output_mode: self._get_github_publish_config(generator_config, github_output_mode),
         )
-        if ir.publish_config is not None: 
+        if ir.publish_config is not None:
             ir_publish_config = ir.publish_config.get_as_union()
-            if ir_publish_config.type == "filesystem" and ir_publish_config.generate_full_project: 
+            if ir_publish_config.type == "filesystem" and ir_publish_config.generate_full_project:
                 project_config = ProjectConfig(package_name=generator_config.organization, package_version="0.0.0")
         maybe_github_output_mode = generator_config.output.mode.visit(
             download_files=lambda: None,

--- a/generators/python/src/fern_python/external_dependencies/websockets.py
+++ b/generators/python/src/fern_python/external_dependencies/websockets.py
@@ -1,6 +1,5 @@
 from fern_python.codegen import AST
-from fern_python.codegen.ast.dependency.dependency import \
-    DependencyCompatibility
+from fern_python.codegen.ast.dependency.dependency import DependencyCompatibility
 
 WEBSOCKETS_MODULE = AST.Module.external(
     module_path=("websockets",),

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -430,23 +430,25 @@ class EndpointResponseCodeWriter:
             return "aiter_bytes"
         else:
             return "iter_bytes"
-    
+
     def is_json_response_optional(self, response: ir_types.JsonResponse) -> bool:
         return response.visit(
             response=lambda response: self._context.resolved_schema_is_optional_or_unknown(response.response_body_type),
-            nested_property_as_response=lambda response: self._context.resolved_schema_is_optional_or_unknown(response.response_body_type)
+            nested_property_as_response=lambda response: self._context.resolved_schema_is_optional_or_unknown(
+                response.response_body_type
+            ),
         )
 
     def _write_status_code_discriminated_response_handler(self, *, writer: AST.NodeWriter) -> None:
         def handle_endpoint_response(writer: AST.NodeWriter) -> None:
             if self._response is not None and self._response.body is not None:
                 is_optional = self._response.body.visit(
-                    json= lambda json_response: self.is_json_response_optional(json_response),
-                    file_download = lambda _: False,
-                    text= lambda _: False,
-                    bytes= lambda _: False,
-                    stream_parameter= lambda _: False,
-                    streaming= lambda _: False,
+                    json=lambda json_response: self.is_json_response_optional(json_response),
+                    file_download=lambda _: False,
+                    text=lambda _: False,
+                    bytes=lambda _: False,
+                    stream_parameter=lambda _: False,
+                    streaming=lambda _: False,
                 )
                 if is_optional:
                     writer.write_line(f"if {RESPONSE_VARIABLE} is None or not {RESPONSE_VARIABLE}.text.strip():")

--- a/generators/python/src/fern_python/generators/sdk/client_generator/websocket_connect_method_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/websocket_connect_method_generator.py
@@ -1,21 +1,19 @@
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-import fern.ir.resources as ir_types
-
+from ..core_utilities.client_wrapper_generator import ClientWrapperGenerator
 from fern_python.codegen import AST
 from fern_python.codegen.ast.ast_node.node_writer import NodeWriter
 from fern_python.external_dependencies import Contextlib, HttpX, Websockets
-from fern_python.generators.pydantic_model.model_utilities import \
-    can_tr_be_fern_model
-from fern_python.generators.sdk.client_generator.endpoint_function_generator import \
-    EndpointFunctionGenerator
-from fern_python.generators.sdk.context.sdk_generator_context import \
-    SdkGeneratorContext
+from fern_python.generators.pydantic_model.model_utilities import can_tr_be_fern_model
+from fern_python.generators.sdk.client_generator.endpoint_function_generator import EndpointFunctionGenerator
+from fern_python.generators.sdk.context.sdk_generator_context import SdkGeneratorContext
 from fern_python.generators.sdk.environment_generators.multiple_base_urls_environment_generator import (
-    get_base_url, get_base_url_property_name)
+    get_base_url,
+    get_base_url_property_name,
+)
 
-from ..core_utilities.client_wrapper_generator import ClientWrapperGenerator
+import fern.ir.resources as ir_types
 
 HTTPX_PRIMITIVE_DATA_TYPES = set(
     [
@@ -304,7 +302,10 @@ class WebsocketConnectMethodGenerator:
                 body = [
                     AST.WithStatement(
                         context_managers=[
-                            AST.WithContextManager(expression=Websockets.async_connect(url=self.WS_URL_VARIABLE, headers="headers"), as_variable="protocol")
+                            AST.WithContextManager(
+                                expression=Websockets.async_connect(url=self.WS_URL_VARIABLE, headers="headers"),
+                                as_variable="protocol",
+                            )
                         ],
                         body=[
                             AST.YieldStatement(
@@ -321,7 +322,10 @@ class WebsocketConnectMethodGenerator:
                 body = [
                     AST.WithStatement(
                         context_managers=[
-                            AST.WithContextManager(expression=Websockets.sync_connect(url=self.WS_URL_VARIABLE, headers="headers"), as_variable="protocol")
+                            AST.WithContextManager(
+                                expression=Websockets.sync_connect(url=self.WS_URL_VARIABLE, headers="headers"),
+                                as_variable="protocol",
+                            )
                         ],
                         body=[
                             AST.YieldStatement(

--- a/generators/python/src/fern_python/generators/sdk/context/sdk_generator_context.py
+++ b/generators/python/src/fern_python/generators/sdk/context/sdk_generator_context.py
@@ -53,7 +53,10 @@ class SdkGeneratorContext(ABC):
 
         # This should be replaced with `hasPaginatedEndpoints` in the IR, but that's on IR44, not 39, which is what Python's on
         _has_paginated_endpoints = any(
-            map(lambda service: any(map(lambda ep: ep.pagination is not None, service.endpoints)), ir.services.values())
+            map(
+                lambda service: any(map(lambda ep: ep.pagination is not None, service.endpoints)),
+                ir.services.values(),
+            )
         )
         self.core_utilities = CoreUtilities(
             has_paginated_endpoints=_has_paginated_endpoints,
@@ -196,3 +199,6 @@ class SdkGeneratorContext(ABC):
 
     @abstractmethod
     def unwrap_optional_type_reference(self, type_reference: ir_types.TypeReference) -> ir_types.TypeReference: ...
+
+    @abstractmethod
+    def get_head_method_return_type(self) -> AST.TypeHint: ...

--- a/generators/python/src/fern_python/generators/sdk/context/sdk_generator_context_impl.py
+++ b/generators/python/src/fern_python/generators/sdk/context/sdk_generator_context_impl.py
@@ -76,7 +76,8 @@ class SdkGeneratorContextImpl(SdkGeneratorContext):
             skip_resources_module=custom_config.improved_imports
         )
         self._environments_enum_declaration_referencer = EnvironmentsEnumDeclarationReferencer(
-            client_class_name=exported_client_class_name, skip_resources_module=custom_config.improved_imports
+            client_class_name=exported_client_class_name,
+            skip_resources_module=custom_config.improved_imports,
         )
         self._subpackage_client_declaration_referencer = SubpackageClientDeclarationReferencer(
             skip_resources_module=custom_config.improved_imports
@@ -187,7 +188,9 @@ class SdkGeneratorContextImpl(SdkGeneratorContext):
     def get_raw_client_class_reference_for_root_client(self) -> AST.ClassReference:
         return self._root_generated_raw_client_declaration_referencer.get_class_reference(name=None, as_request=False)
 
-    def get_async_raw_client_class_reference_for_root_client(self) -> AST.ClassReference:
+    def get_async_raw_client_class_reference_for_root_client(
+        self,
+    ) -> AST.ClassReference:
         return self._root_generated_async_raw_client_declaration_referencer.get_class_reference(
             name=None, as_request=False
         )
@@ -313,7 +316,9 @@ class SdkGeneratorContextImpl(SdkGeneratorContext):
 
     def resolved_schema_is_optional_or_unknown(self, reference: ir_types.TypeReference) -> bool:
         reference_union = reference.get_as_union()
-        while reference_union.type == "container" or reference_union.type == "named" or reference_union.type == "unknown":
+        while (
+            reference_union.type == "container" or reference_union.type == "named" or reference_union.type == "unknown"
+        ):
             if reference_union.type == "unknown":
                 return True
             elif reference_union.type == "container":
@@ -332,3 +337,6 @@ class SdkGeneratorContextImpl(SdkGeneratorContext):
                 else:
                     break
         return False
+
+    def get_head_method_return_type(self) -> AST.TypeHint:
+        return AST.TypeHint.dict(AST.TypeHint.str_(), AST.TypeHint.str_())

--- a/generators/python/src/fern_python/snippet/snippet_registry.py
+++ b/generators/python/src/fern_python/snippet/snippet_registry.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 from fern_python.codegen import AST
 from fern_python.snippet.snippet_endpoint_expression import EndpointExpression
 from fern_python.source_file_factory import SourceFileFactory
-from typing_extensions import assert_never
 
 import fern.generator_exec as generator_exec
 import fern.ir.resources as ir_types

--- a/seed/python-sdk/http-head/src/seed/user/client.py
+++ b/seed/python-sdk/http-head/src/seed/user/client.py
@@ -23,7 +23,7 @@ class UserClient:
         """
         return self._raw_client
 
-    def head(self, *, request_options: typing.Optional[RequestOptions] = None) -> None:
+    def head(self, *, request_options: typing.Optional[RequestOptions] = None) -> typing.Dict[str, str]:
         """
         Parameters
         ----------
@@ -44,7 +44,7 @@ class UserClient:
         client.user.head()
         """
         _response = self._raw_client.head(request_options=request_options)
-        return _response.data
+        return _response.headers
 
     def list(self, *, limit: int, request_options: typing.Optional[RequestOptions] = None) -> typing.List[User]:
         """
@@ -89,7 +89,7 @@ class AsyncUserClient:
         """
         return self._raw_client
 
-    async def head(self, *, request_options: typing.Optional[RequestOptions] = None) -> None:
+    async def head(self, *, request_options: typing.Optional[RequestOptions] = None) -> typing.Dict[str, str]:
         """
         Parameters
         ----------
@@ -118,7 +118,7 @@ class AsyncUserClient:
         asyncio.run(main())
         """
         _response = await self._raw_client.head(request_options=request_options)
-        return _response.data
+        return _response.headers
 
     async def list(self, *, limit: int, request_options: typing.Optional[RequestOptions] = None) -> typing.List[User]:
         """

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -323,6 +323,7 @@ allowedFailures:
   - exhaustive:pydantic-v1-with-utils
   - oauth-client-credentials-custom
   - pagination-custom
+  - public-object
   - response-property
   - simple-fhir
   - streaming-parameter


### PR DESCRIPTION
This adds support for HTTP `HEAD` method in the Python SDK. With this, any `HEAD` endpoint simply returns a `Dict[str, str]`, which represents the set of response headers. This is equivalent to the data type used in the raw client response.

Note that this also reformats a variety of the Python files since this was out-of-sync with the `pre-commit` hook.