### PR TITLE
fix(cli): don't require discriminant field on the top-level and variant-level for JsonSchema conversion

### DIFF
--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_ContainerValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_ContainerValue.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -69,9 +66,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -123,9 +117,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_FieldValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_FieldValue.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -71,9 +68,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -124,9 +118,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_ObjectFieldValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_ObjectFieldValue.json
@@ -35,9 +35,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -89,9 +86,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references/type_ast_ContainerValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references/type_ast_ContainerValue.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -69,9 +66,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -123,9 +117,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references/type_ast_FieldValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references/type_ast_FieldValue.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -71,9 +68,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -124,9 +118,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_commons/types_Data.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_commons/types_Data.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_commons/types_EventInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_commons/types_EventInfo.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_BigEntity.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_BigEntity.json
@@ -330,9 +330,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -408,9 +405,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -475,9 +469,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -543,9 +534,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -592,9 +580,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Exception.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Exception.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Metadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Metadata.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Test.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Test.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/union_Animal.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/union_Animal.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "animal"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1.json
@@ -140,9 +140,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasListVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasListVariant.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasMapVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasMapVariant.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasSetVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasSetVariant.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UnionTypeWithAliasVariant.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/literal/type_inlined_DiscriminatedLiteral.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/literal/type_inlined_DiscriminatedLiteral.json
@@ -11,9 +11,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/mixed-case/type_service_Resource.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/mixed-case/type_service_Resource.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "resource_type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable/type_nullable_Metadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable/type_nullable_Metadata.json
@@ -87,9 +87,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable/type_nullable_Status.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable/type_nullable_Status.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable/type_nullable_User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable/type_nullable_User.json
@@ -115,9 +115,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_admin_Test.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_admin_Test.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_DebugKeyValuePairs.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_DebugKeyValuePairs.json
@@ -228,9 +228,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_DebugMapValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_DebugMapValue.json
@@ -211,9 +211,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_DebugVariableValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_DebugVariableValue.json
@@ -20,9 +20,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -420,9 +417,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_KeyValuePair.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_KeyValuePair.json
@@ -151,9 +151,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_ListType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_ListType.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_MapType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_MapType.json
@@ -33,9 +33,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_MapValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_MapValue.json
@@ -134,9 +134,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_TestCase.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_TestCase.json
@@ -154,9 +154,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_TestCaseWithExpectedResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_TestCaseWithExpectedResult.json
@@ -151,9 +151,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_VariableType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_VariableType.json
@@ -17,9 +17,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -164,9 +161,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_VariableValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_VariableValue.json
@@ -18,9 +18,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -334,9 +331,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_playlist_PlaylistIdNotFoundErrorBody.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_playlist_PlaylistIdNotFoundErrorBody.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemError.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemError.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "_type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemRequest.json
@@ -180,9 +180,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -387,9 +384,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -501,9 +495,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemResponse.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -54,9 +51,6 @@
           ]
         }
       },
