### PR TITLE
chore(cli): relative links for subpath docs

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-12.mdx
+++ b/fern/pages/changelogs/cli/2025-06-12.mdx
@@ -1,0 +1,2 @@
+## 0.64.5
+**`(fix):`** Relative links between markdown files now works for docs using custom subpaths. 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Relative links between markdown files now works for docs using custom subpaths. 
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-12"
+  version: 0.64.5
+
+- changelogEntry:
+    - summary: |
         Don't use posthog when CLI is running from self-hosted container.
       type: fix
   irVersion: 58

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -218,11 +218,10 @@ export class DocsDefinitionResolver {
         });
 
         // postprocess markdown files after uploading all images to replace the image paths in the markdown files with the fileIDs
-        const basePath = this.getDocsBasePath();
 
         // TODO: include more (canonical) slugs from the navigation tree
         const markdownFilesToPathName: Record<AbsoluteFilePath, string> =
-            await this.getMarkdownFilesToFullyQualifiedPathNames(basePath);
+            await this.getMarkdownFilesToFullyQualifiedPathNames();
 
         for (const [relativePath, markdown] of Object.entries(this.parsedDocsConfig.pages)) {
             this.parsedDocsConfig.pages[RelativeFilePath.of(relativePath)] = replaceImagePathsAndUrls(
@@ -345,12 +344,10 @@ export class DocsDefinitionResolver {
 
     /**
      * Creates a map of markdown files to their fully qualified pathnames, based on the entire navigation tree
-     * @param basePath - the base path of the docs
+     * FernNavigation NodeCollector already includes basepath in slugmap
      * @returns a map of markdown files to their fully qualified pathnames
      */
-    private async getMarkdownFilesToFullyQualifiedPathNames(
-        basePath: string
-    ): Promise<Record<AbsoluteFilePath, string>> {
+    private async getMarkdownFilesToFullyQualifiedPathNames(): Promise<Record<AbsoluteFilePath, string>> {
         const markdownFilesToPathName: Record<AbsoluteFilePath, string> = {};
         const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(await this.toRootNode());
 
@@ -367,7 +364,7 @@ export class DocsDefinitionResolver {
             }
 
             const absoluteFilePath = join(this.docsWorkspace.absoluteFilePath, RelativeFilePath.of(pageId));
-            markdownFilesToPathName[absoluteFilePath] = urlJoin(basePath, slug);
+            markdownFilesToPathName[absoluteFilePath] = slug;
         });
         return markdownFilesToPathName;
     }


### PR DESCRIPTION
this pr removes the extraneous subpath that was added to calculate relative mdx links in the docs. 

the base subpath isn't necesary because the nodeCollector already includes the subpath in the slugs it returns
