### PR TITLE
fix(typescript): websocket codegen supports path parameters

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -1,4 +1,9 @@
-import { PackageId, getParameterNameForPositionalPathParameter, getPropertyKey, getTextOfTsNode } from "@fern-typescript/commons";
+import {
+    PackageId,
+    getParameterNameForPositionalPathParameter,
+    getPropertyKey,
+    getTextOfTsNode
+} from "@fern-typescript/commons";
 import { ChannelSignature, GeneratedWebsocketImplementation, SdkContext } from "@fern-typescript/contexts";
 import {
     ClassDeclarationStructure,
@@ -9,9 +14,15 @@ import {
     ts
 } from "ts-morph";
 
-import { assertNever, SetRequired } from "@fern-api/core-utils";
+import { SetRequired, assertNever } from "@fern-api/core-utils";
 
-import { IntermediateRepresentation, PathParameter, PathParameterLocation, WebSocketChannel, WebSocketChannelId } from "@fern-fern/ir-sdk/api";
+import {
+    IntermediateRepresentation,
+    PathParameter,
+    PathParameterLocation,
+    WebSocketChannel,
+    WebSocketChannelId
+} from "@fern-fern/ir-sdk/api";
 
 import { GeneratedSdkClientClassImpl } from "../GeneratedSdkClientClassImpl";
 import { GetReferenceToPathParameterVariableFromRequest } from "../endpoints/utils/buildUrl";
@@ -73,7 +84,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 {
                     name: "args",
                     type: `${this.serviceClassName}.${GeneratedDefaultWebsocketImplementation.CONNECT_ARGS_INTERFACE_NAME}`,
-                    initializer: connectArgsInterface.properties?.every(p => p.hasQuestionToken) ? "{}" : undefined
+                    initializer: connectArgsInterface.properties?.every((p) => p.hasQuestionToken) ? "{}" : undefined
                 }
             ],
             returnTypeWithoutPromise: this.getSocketTypeNode(context)
@@ -118,7 +129,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 {
                     name: "args",
                     type: `${this.serviceClassName}.${GeneratedDefaultWebsocketImplementation.CONNECT_ARGS_INTERFACE_NAME}`,
-                    initializer: connectArgsInterface.properties?.every(p => p.hasQuestionToken) ? "{}" : undefined
+                    initializer: connectArgsInterface.properties?.every((p) => p.hasQuestionToken) ? "{}" : undefined
                 }
             ],
             returnType: getTextOfTsNode(
@@ -395,16 +406,14 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 url,
                 ts.factory.createTemplateMiddle(`${channel.path.head}?`, `${channel.path.head}?`)
             ),