-      "required": [
-        "_type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemDescription.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemDescription.json
@@ -150,9 +150,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -357,9 +354,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemDescriptionBoard.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemDescriptionBoard.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -192,9 +189,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemInfo.json
@@ -195,9 +195,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -402,9 +399,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -516,9 +510,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_VariableTypeAndName.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_VariableTypeAndName.json
@@ -33,9 +33,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ActualResult.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -201,9 +198,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -407,9 +401,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_CodeExecutionUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_CodeExecutionUpdate.json
@@ -18,9 +18,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -311,9 +308,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -496,9 +490,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -702,9 +693,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -752,9 +740,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -853,9 +838,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1020,9 +1002,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1170,9 +1149,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErrorInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErrorInfo.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErroredResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErroredResponse.json
@@ -50,9 +50,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ExceptionV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ExceptionV2.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GetSubmissionStateResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GetSubmissionStateResponse.json
@@ -177,9 +177,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -423,9 +420,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -492,9 +486,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -542,9 +533,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -627,9 +615,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -713,9 +698,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -781,9 +763,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -853,9 +832,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -974,9 +950,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GradedResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GradedResponse.json
@@ -158,9 +158,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -364,9 +361,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -414,9 +408,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GradedResponseV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GradedResponseV2.json
@@ -158,9 +158,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -364,9 +361,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -413,9 +407,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GradedTestCaseUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GradedTestCaseUpdate.json
@@ -154,9 +154,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -360,9 +357,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -409,9 +403,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestCause.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestCause.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestResponse.json
@@ -63,9 +63,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -213,9 +210,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_Scope.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_Scope.json
@@ -227,9 +227,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_StackFrame.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_StackFrame.json
@@ -235,9 +235,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_StackInformation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_StackInformation.json
@@ -234,9 +234,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionRequest.json
@@ -12,9 +12,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionResponse.json
@@ -13,9 +13,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -157,9 +154,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -342,9 +336,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -548,9 +539,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -598,9 +586,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -699,9 +684,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -863,9 +845,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1013,9 +992,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1089,9 +1065,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionStatusForTestCase.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionStatusForTestCase.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -202,9 +199,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -408,9 +402,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -458,9 +449,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -543,9 +531,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionStatusV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionStatusV2.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -103,9 +100,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -291,9 +285,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -497,9 +488,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -546,9 +534,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -619,9 +604,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -739,9 +721,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -829,9 +808,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1049,9 +1025,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1131,9 +1104,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1275,9 +1245,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1327,9 +1294,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1439,9 +1403,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1599,9 +1560,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionTypeState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionTypeState.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -201,9 +198,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -447,9 +441,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -516,9 +507,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -566,9 +554,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -651,9 +636,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -737,9 +719,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -805,9 +784,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -877,9 +853,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseGrade.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseGrade.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -204,9 +201,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -410,9 +404,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseNonHiddenGrade.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseNonHiddenGrade.json
@@ -171,9 +171,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -377,9 +374,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseResult.json
@@ -155,9 +155,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -361,9 +358,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -411,9 +405,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseResultWithStdout.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestCaseResultWithStdout.json
@@ -151,9 +151,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -357,9 +354,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -407,9 +401,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionState.json
@@ -168,9 +168,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -414,9 +411,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -483,9 +477,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -533,9 +524,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -618,9 +606,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -704,9 +689,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -772,9 +754,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatus.json
@@ -11,9 +11,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -101,9 +98,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -296,9 +290,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -502,9 +493,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -552,9 +540,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -637,9 +622,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -723,9 +705,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatusV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatusV2.json
@@ -67,9 +67,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -255,9 +252,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -461,9 +455,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -510,9 +501,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -583,9 +571,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -703,9 +688,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -793,9 +775,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1013,9 +992,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1095,9 +1071,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1239,9 +1212,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1291,9 +1261,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1403,9 +1370,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdate.json
@@ -57,9 +57,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -245,9 +242,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -451,9 +445,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -500,9 +491,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -573,9 +561,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdateInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdateInfo.json
@@ -13,9 +13,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -143,9 +140,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -331,9 +325,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -537,9 +528,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -586,9 +574,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponse.json
@@ -266,9 +266,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponseV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponseV2.json
@@ -286,9 +286,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPage.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPage.json
@@ -241,9 +241,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPageV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPageV2.json
@@ -257,9 +257,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TracedTestCase.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TracedTestCase.json
@@ -151,9 +151,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -357,9 +354,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -407,9 +401,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceRanResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceRanResponse.json
@@ -29,9 +29,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceRunDetails.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceRunDetails.json
@@ -41,9 +41,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionState.json
@@ -42,9 +42,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -111,9 +108,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -163,9 +157,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatus.json
@@ -12,9 +12,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -154,9 +151,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -223,9 +217,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatusV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatusV2.json
@@ -34,9 +34,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -104,9 +101,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -168,9 +162,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdate.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -106,9 +103,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -170,9 +164,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdateInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdateInfo.json
@@ -14,9 +14,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -145,9 +142,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -215,9 +209,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_AssertCorrectnessCheck.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_AssertCorrectnessCheck.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -72,9 +69,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_BasicCustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_BasicCustomFiles.json
@@ -47,9 +47,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -267,9 +264,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_BasicTestCaseTemplate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_BasicTestCaseTemplate.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CreateProblemRequestV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CreateProblemRequestV2.json
@@ -181,9 +181,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -388,9 +385,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -470,9 +464,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -690,9 +681,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -772,9 +760,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -887,9 +872,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -939,9 +921,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1054,9 +1033,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CustomFiles.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -82,9 +79,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -302,9 +296,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_DefaultProvidedFile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_DefaultProvidedFile.json
@@ -60,9 +60,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_FunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_FunctionSignature.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -97,9 +94,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetBasicSolutionFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetBasicSolutionFileRequest.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetFunctionSignatureRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetFunctionSignatureRequest.json
@@ -32,9 +32,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -192,9 +189,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseFileRequest.json
@@ -37,9 +37,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -103,9 +100,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -334,9 +328,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -386,9 +377,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -501,9 +489,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -675,9 +660,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseTemplateFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseTemplateFileRequest.json
@@ -27,9 +27,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -93,9 +90,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -324,9 +318,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -376,9 +367,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_LightweightProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_LightweightProblemInfoV2.json
@@ -48,9 +48,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionDefinition.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionSignature.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_Parameter.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_Parameter.json
@@ -40,9 +40,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_ProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_ProblemInfoV2.json
@@ -196,9 +196,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -403,9 +400,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -493,9 +487,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -713,9 +704,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -795,9 +783,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -939,9 +924,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -991,9 +973,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1106,9 +1085,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseFunction.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseFunction.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -76,9 +73,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -307,9 +301,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementation.json
@@ -28,9 +28,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -94,9 +91,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -325,9 +319,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -377,9 +368,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationDescription.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationDescription.json
@@ -27,9 +27,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationDescriptionBoard.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationDescriptionBoard.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationReference.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationReference.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -63,9 +60,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -129,9 +123,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -360,9 +351,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -412,9 +400,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseTemplate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseTemplate.json
@@ -35,9 +35,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -101,9 +98,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -332,9 +326,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -384,9 +375,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseV2.json
@@ -71,9 +71,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -137,9 +134,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -368,9 +362,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -420,9 +411,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -476,9 +464,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -650,9 +635,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseWithActualResultImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseWithActualResultImplementation.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -267,9 +264,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinition.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinitionThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinitionThatTakesActualResult.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignature.json
@@ -35,9 +35,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignatureThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignatureThatTakesActualResult.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_AssertCorrectnessCheck.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_AssertCorrectnessCheck.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -72,9 +69,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_BasicCustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_BasicCustomFiles.json
@@ -47,9 +47,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -267,9 +264,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_BasicTestCaseTemplate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_BasicTestCaseTemplate.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CreateProblemRequestV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CreateProblemRequestV2.json
@@ -181,9 +181,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -388,9 +385,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -470,9 +464,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -690,9 +681,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -772,9 +760,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -887,9 +872,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -939,9 +921,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1054,9 +1033,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CustomFiles.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -82,9 +79,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -302,9 +296,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_DefaultProvidedFile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_DefaultProvidedFile.json
@@ -60,9 +60,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_FunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_FunctionSignature.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -97,9 +94,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetBasicSolutionFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetBasicSolutionFileRequest.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetFunctionSignatureRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetFunctionSignatureRequest.json
@@ -32,9 +32,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -192,9 +189,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseFileRequest.json
@@ -37,9 +37,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -103,9 +100,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -334,9 +328,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -386,9 +377,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -501,9 +489,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -675,9 +660,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseTemplateFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseTemplateFileRequest.json
@@ -27,9 +27,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -93,9 +90,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -324,9 +318,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -376,9 +367,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_LightweightProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_LightweightProblemInfoV2.json
@@ -48,9 +48,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionDefinition.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionSignature.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_Parameter.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_Parameter.json
@@ -40,9 +40,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_ProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_ProblemInfoV2.json
@@ -196,9 +196,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -403,9 +400,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -493,9 +487,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -713,9 +704,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -795,9 +783,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -939,9 +924,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -991,9 +973,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -1106,9 +1085,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseFunction.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseFunction.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -76,9 +73,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -307,9 +301,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementation.json
@@ -28,9 +28,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -94,9 +91,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -325,9 +319,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -377,9 +368,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationDescription.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationDescription.json
@@ -27,9 +27,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationDescriptionBoard.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationDescriptionBoard.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationReference.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationReference.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {
@@ -63,9 +60,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -129,9 +123,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -360,9 +351,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -412,9 +400,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseTemplate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseTemplate.json
@@ -35,9 +35,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -101,9 +98,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -332,9 +326,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -384,9 +375,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseV2.json
@@ -71,9 +71,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -137,9 +134,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -368,9 +362,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -420,9 +411,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -476,9 +464,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -650,9 +635,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseWithActualResultImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseWithActualResultImplementation.json
@@ -36,9 +36,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {
@@ -267,9 +264,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinition.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinitionThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinitionThatTakesActualResult.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignature.json
@@ -35,9 +35,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignatureThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignatureThatTakesActualResult.json
@@ -39,9 +39,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1.json
@@ -140,9 +140,6 @@
           ]
         }
       },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_bigunion_BigUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_bigunion_BigUnion.json
