### PR TITLE
feat(typescript): TS config to export SDK to custom package path

### DIFF
--- a/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
+++ b/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
@@ -22,6 +22,7 @@ export const TypescriptCustomConfigSchema = z.strictObject({
     publishToJsr: z.optional(z.boolean()),
     omitUndefined: z.optional(z.boolean()),
     useLegacyExports: z.optional(z.boolean()),
+    packagePath: z.optional(z.string()),
 
     // relevant to dynamic snippets
     allowExtraFields: z.optional(z.boolean()),

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -69,7 +69,8 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             generateWireTests: parsed?.generateWireTests ?? true,
             noScripts: parsed?.noScripts ?? false,
             useBigInt: parsed?.useBigInt ?? false,
-            useLegacyExports: parsed?.useLegacyExports ?? false
+            useLegacyExports: parsed?.useLegacyExports ?? false,
+            packagePath: parsed?.packagePath
         };
     }
 
@@ -153,13 +154,13 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
                 useBigInt: customConfig.useBigInt ?? false,
                 enableInlineTypes: customConfig.enableInlineTypes ?? true,
                 useLegacyExports,
-                generateWireTests: customConfig.generateWireTests ?? false
+                generateWireTests: customConfig.generateWireTests ?? false,
+                packagePath: customConfig.packagePath
             }
         });
         const typescriptProject = await sdkGenerator.generate();
         const persistedTypescriptProject = await typescriptProject.persist();
         await sdkGenerator.copyCoreUtilities({
-            pathToSrc: persistedTypescriptProject.getSrcDirectory(),
             pathToRoot: persistedTypescriptProject.getRootDirectory()
         });
 

--- a/generators/typescript/sdk/cli/src/custom-config/SdkCustomConfig.ts
+++ b/generators/typescript/sdk/cli/src/custom-config/SdkCustomConfig.ts
@@ -38,4 +38,5 @@ export interface SdkCustomConfig {
     noScripts: boolean | undefined;
     useBigInt: boolean | undefined;
     useLegacyExports: boolean | undefined;
+    packagePath: string | undefined;
 }