-            ...channel.path.parts.map((part) => 
+            ...channel.path.parts.map((part) =>
                 ts.factory.createTemplateSpan(
-                    ts.factory.createCallExpression(
-                        ts.factory.createIdentifier("encodeURIComponent"),
-                        undefined,
-                        [ts.factory.createElementAccessExpression(
+                    ts.factory.createCallExpression(ts.factory.createIdentifier("encodeURIComponent"), undefined, [
+                        ts.factory.createElementAccessExpression(
                             ts.factory.createIdentifier("args"),
                             ts.factory.createStringLiteral(part.pathParameter)
-                        )]
-                    ),
+                        )
+                    ]),
                     ts.factory.createTemplateMiddle(part.tail, part.tail)
                 )
             ),

--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -1,4 +1,4 @@
-import { PackageId, getPropertyKey, getTextOfTsNode } from "@fern-typescript/commons";
+import { PackageId, getParameterNameForPositionalPathParameter, getPropertyKey, getTextOfTsNode } from "@fern-typescript/commons";
 import { ChannelSignature, GeneratedWebsocketImplementation, SdkContext } from "@fern-typescript/contexts";
 import {
     ClassDeclarationStructure,
@@ -9,11 +9,12 @@ import {
     ts
 } from "ts-morph";
 
-import { SetRequired } from "@fern-api/core-utils";
+import { assertNever, SetRequired } from "@fern-api/core-utils";
 
-import { IntermediateRepresentation, WebSocketChannel, WebSocketChannelId } from "@fern-fern/ir-sdk/api";
+import { IntermediateRepresentation, PathParameter, PathParameterLocation, WebSocketChannel, WebSocketChannelId } from "@fern-fern/ir-sdk/api";
 
 import { GeneratedSdkClientClassImpl } from "../GeneratedSdkClientClassImpl";
+import { GetReferenceToPathParameterVariableFromRequest } from "../endpoints/utils/buildUrl";
 
 export declare namespace GeneratedDefaultWebsocketImplementation {
     export interface Init {
@@ -65,12 +66,14 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
     }
 
     public getSignature(context: SdkContext): ChannelSignature {
+        const connectArgsInterface = this.generateConnectArgsInterface(context);
+
         return {
             parameters: [
                 {
                     name: "args",
                     type: `${this.serviceClassName}.${GeneratedDefaultWebsocketImplementation.CONNECT_ARGS_INTERFACE_NAME}`,
-                    initializer: "{}"
+                    initializer: connectArgsInterface.properties?.every(p => p.hasQuestionToken) ? "{}" : undefined
                 }
             ],
             returnTypeWithoutPromise: this.getSocketTypeNode(context)
@@ -86,12 +89,14 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
     }
 
     public writeToFile(context: SdkContext): void {
+        const connectArgsInterface = this.generateConnectArgsInterface(context);
+
         const serviceModule: ModuleDeclarationStructure = {
             kind: StructureKind.Module,
             name: this.serviceClassName,
             isExported: true,
             hasDeclareKeyword: true,
-            statements: [this.generateConnectArgsInterface(context)]
+            statements: [connectArgsInterface]
         };
 
         const serviceClass: ClassDeclarationStructure = {
@@ -113,7 +118,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 {
                     name: "args",
                     type: `${this.serviceClassName}.${GeneratedDefaultWebsocketImplementation.CONNECT_ARGS_INTERFACE_NAME}`,
-                    initializer: "{}"
+                    initializer: connectArgsInterface.properties?.every(p => p.hasQuestionToken) ? "{}" : undefined
                 }
             ],
             returnType: getTextOfTsNode(
@@ -133,6 +138,13 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
             kind: StructureKind.Interface,
             name: GeneratedDefaultWebsocketImplementation.CONNECT_ARGS_INTERFACE_NAME,
             properties: [
+                ...(this.channel.pathParameters ?? []).map((pathParameter) => {
+                    return {
+                        name: getPropertyKey(pathParameter.name.originalName),
+                        type: getTextOfTsNode(context.type.getReferenceToType(pathParameter.valueType).typeNode),
+                        hasQuestionToken: false
+                    };
+                }),
                 ...(this.channel.queryParameters ?? []).map((queryParameter) => {
                     return {
                         name: getPropertyKey(queryParameter.name.wireValue),
@@ -382,6 +394,19 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
             ts.factory.createTemplateSpan(
                 url,
                 ts.factory.createTemplateMiddle(`${channel.path.head}?`, `${channel.path.head}?`)
+            ),
+            ...channel.path.parts.map((part) => 
+                ts.factory.createTemplateSpan(
+                    ts.factory.createCallExpression(
+                        ts.factory.createIdentifier("encodeURIComponent"),
+                        undefined,
+                        [ts.factory.createElementAccessExpression(
+                            ts.factory.createIdentifier("args"),
+                            ts.factory.createStringLiteral(part.pathParameter)
+                        )]
+                    ),
+                    ts.factory.createTemplateMiddle(part.tail, part.tail)
+                )
             ),
             ts.factory.createTemplateSpan(
                 context.externalDependencies.qs.stringify(ts.factory.createIdentifier("queryParams")),

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 1.5.0
+  changelogEntry:
+    - summary: Add support for websocket connect methods with path parameters in the TypeScript generator
+      type: feat
+  createdAt: '2025-06-11'
+  irVersion: 58
+
 - version: 1.4.0
   changelogEntry:
     - summary: You can now pass in headers to the root client. These headers will be merged with service and endpoint specific headers.

--- a/seed/ts-sdk/websocket/websocket-serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/websocket-serde/src/api/resources/realtime/client/Client.ts
@@ -16,6 +16,7 @@ export declare namespace Realtime {
     }
 
     export interface ConnectArgs {
+        id: string;
         model?: string | undefined;
         temperature?: number | undefined;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -34,7 +35,7 @@ export class Realtime {
         this._options = _options;
     }
 
-    public async connect(args: Realtime.ConnectArgs = {}): Promise<RealtimeSocket> {
+    public async connect(args: Realtime.ConnectArgs): Promise<RealtimeSocket> {
         const queryParams: Record<string, unknown> = {};
         if (args["model"] != null) {
             queryParams["model"] = args["model"];
@@ -50,7 +51,7 @@ export class Realtime {
             ...args["headers"],
         };
         const socket = new core.ReconnectingWebSocket(
-            `${(await core.Supplier.get(this._options["baseUrl"])) ?? (await core.Supplier.get(this._options["environment"]))}/realtime/?${qs.stringify(queryParams, { arrayFormat: "repeat" })}`,
+            `${(await core.Supplier.get(this._options["baseUrl"])) ?? (await core.Supplier.get(this._options["environment"]))}/realtime/?${encodeURIComponent(args["id"])}${qs.stringify(queryParams, { arrayFormat: "repeat" })}`,
             [],
             { debug: args["debug"] ?? false, maxRetries: args["reconnectAttempts"] ?? 30 },
             websocketHeaders,

--- a/seed/ts-sdk/websocket/websocket-with-serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/websocket-with-serde/src/api/resources/realtime/client/Client.ts
@@ -16,6 +16,7 @@ export declare namespace Realtime {
     }
 
     export interface ConnectArgs {
+        id: string;
         model?: string | undefined;
         temperature?: number | undefined;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -34,7 +35,7 @@ export class Realtime {
         this._options = _options;
     }
 
-    public async connect(args: Realtime.ConnectArgs = {}): Promise<RealtimeSocket> {
+    public async connect(args: Realtime.ConnectArgs): Promise<RealtimeSocket> {
         const queryParams: Record<string, unknown> = {};
         if (args["model"] != null) {
             queryParams["model"] = args["model"];
@@ -50,7 +51,7 @@ export class Realtime {
             ...args["headers"],
         };
         const socket = new core.ReconnectingWebSocket(
-            `${(await core.Supplier.get(this._options["baseUrl"])) ?? (await core.Supplier.get(this._options["environment"]))}/realtime/?${qs.stringify(queryParams, { arrayFormat: "repeat" })}`,
+            `${(await core.Supplier.get(this._options["baseUrl"])) ?? (await core.Supplier.get(this._options["environment"]))}/realtime/?${encodeURIComponent(args["id"])}${qs.stringify(queryParams, { arrayFormat: "repeat" })}`,
             [],
             { debug: args["debug"] ?? false, maxRetries: args["reconnectAttempts"] ?? 30 },
             websocketHeaders,


### PR DESCRIPTION
## Description
TypeScript websocket codegen would skip generating path parameters. 

## Changes Made
- See files changed. 

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

