### PR TITLE
feat(java): Add support for HEAD methods

### DIFF
--- a/fern/pages/changelogs/java-sdk/2025-06-06.mdx
+++ b/fern/pages/changelogs/java-sdk/2025-06-06.mdx
@@ -1,0 +1,4 @@
+## 2.38.0
+**`(feat):`** Add support for HEAD method endpoints.
+
+

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractDelegatingHttpEndpointMethodSpecs.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractDelegatingHttpEndpointMethodSpecs.java
@@ -1,5 +1,7 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
+import com.fern.ir.model.http.HttpMethod;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import java.util.Objects;
@@ -17,6 +19,8 @@ public abstract class AbstractDelegatingHttpEndpointMethodSpecs implements HttpE
         this.rawClientName = rawClientName;
         this.bodyGetterName = bodyGetterName;
     }
+
+    public abstract HttpEndpoint getHttpEndpoint();
 
     public abstract MethodSpec getNonRequestOptionsMethodSpec();
 
@@ -39,5 +43,9 @@ public abstract class AbstractDelegatingHttpEndpointMethodSpecs implements HttpE
         }
         argString.append(")");
         return argString.toString();
+    }
+
+    protected boolean isHeadMethod() {
+        return getHttpEndpoint().getMethod().equals(HttpMethod.HEAD);
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpEndpointMethodSpecFactory.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpEndpointMethodSpecFactory.java
@@ -100,6 +100,10 @@ public abstract class AbstractHttpEndpointMethodSpecFactory {
 
     public abstract HttpEndpointMethodSpecsFactory httpEndpointMethodSpecsFactory();
 
+    public HttpEndpoint getHttpEndpoint() {
+        return httpEndpoint;
+    }
+
     public HttpEndpointMethodSpecs create() {
         if (httpEndpoint.getSdkRequest().isPresent()) {
             return httpEndpoint.getSdkRequest().get().getShape().visit(new SdkRequestShape.Visitor<>() {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -161,6 +161,8 @@ public abstract class AbstractHttpResponseParserGenerator {
                     .getBody()
                     .get()
                     .visit(new SuccessResponseWriter(httpResponseBuilder, endpointMethodBuilder));
+        } else if (httpEndpoint.getMethod().equals(HttpMethod.HEAD)) {
+            endpointMethodBuilder.returns(getHeadMethodReturnType());
         } else {
             addNoBodySuccessResponse(httpResponseBuilder);
         }
@@ -1273,5 +1275,12 @@ public abstract class AbstractHttpResponseParserGenerator {
         public Void _visitUnknown(Object unknownType) {
             throw new RuntimeException("Unknown pagination type " + unknownType);
         }
+    }
+
+    private TypeName getHeadMethodReturnType() {
+        return ParameterizedTypeName.get(
+                ClassName.get(Map.class),
+                ClassName.get(String.class),
+                ParameterizedTypeName.get(ClassName.get(List.class), ClassName.get(String.class)));
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncDelegatingHttpEndpointMethodSpecs.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncDelegatingHttpEndpointMethodSpecs.java
@@ -1,6 +1,9 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
+import java.util.HashMap;
 import java.util.Optional;
 
 public final class AsyncDelegatingHttpEndpointMethodSpecs extends AbstractDelegatingHttpEndpointMethodSpecs {
@@ -10,83 +13,52 @@ public final class AsyncDelegatingHttpEndpointMethodSpecs extends AbstractDelega
     }
 
     @Override
+    public HttpEndpoint getHttpEndpoint() {
+        return httpEndpointMethodSpecs.getHttpEndpoint();
+    }
+
+    @Override
     public MethodSpec getNonRequestOptionsMethodSpec() {
-        MethodSpec methodSpec = httpEndpointMethodSpecs.getNonRequestOptionsMethodSpec();
-        return MethodSpec.methodBuilder(methodSpec.name)
-                .addJavadoc(methodSpec.javadoc)
-                .returns(methodSpec.returnType)
-                .addModifiers(methodSpec.modifiers)
-                .addParameters(methodSpec.parameters)
-                .addStatement(
-                        "return this.$L.$L" + paramString(methodSpec) + ".thenApply(response -> response.$L())",
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
-                .build();
+        return createAsyncMethodSpec(httpEndpointMethodSpecs.getNonRequestOptionsMethodSpec());
     }
 
     @Override
     public MethodSpec getRequestOptionsMethodSpec() {
-        MethodSpec methodSpec = httpEndpointMethodSpecs.getRequestOptionsMethodSpec();
+        return createAsyncMethodSpec(httpEndpointMethodSpecs.getRequestOptionsMethodSpec());
+    }
+
+    @Override
+    public Optional<MethodSpec> getNoRequestBodyMethodSpec() {
+        return httpEndpointMethodSpecs.getNoRequestBodyMethodSpec().map(this::createAsyncMethodSpec);
+    }
+
+    @Override
+    public Optional<MethodSpec> getByteArrayMethodSpec() {
+        return httpEndpointMethodSpecs.getByteArrayMethodSpec().map(this::createAsyncMethodSpec);
+    }
+
+    @Override
+    public Optional<MethodSpec> getNonRequestOptionsByteArrayMethodSpec() {
+        return httpEndpointMethodSpecs.getNonRequestOptionsByteArrayMethodSpec().map(this::createAsyncMethodSpec);
+    }
+
+    private MethodSpec createAsyncMethodSpec(MethodSpec methodSpec) {
         return MethodSpec.methodBuilder(methodSpec.name)
                 .addJavadoc(methodSpec.javadoc)
                 .returns(methodSpec.returnType)
                 .addModifiers(methodSpec.modifiers)
                 .addParameters(methodSpec.parameters)
                 .addStatement(
-                        "return this.$L.$L" + paramString(methodSpec) + ".thenApply(response -> response.$L())",
+                        "return this.$L.$L" + paramString(methodSpec) + ".thenApply(response -> $L)",
                         rawClientName,
                         methodSpec.name,
-                        bodyGetterName)
+                        getResponseMapper(methodSpec))
                 .build();
     }
 
-    @Override
-    public Optional<MethodSpec> getNoRequestBodyMethodSpec() {
-        return httpEndpointMethodSpecs.getNoRequestBodyMethodSpec().map(methodSpec -> MethodSpec.methodBuilder(
-                        methodSpec.name)
-                .addJavadoc(methodSpec.javadoc)
-                .returns(methodSpec.returnType)
-                .addModifiers(methodSpec.modifiers)
-                .addParameters(methodSpec.parameters)
-                .addStatement(
-                        "return this.$L.$L" + paramString(methodSpec) + ".thenApply(response -> response.$L())",
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
-                .build());
-    }
-
-    @Override
-    public Optional<MethodSpec> getByteArrayMethodSpec() {
-        return httpEndpointMethodSpecs.getByteArrayMethodSpec().map(methodSpec -> MethodSpec.methodBuilder(
-                        methodSpec.name)
-                .addJavadoc(methodSpec.javadoc)
-                .returns(methodSpec.returnType)
-                .addModifiers(methodSpec.modifiers)
-                .addParameters(methodSpec.parameters)
-                .addStatement(
-                        "return this.$L.$L" + paramString(methodSpec) + ".thenApply(response -> response.$L())",
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
-                .build());
-    }
-
-    @Override
-    public Optional<MethodSpec> getNonRequestOptionsByteArrayMethodSpec() {
-        return httpEndpointMethodSpecs
-                .getNonRequestOptionsByteArrayMethodSpec()
-                .map(methodSpec -> MethodSpec.methodBuilder(methodSpec.name)
-                        .addJavadoc(methodSpec.javadoc)
-                        .returns(methodSpec.returnType)
-                        .addModifiers(methodSpec.modifiers)
-                        .addParameters(methodSpec.parameters)
-                        .addStatement(
-                                "return this.$L.$L" + paramString(methodSpec) + ".thenApply(response -> response.$L())",
-                                rawClientName,
-                                methodSpec.name,
-                                bodyGetterName)
-                        .build());
+    private CodeBlock getResponseMapper(MethodSpec methodSpec) {
+        return isHeadMethod()
+                ? CodeBlock.of("new $T<>(response.headers())", HashMap.class)
+                : CodeBlock.of("response.$L()", bodyGetterName);
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpEndpointMethodSpecFactory.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpEndpointMethodSpecFactory.java
@@ -63,6 +63,6 @@ public class AsyncHttpEndpointMethodSpecFactory extends AbstractHttpEndpointMeth
 
     @Override
     public HttpEndpointMethodSpecsFactory httpEndpointMethodSpecsFactory() {
-        return new AsyncHttpEndpointMethodSpecsFactory();
+        return new AsyncHttpEndpointMethodSpecsFactory(getHttpEndpoint());
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpEndpointMethodSpecsFactory.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpEndpointMethodSpecsFactory.java
@@ -1,9 +1,17 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
 import com.fern.java.utils.CompletableFutureUtils;
 import com.squareup.javapoet.MethodSpec;
 
 public class AsyncHttpEndpointMethodSpecsFactory implements HttpEndpointMethodSpecsFactory {
+
+    private final HttpEndpoint httpEndpoint;
+
+    public AsyncHttpEndpointMethodSpecsFactory(HttpEndpoint httpEndpoint) {
+        this.httpEndpoint = httpEndpoint;
+    }
+
     @Override
     public HttpEndpointMethodSpecs create(
             MethodSpec requestOptionsMethodSpec,
@@ -12,6 +20,7 @@ public class AsyncHttpEndpointMethodSpecsFactory implements HttpEndpointMethodSp
             MethodSpec byteArrayMethodSpec,
             MethodSpec nonRequestOptionsByteArrayMethodSpec) {
         return new DefaultHttpEndpointMethodSpecs(
+                httpEndpoint,
                 wrapReturnTypeInCompletableFuture(requestOptionsMethodSpec),
                 wrapReturnTypeInCompletableFuture(nonRequestOptionsMethodSpec),
                 wrapReturnTypeInCompletableFuture(noRequestBodyMethodSpec),

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/DefaultHttpEndpointMethodSpecs.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/DefaultHttpEndpointMethodSpecs.java
@@ -16,11 +16,13 @@
 
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
 import com.squareup.javapoet.MethodSpec;
 import java.util.Optional;
 
 public final class DefaultHttpEndpointMethodSpecs implements HttpEndpointMethodSpecs {
 
+    private final HttpEndpoint httpEndpoint;
     private final MethodSpec nonRequestOptionsMethodSpec;
     private final MethodSpec requestOptionsMethodSpec;
     private final MethodSpec noRequestBodyMethodSpec;
@@ -28,16 +30,23 @@ public final class DefaultHttpEndpointMethodSpecs implements HttpEndpointMethodS
     private final MethodSpec nonRequestOptionsByteArrayMethodSpec;
 
     public DefaultHttpEndpointMethodSpecs(
+            HttpEndpoint httpEndpoint,
             MethodSpec requestOptionsMethodSpec,
             MethodSpec nonRequestOptionsMethodSpec,
             MethodSpec noRequestBodyMethodSpec,
             MethodSpec byteArrayMethodSpec,
             MethodSpec nonRequestOptionsByteArrayMethodSpec) {
+        this.httpEndpoint = httpEndpoint;
         this.nonRequestOptionsMethodSpec = nonRequestOptionsMethodSpec;
         this.requestOptionsMethodSpec = requestOptionsMethodSpec;
         this.noRequestBodyMethodSpec = noRequestBodyMethodSpec;
         this.byteArrayMethodSpec = byteArrayMethodSpec;
         this.nonRequestOptionsByteArrayMethodSpec = nonRequestOptionsByteArrayMethodSpec;
+    }
+
+    @Override
+    public HttpEndpoint getHttpEndpoint() {
+        return httpEndpoint;
     }
 
     @Override

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/HttpEndpointMethodSpecs.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/HttpEndpointMethodSpecs.java
@@ -1,9 +1,12 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
 import com.squareup.javapoet.MethodSpec;
 import java.util.Optional;
 
 public interface HttpEndpointMethodSpecs {
+    HttpEndpoint getHttpEndpoint();
+
     MethodSpec getNonRequestOptionsMethodSpec();
 
     MethodSpec getRequestOptionsMethodSpec();

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/RawHttpEndpointMethodSpecs.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/RawHttpEndpointMethodSpecs.java
@@ -1,5 +1,7 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
+import com.fern.ir.model.http.HttpMethod;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
@@ -17,6 +19,11 @@ public final class RawHttpEndpointMethodSpecs implements HttpEndpointMethodSpecs
             HttpEndpointMethodSpecs httpEndpointMethodSpecs, ClassName rawHttpResponseClassName) {
         this.httpEndpointMethodSpecs = httpEndpointMethodSpecs;
         this.rawHttpResponseClassName = rawHttpResponseClassName;
+    }
+
+    @Override
+    public HttpEndpoint getHttpEndpoint() {
+        return httpEndpointMethodSpecs.getHttpEndpoint();
     }
 
     @Override
@@ -62,11 +69,15 @@ public final class RawHttpEndpointMethodSpecs implements HttpEndpointMethodSpecs
         if (rawTypeName instanceof ParameterizedTypeName
                 && ((ParameterizedTypeName) rawTypeName).rawType.equals(ClassName.get(CompletableFuture.class))) {
             TypeName typeArgument = Objects.requireNonNull(((ParameterizedTypeName) rawTypeName).typeArguments.get(0));
+            if (getHttpEndpoint().getMethod().equals(HttpMethod.HEAD)) {
+                return ParameterizedTypeName.get(
+                        ClassName.get(CompletableFuture.class),
+                        ParameterizedTypeName.get(rawHttpResponseClassName, ClassName.get(Void.class)));
+            }
             return ParameterizedTypeName.get(
                     ClassName.get(CompletableFuture.class),
                     ParameterizedTypeName.get(rawHttpResponseClassName, typeArgument));
         }
-
         return ParameterizedTypeName.get(
                 rawHttpResponseClassName,
                 rawTypeName.isPrimitive() || rawTypeName.equals(TypeName.VOID) ? rawTypeName.box() : rawTypeName);

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncDelegatingHttpEndpointMethodSpecs.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncDelegatingHttpEndpointMethodSpecs.java
@@ -1,7 +1,10 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
+import java.util.HashMap;
 import java.util.Optional;
 
 public final class SyncDelegatingHttpEndpointMethodSpecs extends AbstractDelegatingHttpEndpointMethodSpecs {
@@ -11,87 +14,59 @@ public final class SyncDelegatingHttpEndpointMethodSpecs extends AbstractDelegat
     }
 
     @Override
+    public HttpEndpoint getHttpEndpoint() {
+        return httpEndpointMethodSpecs.getHttpEndpoint();
+    }
+
+    @Override
     public MethodSpec getNonRequestOptionsMethodSpec() {
-        MethodSpec methodSpec = httpEndpointMethodSpecs.getNonRequestOptionsMethodSpec();
-        return MethodSpec.methodBuilder(methodSpec.name)
-                .addJavadoc(methodSpec.javadoc)
-                .returns(methodSpec.returnType)
-                .addModifiers(methodSpec.modifiers)
-                .addParameters(methodSpec.parameters)
-                .addStatement(
-                        returnString(methodSpec.returnType, "this.$L.$L" + paramString(methodSpec) + ".$L()"),
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
-                .build();
+        return createSyncMethodSpec(httpEndpointMethodSpecs.getNonRequestOptionsMethodSpec());
     }
 
     @Override
     public MethodSpec getRequestOptionsMethodSpec() {
-        MethodSpec methodSpec = httpEndpointMethodSpecs.getRequestOptionsMethodSpec();
+        return createSyncMethodSpec(httpEndpointMethodSpecs.getRequestOptionsMethodSpec());
+    }
+
+    @Override
+    public Optional<MethodSpec> getNoRequestBodyMethodSpec() {
+        return httpEndpointMethodSpecs.getNoRequestBodyMethodSpec().map(this::createSyncMethodSpec);
+    }
+
+    @Override
+    public Optional<MethodSpec> getByteArrayMethodSpec() {
+        return httpEndpointMethodSpecs.getByteArrayMethodSpec().map(this::createSyncMethodSpec);
+    }
+
+    @Override
+    public Optional<MethodSpec> getNonRequestOptionsByteArrayMethodSpec() {
+        return httpEndpointMethodSpecs.getNonRequestOptionsByteArrayMethodSpec().map(this::createSyncMethodSpec);
+    }
+
+    private MethodSpec createSyncMethodSpec(MethodSpec methodSpec) {
         return MethodSpec.methodBuilder(methodSpec.name)
                 .addJavadoc(methodSpec.javadoc)
                 .returns(methodSpec.returnType)
                 .addModifiers(methodSpec.modifiers)
                 .addParameters(methodSpec.parameters)
-                .addStatement(
-                        returnString(methodSpec.returnType, "this.$L.$L" + paramString(methodSpec) + ".$L()"),
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
+                .addCode(returnCodeBlock(methodSpec.returnType, methodSpec))
                 .build();
     }
 
-    @Override
-    public Optional<MethodSpec> getNoRequestBodyMethodSpec() {
-        return httpEndpointMethodSpecs.getNoRequestBodyMethodSpec().map(methodSpec -> MethodSpec.methodBuilder(
-                        methodSpec.name)
-                .addJavadoc(methodSpec.javadoc)
-                .returns(methodSpec.returnType)
-                .addModifiers(methodSpec.modifiers)
-                .addParameters(methodSpec.parameters)
-                .addStatement(
-                        returnString(methodSpec.returnType, "this.$L.$L" + paramString(methodSpec) + ".$L()"),
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
-                .build());
+    private CodeBlock returnCodeBlock(TypeName returnType, MethodSpec methodSpec) {
+        CodeBlock responseCall = CodeBlock.of("this.$L.$L" + paramString(methodSpec), rawClientName, methodSpec.name);
+        CodeBlock fullExpression = CodeBlock.builder()
+                .add(getResponseMapper(methodSpec, responseCall))
+                .build();
+
+        return returnType.equals(TypeName.VOID)
+                ? CodeBlock.of("$L;", fullExpression)
+                : CodeBlock.of("return $L;", fullExpression);
     }
 
-    @Override
-    public Optional<MethodSpec> getByteArrayMethodSpec() {
-        return httpEndpointMethodSpecs.getByteArrayMethodSpec().map(methodSpec -> MethodSpec.methodBuilder(
-                        methodSpec.name)
-                .addJavadoc(methodSpec.javadoc)
-                .returns(methodSpec.returnType)
-                .addModifiers(methodSpec.modifiers)
-                .addParameters(methodSpec.parameters)
-                .addStatement(
-                        returnString(methodSpec.returnType, "this.$L.$L" + paramString(methodSpec) + ".$L()"),
-                        rawClientName,
-                        methodSpec.name,
-                        bodyGetterName)
-                .build());
-    }
-
-    @Override
-    public Optional<MethodSpec> getNonRequestOptionsByteArrayMethodSpec() {
-        return httpEndpointMethodSpecs
-                .getNonRequestOptionsByteArrayMethodSpec()
-                .map(methodSpec -> MethodSpec.methodBuilder(methodSpec.name)
-                        .addJavadoc(methodSpec.javadoc)
-                        .returns(methodSpec.returnType)
-                        .addModifiers(methodSpec.modifiers)
-                        .addParameters(methodSpec.parameters)
-                        .addStatement(
-                                returnString(methodSpec.returnType, "this.$L.$L" + paramString(methodSpec) + ".$L()"),
-                                rawClientName,
-                                methodSpec.name,
-                                bodyGetterName)
-                        .build());
-    }
-
-    private String returnString(TypeName returnType, String valueString) {
-        return returnType.equals(TypeName.VOID) ? valueString : "return " + valueString;
+    private CodeBlock getResponseMapper(MethodSpec methodSpec, CodeBlock responseCall) {
+        return isHeadMethod()
+                ? CodeBlock.of("new $T<>($L.headers())", HashMap.class, responseCall)
+                : CodeBlock.of("$L.$L()", responseCall, bodyGetterName);
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpEndpointMethodSpecFactory.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpEndpointMethodSpecFactory.java
@@ -63,6 +63,6 @@ public class SyncHttpEndpointMethodSpecFactory extends AbstractHttpEndpointMetho
 
     @Override
     public HttpEndpointMethodSpecsFactory httpEndpointMethodSpecsFactory() {
-        return new SyncHttpEndpointMethodSpecsFactory();
+        return new SyncHttpEndpointMethodSpecsFactory(getHttpEndpoint());
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpEndpointMethodSpecsFactory.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpEndpointMethodSpecsFactory.java
@@ -1,8 +1,16 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fern.ir.model.http.HttpEndpoint;
 import com.squareup.javapoet.MethodSpec;
 
 public class SyncHttpEndpointMethodSpecsFactory implements HttpEndpointMethodSpecsFactory {
+
+    private final HttpEndpoint httpEndpoint;
+
+    public SyncHttpEndpointMethodSpecsFactory(HttpEndpoint httpEndpoint) {
+        this.httpEndpoint = httpEndpoint;
+    }
+
     @Override
     public HttpEndpointMethodSpecs create(
             MethodSpec requestOptionsMethodSpec,
@@ -11,6 +19,7 @@ public class SyncHttpEndpointMethodSpecsFactory implements HttpEndpointMethodSpe
             MethodSpec byteArrayMethodSpec,
             MethodSpec nonRequestOptionsByteArrayMethodSpec) {
         return new DefaultHttpEndpointMethodSpecs(
+                httpEndpoint,
                 requestOptionsMethodSpec,
                 nonRequestOptionsMethodSpec,
                 noRequestBodyMethodSpec,

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.38.0
+  changelogEntry:
+    - summary: |
+        Add support for HEAD method endpoints.
+      type: feat
+  createdAt: '2025-06-06'
+  irVersion: 58
 - version: 2.37.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/AsyncRawUserClient.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/AsyncRawUserClient.java
@@ -56,10 +56,7 @@ public class AsyncRawUserClient {
             @Override
             public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
                 try (ResponseBody responseBody = response.body()) {
-                    if (response.isSuccessful()) {
-                        future.complete(new SeedHttpHeadHttpResponse<>(null, response));
-                        return;
-                    }
+                    if (response.isSuccessful()) {}
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     future.completeExceptionally(new SeedHttpHeadApiException(
                             "Error with status code " + response.code(),

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/AsyncUserClient.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/AsyncUserClient.java
@@ -7,7 +7,9 @@ import com.seed.httpHead.core.ClientOptions;
 import com.seed.httpHead.core.RequestOptions;
 import com.seed.httpHead.resources.user.requests.ListUsersRequest;
 import com.seed.httpHead.resources.user.types.User;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class AsyncUserClient {
@@ -27,12 +29,12 @@ public class AsyncUserClient {
         return this.rawClient;
     }
 
-    public CompletableFuture<Void> head() {
-        return this.rawClient.head().thenApply(response -> response.body());
+    public CompletableFuture<Map<String, List<String>>> head() {
+        return this.rawClient.head().thenApply(response -> new HashMap<>(response.headers()));
     }
 
-    public CompletableFuture<Void> head(RequestOptions requestOptions) {
-        return this.rawClient.head(requestOptions).thenApply(response -> response.body());
+    public CompletableFuture<Map<String, List<String>>> head(RequestOptions requestOptions) {
+        return this.rawClient.head(requestOptions).thenApply(response -> new HashMap<>(response.headers()));
     }
 
     public CompletableFuture<List<User>> list(ListUsersRequest request) {

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/RawUserClient.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/RawUserClient.java
@@ -15,6 +15,7 @@ import com.seed.httpHead.resources.user.requests.ListUsersRequest;
 import com.seed.httpHead.resources.user.types.User;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -29,11 +30,11 @@ public class RawUserClient {
         this.clientOptions = clientOptions;
     }
 
-    public SeedHttpHeadHttpResponse<Void> head() {
+    public SeedHttpHeadHttpResponse<Map<String, List<String>>> head() {
         return head(null);
     }
 
-    public SeedHttpHeadHttpResponse<Void> head(RequestOptions requestOptions) {
+    public SeedHttpHeadHttpResponse<Map<String, List<String>>> head(RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("users")
@@ -49,9 +50,7 @@ public class RawUserClient {
         }
         try (Response response = client.newCall(okhttpRequest).execute()) {
             ResponseBody responseBody = response.body();
-            if (response.isSuccessful()) {
-                return new SeedHttpHeadHttpResponse<>(null, response);
-            }
+            if (response.isSuccessful()) {}
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             throw new SeedHttpHeadApiException(
                     "Error with status code " + response.code(),

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/UserClient.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/UserClient.java
@@ -7,7 +7,9 @@ import com.seed.httpHead.core.ClientOptions;
 import com.seed.httpHead.core.RequestOptions;
 import com.seed.httpHead.resources.user.requests.ListUsersRequest;
 import com.seed.httpHead.resources.user.types.User;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class UserClient {
     protected final ClientOptions clientOptions;
@@ -26,12 +28,12 @@ public class UserClient {
         return this.rawClient;
     }
 
-    public void head() {
-        this.rawClient.head().body();
+    public Map<String, List<String>> head() {
+        return new HashMap<>(this.rawClient.head().headers());
     }
 
-    public void head(RequestOptions requestOptions) {
-        this.rawClient.head(requestOptions).body();
+    public Map<String, List<String>> head(RequestOptions requestOptions) {
+        return new HashMap<>(this.rawClient.head(requestOptions).headers());
     }
 
     public List<User> list(ListUsersRequest request) {


### PR DESCRIPTION
This adds support for HTTP `HEAD` methods by adapting the non-raw client to surface the OkHttp response headers as a `Map<string, List<string>>`, which matches the interface already used by the generated `HttpResponse` class.