--- a/generators/typescript/sdk/generator/src/test-generator/JestTestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/JestTestGenerator.ts
@@ -134,8 +134,9 @@ export class JestTestGenerator {
     }
 
     public get extraFiles(): Record<string, string> {
+        const testDirWithoutLeadingSlash = this.rootDirectory.getPath().replace(/^\//, "");
         return {
-            "tests/tsconfig.json": `{
+            [path.join(testDirWithoutLeadingSlash, "tsconfig.json")]: `{
     "extends": "../tsconfig.base.json",
     "compilerOptions": {
         "outDir": null,
@@ -145,7 +146,7 @@ export class JestTestGenerator {
     "include": ["../src", "../tests"],
     "exclude": []
 }`,
-            "tests/custom.test.ts": `
+            [path.join(testDirWithoutLeadingSlash, "custom.test.ts")]: `
 /**
 * This is a custom test file, if you wish to add more tests
 * to your SDK.

--- a/generators/typescript/sdk/generator/src/version/VersionFileGenerator.ts
+++ b/generators/typescript/sdk/generator/src/version/VersionFileGenerator.ts
@@ -28,6 +28,6 @@ export class VersionFileGenerator {
                 name: "SDK_VERSION"
             })
         );
-        this.rootDirectory.createSourceFile("src/version.ts", writer.toString());
+        this.rootDirectory.createSourceFile("version.ts", writer.toString());
     }
 }

--- a/generators/typescript/utils/commons/src/asIs/AsIsManager.ts
+++ b/generators/typescript/utils/commons/src/asIs/AsIsManager.ts
@@ -6,47 +6,57 @@ import { Project } from "ts-morph";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 
 const filePathOnDockerContainer = AbsoluteFilePath.of("/assets/asIs");
-/**
- * A map containing the original source path and the target path in the generated project
- */
-const asIsFiles = {
-    core: {
-        mergeHeaders: { "core/headers.ts": "src/core/headers.ts" },
-        json: {
-            vanilla: { "core/json.vanilla.ts": "src/core/json.ts" },
-            bigint: { "core/json.bigint.ts": "src/core/json.ts" }
-        }
-    },
-    tests: {
-        mockServer: {
-            "tests/mock-server/*": "tests/mock-server/"
-        },
-        bigintSetup: { "tests/bigint.setup.ts": "tests/bigint.setup.ts" }
-    },
-    scripts: {
-        renameToEsmFiles: {
-            "scripts/rename-to-esm-files.js": "scripts/rename-to-esm-files.js"
-        }
-    }
-} as const;
 
 export namespace AsIsManager {
     export interface Init {
         useBigInt: boolean;
         generateWireTests: boolean;
+        rootDirectory: string;
+        testDirectory: string;
     }
 }
 
 export class AsIsManager {
     private readonly useBigInt: boolean;
     private readonly generateWireTests: boolean;
-    constructor({ useBigInt, generateWireTests }: AsIsManager.Init) {
+    private readonly rootDirectory: string;
+    private readonly testDirectory: string;
+    constructor({ useBigInt, generateWireTests, testDirectory, rootDirectory }: AsIsManager.Init) {
         this.useBigInt = useBigInt;
         this.generateWireTests = generateWireTests;
+        this.rootDirectory = rootDirectory;
+        this.testDirectory = testDirectory;
+    }
+
+    /**
+     * A map containing the original source path and the target path in the generated project
+     */
+    private getAsIsFiles() {
+        return {
+            core: {
+                mergeHeaders: { "core/headers.ts": `${this.rootDirectory}/core/headers.ts` },
+                json: {
+                    vanilla: { "core/json.vanilla.ts": `${this.rootDirectory}/core/json.ts` },
+                    bigint: { "core/json.bigint.ts": `${this.rootDirectory}/core/json.ts` }
+                }
+            },
+            tests: {
+                mockServer: {
+                    ["tests/mock-server/*"]: `${this.testDirectory}/mock-server/`
+                },
+                bigintSetup: { ["tests/bigint.setup.ts"]: `${this.testDirectory}/bigint.setup.ts` }
+            },
+            scripts: {
+                renameToEsmFiles: {
+                    "scripts/rename-to-esm-files.js": "scripts/rename-to-esm-files.js"
+                }
+            }
+        };
     }
 
     public async AddToTsProject({ project }: { project: Project }): Promise<void> {
         const filesToCopy: Record<string, string>[] = [];
+        const asIsFiles = this.getAsIsFiles();
 
         filesToCopy.push(asIsFiles.core.mergeHeaders);
         filesToCopy.push(asIsFiles.scripts.renameToEsmFiles);
@@ -69,7 +79,8 @@ export class AsIsManager {
 
                 for (const match of matches) {
                     const sourceFilePath = path.join(filePathOnDockerContainer, match);
-                    const relativePath = path.relative(filePathOnDockerContainer, match);
+                    const sourcePatternBase = sourcePattern.replace("/*", "");
+                    const relativePath = path.relative(sourcePatternBase, match);
                     const targetFilePath = path.join(targetPattern, relativePath);
                     const fileContent = await fs.readFile(sourceFilePath, "utf-8");
                     project.createSourceFile(targetFilePath, fileContent, { overwrite: true });

--- a/generators/typescript/utils/commons/src/exports-manager/ExportedFilePath.ts
+++ b/generators/typescript/utils/commons/src/exports-manager/ExportedFilePath.ts
@@ -10,7 +10,7 @@ export interface ExportedFilePath {
     /**
      * @default "src"
      */
-    rootDir?: "src" | "tests" | "";
+    rootDir?: string;
 }
 
 export interface ExportedDirectory extends ExportedFilePathPart {
@@ -38,7 +38,7 @@ export function convertExportedFilePathToFilePath(exportedFilePath: ExportedFile
 
 export function convertExportedDirectoryPathToFilePath(
     exportedDirectoryPath: ExportedDirectory[],
-    rootDir: "src" | "tests" | "" = "src"
+    rootDir: string = ""
 ): string {
     return path.join(
         // within a ts-morph Project, we treat "/src" as the root of the project

--- a/generators/typescript/utils/commons/src/exports-manager/ExportsManager.ts
+++ b/generators/typescript/utils/commons/src/exports-manager/ExportsManager.ts
@@ -23,6 +23,11 @@ type PathToDirectory = string;
 
 export class ExportsManager {
     private exports: Record<PathToDirectory, Record<ModuleSpecifier, CombinedExportDeclarations>> = {};
+    private packagePath: string;
+
+    constructor(packagePath: string = "/src") {
+        this.packagePath = packagePath;
+    }
 
     public addExport(
         from: SourceFile | string,
@@ -57,7 +62,7 @@ export class ExportsManager {
     }
 
     public addExportsForDirectories(directories: ExportedDirectory[], addExportTypeModifier?: boolean): void {
-        let directoryFilepath = "/src";
+        let directoryFilepath = this.packagePath;
         for (const part of directories) {
             const nextDirectoryPath = path.join(directoryFilepath, part.nameOnDisk);
             this.addExportDeclarationForDirectory({

--- a/generators/typescript/utils/commons/src/typescript-project/BundledTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/BundledTypescriptProject.ts
@@ -67,7 +67,7 @@ async function bundle({ platform, target, format, outdir }) {
         platform,
         target,
         format,
-        entryPoint: "./${TypescriptProject.SRC_DIRECTORY}/index.ts",
+        entryPoint: "./${this.packagePath}/index.ts",
         outfile: \`./${TypescriptProject.DIST_DIRECTORY}/\${outdir}/${BundledTypescriptProject.API_BUNDLE_FILENAME}\`,
     });
     ${this.getFoldersForExports()
@@ -76,7 +76,7 @@ async function bundle({ platform, target, format, outdir }) {
         platform,
         target,
         format,
-        entryPoint: "./${BundledTypescriptProject.SRC_DIRECTORY}/${folder}/index.ts",
+        entryPoint: "./${this.packagePath}/${folder}/index.ts",
         outfile: \`./${BundledTypescriptProject.DIST_DIRECTORY}/\${outdir}/${this.getBundleForNonExportedFolder(
             folder
         )}\`,
@@ -166,8 +166,8 @@ export * from "./${BundledTypescriptProject.TYPES_DIRECTORY}/${folder}";
             emitDeclarationOnly: true,
             sourceMap: true,
             outDir: BundledTypescriptProject.TYPES_DIRECTORY,
-            rootDir: BundledTypescriptProject.SRC_DIRECTORY,
-            baseUrl: BundledTypescriptProject.SRC_DIRECTORY
+            rootDir: this.packagePath,
+            baseUrl: this.packagePath
         };
 
         await this.writeFileToVolume(
@@ -175,7 +175,7 @@ export * from "./${BundledTypescriptProject.TYPES_DIRECTORY}/${folder}";
             JSON.stringify(
                 {
                     compilerOptions,
-                    include: [BundledTypescriptProject.SRC_DIRECTORY],
+                    include: [this.packagePath],
                     exclude: []
                 },
                 undefined,

--- a/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
@@ -61,7 +61,7 @@ export class SimpleTypescriptProject extends TypescriptProject {
             RelativeFilePath.of(TypescriptProject.NPM_IGNORE_FILENAME),
             [
                 "node_modules",
-                SimpleTypescriptProject.SRC_DIRECTORY,
+                this.packagePath,
                 SimpleTypescriptProject.TEST_DIRECTORY,
                 SimpleTypescriptProject.GIT_IGNORE_FILENAME,
                 ".github",
@@ -93,8 +93,8 @@ export class SimpleTypescriptProject extends TypescriptProject {
             skipLibCheck: true,
             declaration: true,
             outDir: SimpleTypescriptProject.DIST_DIRECTORY,
-            rootDir: SimpleTypescriptProject.SRC_DIRECTORY,
-            baseUrl: SimpleTypescriptProject.SRC_DIRECTORY
+            rootDir: this.packagePath,
+            baseUrl: this.packagePath
         };
 
         if (this.useLegacyExports) {
@@ -107,7 +107,7 @@ export class SimpleTypescriptProject extends TypescriptProject {
                             module: (this.outputEsm ? "esnext" : "CommonJS") as unknown as ModuleKind,
                             outDir: SimpleTypescriptProject.DIST_DIRECTORY
                         },
-                        include: [SimpleTypescriptProject.SRC_DIRECTORY],
+                        include: [this.packagePath],
                         exclude: []
                     },
                     undefined,
@@ -123,7 +123,7 @@ export class SimpleTypescriptProject extends TypescriptProject {
             JSON.stringify(
                 {
                     compilerOptions,
-                    include: [SimpleTypescriptProject.SRC_DIRECTORY],
+                    include: [this.packagePath],
                     exclude: []
                 },
                 undefined,
@@ -142,7 +142,7 @@ export class SimpleTypescriptProject extends TypescriptProject {
                 {
                     extends: `./${baseTsConfigPath}`,
                     compilerOptions: cjsCompilerOptions,
-                    include: [SimpleTypescriptProject.SRC_DIRECTORY],
+                    include: [this.packagePath],
                     exclude: []
                 },
                 undefined,
@@ -161,7 +161,7 @@ export class SimpleTypescriptProject extends TypescriptProject {
                 {
                     extends: `./${baseTsConfigPath}`,
                     compilerOptions: esmCompilerOptions,
-                    include: [SimpleTypescriptProject.SRC_DIRECTORY],
+                    include: [this.packagePath],
                     exclude: []
                 },
                 undefined,

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -26,11 +26,12 @@ export declare namespace TypescriptProject {
         extraConfigs: Record<string, unknown> | undefined;
         outputJsr: boolean;
         exportSerde: boolean;
+        packagePath?: string;
     }
 }
 
 export abstract class TypescriptProject {
-    protected static SRC_DIRECTORY = "src" as const;
+    protected static DEFAULT_SRC_DIRECTORY = "src" as const;
     protected static TEST_DIRECTORY = "tests" as const;
     protected static DIST_DIRECTORY = "dist" as const;
     protected static SCRIPTS_DIRECTORY_NAME = "scripts" as const;
@@ -80,6 +81,7 @@ export abstract class TypescriptProject {
     protected extraPeerDependenciesMeta: Record<string, unknown>;
     protected extraPeerDependencies: Record<string, string>;
     protected extraScripts: Record<string, string>;
+    protected packagePath: string;
 
     private runScripts: boolean;
 
@@ -96,7 +98,8 @@ export abstract class TypescriptProject {
         dependencies,
         outputJsr,
         exportSerde,
-        extraConfigs
+        extraConfigs,
+        packagePath
     }: TypescriptProject.Init) {
         this.npmPackage = npmPackage;
         this.runScripts = runScripts;
@@ -111,6 +114,7 @@ export abstract class TypescriptProject {
         this.outputJsr = outputJsr ?? false;
         this.exportSerde = exportSerde;
         this.extraConfigs = extraConfigs;
+        this.packagePath = packagePath ?? TypescriptProject.DEFAULT_SRC_DIRECTORY;
     }
 
     public getFoldersForExports(): string[] {
@@ -139,7 +143,7 @@ export abstract class TypescriptProject {
         return new PersistedTypescriptProject({
             runScripts: this.runScripts,
             directory: directoryOnDiskToWriteTo,
-            srcDirectory: RelativeFilePath.of(TypescriptProject.SRC_DIRECTORY),
+            srcDirectory: RelativeFilePath.of(this.packagePath),
             testDirectory: RelativeFilePath.of(TypescriptProject.TEST_DIRECTORY),
             distDirectory: RelativeFilePath.of(TypescriptProject.DIST_DIRECTORY),
             yarnBuildCommand: this.getYarnBuildCommand(),


### PR DESCRIPTION
## Description
Auth0 wants to have our generator export their SDK to a custom folder within their repo, which is supported by this PR

## Changes Made
Effectively, instead of hard-coding that we're generating the SDK client to `src`, we're enabling users to pass in a custom value

## Testing
Added a fixture test (`seed/ts-sdk/exhaustive/package-path`), but I left it out of this PR to keep it cleaner for now

