### PR TITLE
fix(cli): readme importer downloads mdx files

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        The Readme importer now downloads MDX files from the source documentation. 
+        This allows for better handling of React components and dynamic content in the imported documentation. 
+        The importer will preserve the MDX syntax and structure while converting the content to a format compatible with Fern's documentation system.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-12"
+  version: 0.64.6
+
+- changelogEntry:
+    - summary: |
         Relative links between markdown files now works for docs using custom subpaths. 
       type: fix
   irVersion: 58

--- a/packages/cli/docs-importers/readme/src/ReadmeImporter.ts
+++ b/packages/cli/docs-importers/readme/src/ReadmeImporter.ts
@@ -78,10 +78,10 @@ export class ReadmeImporter extends DocsImporter<object> {
                 this.absolutePathToFernDirectory,
                 RelativeFilePath.of(this.kebabCaseWithoutEmojis(tab.name))
             );
-            // await this.downloadMarkdownPages({
-            //     absolutePathToOutputDirectory,
-            //     sections: sidebar
-            // });
+            await this.downloadMarkdownPages({
+                absolutePathToOutputDirectory,
+                sections: sidebar
+            });
             const navigationItems = await this.getNavigationItems({ absolutePathToOutputDirectory, sections: sidebar });
             for (const item of navigationItems) {
                 nav.addItem({ item });


### PR DESCRIPTION
## Description
Actually download mdx files from readme importer

## Changes Made
- Uncommented code

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

