### PR TITLE
chore(cli): Correctly filter audience-specific websocket channels when constructing the filtered IR.

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-05.mdx
+++ b/fern/pages/changelogs/cli/2025-06-05.mdx
@@ -1,3 +1,7 @@
+## 0.63.36
+**`(feat):`** Add `openapi-parser-v3` to the docs config upon initialization.
+
+
 ## 0.63.35
 **`(fix):`** Also add referenced parameter types to the audience-filtered IR.
 

--- a/fern/pages/changelogs/cli/2025-06-06.mdx
+++ b/fern/pages/changelogs/cli/2025-06-06.mdx
@@ -1,0 +1,4 @@
+## 0.63.37
+**`(fix):`** Correctly filter audience-specific websocket channels when constructing the filtered IR.
+
+

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Correctly filter audience-specific websocket channels when constructing the filtered IR.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-06"
+  version: 0.63.37
+
+- changelogEntry:
+    - summary: |
         Add `openapi-parser-v3` to the docs config upon initialization.
       type: feat
   irVersion: 58

--- a/packages/cli/generation/ir-generator/src/PackageTreeGenerator.ts
+++ b/packages/cli/generation/ir-generator/src/PackageTreeGenerator.ts
@@ -109,6 +109,12 @@ export class PackageTreeGenerator {
                                     ? subpackage.service
                                     : undefined
                                 : undefined,
+                        websocket:
+                            subpackage.websocket != null
+                                ? filteredIr.hasChannel(subpackage.websocket)
+                                    ? subpackage.websocket
+                                    : undefined
+                                : undefined,
                         subpackages: subpackage.subpackages.filter((subpackageId) =>
                             filteredIr.hasSubpackageId(subpackageId)
                         )

--- a/packages/commons/ir-utils/src/filtered-ir/FilteredIr.ts
+++ b/packages/commons/ir-utils/src/filtered-ir/FilteredIr.ts
@@ -26,7 +26,7 @@ export interface FilteredIr {
     hasRequestProperty(endpoint: string, property: string): boolean;
     hasQueryParameter(endpoint: string, parameter: string): boolean;
     hasSubpackageId(subpackageId: string): boolean;
-    hasChannel(channel: WebSocketChannel): boolean;
+    hasChannel(channelId: WebSocketChannelId): boolean;
 }
 
 export class FilteredIrImpl implements FilteredIr {
@@ -161,9 +161,9 @@ export class FilteredIrImpl implements FilteredIr {
         return true;
     }
 
-    public hasChannel(channel: WebSocketChannel): boolean {
-        if (channel.name.originalName) {
-            return this.channels.has(channel.name.originalName);
+    public hasChannel(channelId: WebSocketChannelId): boolean {
+        if (channelId) {
+            return this.channels.has(channelId);
         }
         return true;
     }

--- a/packages/commons/ir-utils/src/filtered-ir/filterIntermediateRepresentationForAudiences.ts
+++ b/packages/commons/ir-utils/src/filtered-ir/filterIntermediateRepresentationForAudiences.ts
@@ -69,6 +69,23 @@ export function filterIntermediateRepresentationForAudiences(
             return [webhookGroupId, filteredWebhooks];
         })
     );
+    const filteredChannels =
+        intermediateRepresentation.websocketChannels != null
+            ? Object.fromEntries(
+                  Object.entries(intermediateRepresentation.websocketChannels)
+                      .filter(([channelId]) => {
+                          return filteredIr.hasChannel(channelId);
+                      })
+                      .map(([channelId, channel]) => {
+                          return [
+                              channelId,
+                              {
+                                  ...channel
+                              }
+                          ];
+                      })
+              )
+            : {};
 
     const filteredEnvironmentsConfig = intermediateRepresentation.environments;
     if (filteredEnvironmentsConfig) {
@@ -144,6 +161,7 @@ export function filterIntermediateRepresentationForAudiences(
                     })
             })
         ),
+        websocketChannels: filteredChannels,
         webhookGroups: filteredWebhookGroups,
         serviceTypeReferenceInfo: filterServiceTypeReferenceInfoForAudiences(
             intermediateRepresentation.serviceTypeReferenceInfo,


### PR DESCRIPTION
## Description
Add support for filtering channels by audience when constructing the filteredIr and the generated PackageTree.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