@@ -36,9 +36,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_Union.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_Union.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithBaseProperties.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithBaseProperties.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDiscriminant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDiscriminant.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "_type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDuplicatePrimitive.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDuplicatePrimitive.json
@@ -11,9 +11,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDuplicateTypes.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDuplicateTypes.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithLiteral.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithLiteral.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithMultipleNoProperties.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithMultipleNoProperties.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithNoProperties.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithNoProperties.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithOptionalTime.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithOptionalTime.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithPrimitive.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithPrimitive.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithSingleElement.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithSingleElement.json
@@ -8,9 +8,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithSubTypes.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithSubTypes.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithTime.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithTime.json
@@ -10,9 +10,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithoutKey.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithoutKey.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_union_Shape.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_union_Shape.json
@@ -9,9 +9,6 @@
       ]
     }
   },
-  "required": [
-    "type"
-  ],
   "oneOf": [
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/converters/unionToJsonSchema.ts
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/converters/unionToJsonSchema.ts
@@ -24,7 +24,6 @@ export function convertUnionToJsonSchema({ union, context }: convertUnionToJsonS
                 enum: union.types.map((member) => member.discriminantValue.wireValue)
             }
         },
-        required: [discriminant],
         oneOf: union.types.map((member) => {
             let properties: Record<string, JSONSchema4> = {};
             let required: string[] = [];


### PR DESCRIPTION
## Description
- during discriminated union conversion for JsonSchema, the discriminant property is required on the top-level and the variant-level 
## Changes Made
- dedupe the discriminant so that it is only marked required on the variant-level

## Testing
- [X] Unit tests added/updated
