### PR TITLE
feat(typescript): creating websocket util files

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -777,6 +777,11 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
         }
 
         if (this.generatedWebsocketImplementation != null) {
+            // we need to import the factory for the client
+            this.importsManager.addImport("../utils/createWebSocket.js", {
+                namedImports: ["createWebSocket"]
+            });
+
             const signature = this.generatedWebsocketImplementation.getSignature(context);
             const classStatements = this.generatedWebsocketImplementation.getClassStatements(context);
 

--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -32,7 +32,6 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
     private static readonly CONNECT_ARGS_PRIVATE_MEMBER = "args";
     private static readonly DEBUG_PROPERTY_NAME = "debug";
     private static readonly HEADERS_PROPERTY_NAME = "headers";
-    private static readonly HEADERS_VARIABLE_NAME = "websocketHeaders";
 
     private static readonly RECONNECT_ATTEMPTS_PROPERTY_NAME = "reconnectAttempts";
     private static readonly GENERATED_VERSION_PROPERTY_NAME = "fernSdkVersion";
@@ -230,97 +229,47 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                     )
                 )
             ),
+
             ts.factory.createVariableStatement(
                 undefined,
                 ts.factory.createVariableDeclarationList(
                     [
                         ts.factory.createVariableDeclaration(
-                            ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME),
+                            ts.factory.createIdentifier("clientOptions"),
                             undefined,
-                            ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Record"), [
-                                ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-                                ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
-                            ]),
-                            ts.factory.createObjectLiteralExpression()
+                            undefined,
+                            this.createClientOptionsExpression()
                         )
                     ],
-                    ts.NodeFlags.Let
+                    ts.NodeFlags.Const
                 )
             ),
-            ...(this.generatedSdkClientClass.shouldGenerateCustomAuthorizationHeaderHelperMethod()
-                ? [
-                      ts.factory.createExpressionStatement(
-                          ts.factory.createBinaryExpression(
-                              ts.factory.createIdentifier(
-                                  GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME
-                              ),
-                              ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-                              ts.factory.createObjectLiteralExpression(
-                                  [
-                                      ts.factory.createSpreadAssignment(
-                                          ts.factory.createIdentifier(
-                                              GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME
-                                          )
-                                      ),
-                                      ts.factory.createSpreadAssignment(
-                                          ts.factory.createAwaitExpression(
-                                              ts.factory.createCallExpression(
-                                                  ts.factory.createPropertyAccessExpression(
-                                                      ts.factory.createThis(),
-                                                      GeneratedSdkClientClassImpl.CUSTOM_AUTHORIZATION_HEADER_HELPER_METHOD_NAME
-                                                  ),
-                                                  undefined,
-                                                  []
-                                              )
-                                          )
-                                      )
-                                  ],
-                                  true
-                              )
-                          )
-                      )
-                  ]
-                : []),
-            ...(this.channel.headers ?? []).map((header) => {
-                return ts.factory.createIfStatement(
-                    ts.factory.createBinaryExpression(
-                        this.getReferenceToArg(header.name.wireValue),
-                        ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
-                        ts.factory.createNull()
-                    ),
-                    ts.factory.createBlock([
-                        ts.factory.createExpressionStatement(
-                            ts.factory.createBinaryExpression(
-                                ts.factory.createElementAccessExpression(
-                                    ts.factory.createIdentifier(
-                                        GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME
-                                    ),
-                                    ts.factory.createStringLiteral(header.name.wireValue)
-                                ),
-                                ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-                                this.getReferenceToArg(header.name.wireValue)
-                            )
+            ts.factory.createVariableStatement(
+                undefined,
+                ts.factory.createVariableDeclarationList(
+                    [
+                        ts.factory.createVariableDeclaration(
+                            ts.factory.createIdentifier("url"),
+                            undefined,
+                            undefined,
+                            this.buildFullUrl(this.getBaseUrl(this.channel, context), this.channel, context)
                         )
-                    ])
-                );
-            }),
-            ts.factory.createExpressionStatement(
-                ts.factory.createBinaryExpression(
-                    ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME),
-                    ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-                    ts.factory.createObjectLiteralExpression(
-                        [
-                            ts.factory.createSpreadAssignment(
-                                ts.factory.createIdentifier(
-                                    GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME
-                                )
-                            ),
-                            ts.factory.createSpreadAssignment(
-                                this.getReferenceToArg(GeneratedDefaultWebsocketImplementation.HEADERS_PROPERTY_NAME)
-                            )
-                        ],
-                        true
-                    )
+                    ],
+                    ts.NodeFlags.Const
+                )
+            ),
+            ts.factory.createVariableStatement(
+                undefined,
+                ts.factory.createVariableDeclarationList(
+                    [
+                        ts.factory.createVariableDeclaration(
+                            ts.factory.createIdentifier("reconnectingOptions"),
+                            undefined,
+                            undefined,
+                            this.createReconnectingOptionsExpression()
+                        )
+                    ],
+                    ts.NodeFlags.Const
                 )
             ),
             ts.factory.createVariableStatement(
@@ -331,7 +280,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                             ts.factory.createIdentifier("socket"),
                             undefined,
                             undefined,
-                            this.getReferenceToWebsocket(context)
+                            this.createReconnectingWebSocketExpression()
                         )
                     ],
                     ts.NodeFlags.Const
@@ -347,34 +296,96 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
         ];
     }
 
-    private getReferenceToWebsocket(context: SdkContext): ts.Expression {
-        return context.coreUtilities.websocket.ReconnectingWebSocket._connect({
-            url: this.buildFullUrl(this.getBaseUrl(this.channel, context), this.channel, context),
-            protocols: ts.factory.createArrayLiteralExpression([]),
-            options: ts.factory.createObjectLiteralExpression([
-                ts.factory.createPropertyAssignment(
-                    "debug",
-                    ts.factory.createBinaryExpression(
-                        this.getReferenceToArg(GeneratedDefaultWebsocketImplementation.DEBUG_PROPERTY_NAME),
-                        ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                        ts.factory.createFalse()
-                    )
-                ),
-                ts.factory.createPropertyAssignment(
-                    "maxRetries",
-                    ts.factory.createBinaryExpression(
-                        this.getReferenceToArg(
-                            GeneratedDefaultWebsocketImplementation.RECONNECT_ATTEMPTS_PROPERTY_NAME
-                        ),
-                        ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                        ts.factory.createNumericLiteral(
-                            GeneratedDefaultWebsocketImplementation.DEFAULT_NUM_RECONNECT_ATTEMPTS
-                        )
+    private createClientOptionsExpression(): ts.Expression {
+        return ts.factory.createObjectLiteralExpression([
+            ts.factory.createPropertyAssignment(
+                "debug",
+                ts.factory.createBinaryExpression(
+                    this.getReferenceToArg(GeneratedDefaultWebsocketImplementation.DEBUG_PROPERTY_NAME),
+                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                    ts.factory.createFalse()
+                )
+            ),
+            ts.factory.createSpreadAssignment(
+                ts.factory.createPropertyAccessExpression(
+                    ts.factory.createThis(),
+                    GeneratedSdkClientClassImpl.OPTIONS_PRIVATE_MEMBER
+                )
+            ),
+            ts.factory.createPropertyAssignment("headers", this.createHeadersObjectExpression())
+        ]);
+    }
+
+    private createHeadersObjectExpression(): ts.Expression {
+        const headerProperties: ts.ObjectLiteralElementLike[] = [];
+
+        // Add args.headers spread
+        headerProperties.push(
+            ts.factory.createSpreadAssignment(
+                this.getReferenceToArg(GeneratedDefaultWebsocketImplementation.HEADERS_PROPERTY_NAME)
+            )
+        );
+
+        // Add Authorization header if provided: ...(args.Authorization ? { Authorization: args.Authorization } : {})
+        headerProperties.push(
+            ts.factory.createSpreadAssignment(
+                ts.factory.createParenthesizedExpression(
+                    ts.factory.createConditionalExpression(
+                        this.getReferenceToArg("Authorization"),
+                        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                        ts.factory.createObjectLiteralExpression([
+                            ts.factory.createPropertyAssignment(
+                                "Authorization",
+                                this.getReferenceToArg("Authorization")
+                            )
+                        ]),
+                        ts.factory.createToken(ts.SyntaxKind.ColonToken),
+                        ts.factory.createObjectLiteralExpression()
                     )
                 )
-            ]),
-            headers: ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME)
-        });
+            )
+        );
+
+        return ts.factory.createObjectLiteralExpression(headerProperties, true);
+    }
+
+    private createReconnectingOptionsExpression(): ts.Expression {
+        return ts.factory.createObjectLiteralExpression([
+            ts.factory.createPropertyAssignment(
+                "debug",
+                ts.factory.createBinaryExpression(
+                    this.getReferenceToArg(GeneratedDefaultWebsocketImplementation.DEBUG_PROPERTY_NAME),
+                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                    ts.factory.createFalse()
+                )
+            ),
+            ts.factory.createPropertyAssignment(
+                "maxRetries",
+                ts.factory.createBinaryExpression(
+                    this.getReferenceToArg(GeneratedDefaultWebsocketImplementation.RECONNECT_ATTEMPTS_PROPERTY_NAME),
+                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                    ts.factory.createNumericLiteral(
+                        GeneratedDefaultWebsocketImplementation.DEFAULT_NUM_RECONNECT_ATTEMPTS
+                    )
+                )
+            )
+        ]);
+    }
+
+    private createReconnectingWebSocketExpression(): ts.Expression {
+        return ts.factory.createNewExpression(
+            ts.factory.createPropertyAccessExpression(
+                ts.factory.createIdentifier("core"),
+                ts.factory.createIdentifier("ReconnectingWebSocket")
+            ),
+            undefined,
+            [
+                ts.factory.createIdentifier("createWebSocket"), // websocketFactory
+                ts.factory.createIdentifier("url"), // url variable
+                ts.factory.createIdentifier("clientOptions"), // clientOptions variable
+                ts.factory.createIdentifier("reconnectingOptions") // reconnectingOptions variable
+            ]
+        );
     }
 
     private buildFullUrl(url: ts.Expression, channel: WebSocketChannel, context: SdkContext): ts.Expression {

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -47,6 +47,7 @@
     "@fern-typescript/sdk-error-generator": "workspace:*",
     "@fern-typescript/sdk-error-schema-generator": "workspace:*",
     "@fern-typescript/sdk-inlined-request-schema-generator": "workspace:*",
+    "@fern-typescript/sdk-client-utils-generator": "workspace:*",
     "@fern-typescript/websocket-type-schema-generator": "workspace:*",
     "@fern-typescript/type-generator": "workspace:*",
     "@fern-typescript/type-reference-converters": "workspace:*",

--- a/generators/typescript/sdk/generator/src/contexts/SdkContextImpl.ts
+++ b/generators/typescript/sdk/generator/src/contexts/SdkContextImpl.ts
@@ -13,6 +13,7 @@ import {
     GenericAPISdkErrorContext,
     JsonContext,
     SdkClientClassContext,
+    SdkClientUtilsContext,
     SdkContext,
     SdkInlinedRequestBodySchemaContext,
     TimeoutSdkErrorContext,
@@ -24,6 +25,7 @@ import { GenericAPISdkErrorGenerator, TimeoutSdkErrorGenerator } from "@fern-typ
 import { RequestWrapperGenerator } from "@fern-typescript/request-wrapper-generator";
 import { ErrorResolver, PackageResolver, TypeResolver } from "@fern-typescript/resolvers";
 import { SdkClientClassGenerator, WebsocketClassGenerator } from "@fern-typescript/sdk-client-class-generator";
+import { SdkClientUtilsGenerator } from "@fern-typescript/sdk-client-utils-generator";
 import { SdkEndpointTypeSchemasGenerator } from "@fern-typescript/sdk-endpoint-type-schemas-generator";
 import { SdkErrorGenerator } from "@fern-typescript/sdk-error-generator";
 import { SdkErrorSchemaGenerator } from "@fern-typescript/sdk-error-schema-generator";
@@ -46,6 +48,7 @@ import { GenericAPISdkErrorDeclarationReferencer } from "../declaration-referenc
 import { JsonDeclarationReferencer } from "../declaration-referencers/JsonDeclarationReferencer";
 import { RequestWrapperDeclarationReferencer } from "../declaration-referencers/RequestWrapperDeclarationReferencer";
 import { SdkClientClassDeclarationReferencer } from "../declaration-referencers/SdkClientClassDeclarationReferencer";
+import { SdkClientUtilsDeclarationReferencer } from "../declaration-referencers/SdkClientUtilsDeclarationReferencer";
 import { SdkErrorDeclarationReferencer } from "../declaration-referencers/SdkErrorDeclarationReferencer";
 import { SdkInlinedRequestBodyDeclarationReferencer } from "../declaration-referencers/SdkInlinedRequestBodyDeclarationReferencer";
 import { TimeoutSdkErrorDeclarationReferencer } from "../declaration-referencers/TimeoutSdkErrorDeclarationReferencer";
@@ -60,6 +63,7 @@ import { GenericAPISdkErrorContextImpl } from "./generic-api-sdk-error/GenericAP
 import { JsonContextImpl } from "./json/JsonContextImpl";
 import { RequestWrapperContextImpl } from "./request-wrapper/RequestWrapperContextImpl";
 import { SdkClientClassContextImpl } from "./sdk-client-class/SdkClientClassContextImpl";
+import { SdkClientUtilsContextImpl } from "./sdk-client-utils/SdkClientUtilsContextImpl";
 import { SdkEndpointTypeSchemasContextImpl } from "./sdk-endpoint-type-schemas/SdkEndpointTypeSchemasContextImpl";
 import { SdkErrorSchemaContextImpl } from "./sdk-error-schema/SdkErrorSchemaContextImpl";
 import { SdkErrorContextImpl } from "./sdk-error/SdkErrorContextImpl";
@@ -110,6 +114,8 @@ export declare namespace SdkContextImpl {
         sdkEndpointTypeSchemasGenerator: SdkEndpointTypeSchemasGenerator;
         sdkClientClassDeclarationReferencer: SdkClientClassDeclarationReferencer;
         sdkClientClassGenerator: SdkClientClassGenerator;
+        sdkClientUtilsDeclarationReferencer: SdkClientUtilsDeclarationReferencer;
+        sdkClientUtilsGenerator: SdkClientUtilsGenerator;
         websocketSocketDeclarationReferencer: WebsocketSocketDeclarationReferencer;
         websocketTypeSchemaDeclarationReferencer: WebsocketTypeSchemaDeclarationReferencer;
         websocketGenerator: WebsocketClassGenerator;
@@ -163,6 +169,7 @@ export class SdkContextImpl implements SdkContext {
     public readonly sdkInlinedRequestBodySchema: SdkInlinedRequestBodySchemaContext;
     public readonly sdkEndpointTypeSchemas: SdkEndpointTypeSchemasContextImpl;
     public readonly sdkClientClass: SdkClientClassContext;
+    public readonly sdkClientUtils: SdkClientUtilsContext;
     public readonly websocketTypeSchema: WebsocketTypeSchemaContext;
     public readonly websocket: WebsocketContextImpl;
     public readonly environments: EnvironmentsContext;
@@ -212,6 +219,8 @@ export class SdkContextImpl implements SdkContext {
         packageResolver,
         sdkClientClassDeclarationReferencer,
         sdkClientClassGenerator,
+        sdkClientUtilsDeclarationReferencer,
+        sdkClientUtilsGenerator,
         websocketTypeSchemaDeclarationReferencer,
         environmentsGenerator,
         environmentsDeclarationReferencer,
@@ -365,6 +374,12 @@ export class SdkContextImpl implements SdkContext {
             sdkClientClassDeclarationReferencer,
             sdkClientClassGenerator,
             packageResolver
+        });
+        this.sdkClientUtils = new SdkClientUtilsContextImpl({
+            sourceFile: this.sourceFile,
+            importsManager,
+            sdkClientUtilsDeclarationReferencer,
+            sdkClientUtilsGenerator
         });
         this.websocketTypeSchema = new WebsocketTypeSchemaContextImpl({
             sourceFile: this.sourceFile,

--- a/generators/typescript/sdk/generator/src/contexts/sdk-client-utils/SdkClientUtilsContextImpl.ts
+++ b/generators/typescript/sdk/generator/src/contexts/sdk-client-utils/SdkClientUtilsContextImpl.ts
@@ -1,0 +1,66 @@
+import { ImportsManager, NpmPackage, PackageId, Reference } from "@fern-typescript/commons";
+import { GeneratedSdkClientUtils, SdkClientUtilsContext } from "@fern-typescript/contexts";
+import { SdkClientUtilsGenerator } from "@fern-typescript/sdk-client-utils-generator";
+import { SourceFile } from "ts-morph";
+
+import { SdkClientUtilsDeclarationReferencer } from "../../declaration-referencers/SdkClientUtilsDeclarationReferencer";
+
+export declare namespace SdkClientUtilsContextImpl {
+    export interface Init {
+        sourceFile: SourceFile;
+        importsManager: ImportsManager;
+        sdkClientUtilsDeclarationReferencer: SdkClientUtilsDeclarationReferencer;
+        sdkClientUtilsGenerator: SdkClientUtilsGenerator;
+    }
+}
+
+export class SdkClientUtilsContextImpl implements SdkClientUtilsContext {
+    public sourceFile: SourceFile;
+    public importsManager: ImportsManager;
+    public sdkClientUtilsGenerator: SdkClientUtilsGenerator;
+    public sdkClientUtilsDeclarationReferencer: SdkClientUtilsDeclarationReferencer;
+
+    constructor({
+        sourceFile,
+        importsManager,
+        sdkClientUtilsGenerator,
+        sdkClientUtilsDeclarationReferencer
+    }: SdkClientUtilsContextImpl.Init) {
+        this.sourceFile = sourceFile;
+        this.importsManager = importsManager;
+        this.sdkClientUtilsGenerator = sdkClientUtilsGenerator;
+        this.sdkClientUtilsDeclarationReferencer = sdkClientUtilsDeclarationReferencer;
+    }
+
+    public getGeneratedUtilsFile(packageId: PackageId, filename: string): GeneratedSdkClientUtils {
+        return this.sdkClientUtilsGenerator.generateUtilsFile({
+            packageId,
+            filename,
+            importsManager: this.importsManager
+        });
+    }
+
+    public getReferenceToUtils(
+        packageId: PackageId,
+        { importAlias, npmPackage }: { importAlias?: string; npmPackage?: NpmPackage } = {}
+    ): Reference {
+        if (packageId.isRoot) {
+            throw new Error("Utils are only generated for subpackages, not root package");
+        }
+
+        if (npmPackage != null) {
+            return this.sdkClientUtilsDeclarationReferencer.getReferenceToUtils({
+                name: packageId.subpackageId,
+                referencedIn: this.sourceFile,
+                importsManager: this.importsManager,
+                importStrategy: { type: "fromPackage", packageName: npmPackage.packageName }
+            });
+        }
+        return this.sdkClientUtilsDeclarationReferencer.getReferenceToUtils({
+            name: packageId.subpackageId,
+            referencedIn: this.sourceFile,
+            importsManager: this.importsManager,
+            importStrategy: { type: "direct", alias: importAlias }
+        });
+    }
+}

--- a/generators/typescript/sdk/generator/src/declaration-referencers/SdkClientUtilsDeclarationReferencer.ts
+++ b/generators/typescript/sdk/generator/src/declaration-referencers/SdkClientUtilsDeclarationReferencer.ts
@@ -1,0 +1,67 @@
+import {
+    ExportedDirectory,
+    ExportedFilePath,
+    PackageId,
+    Reference,
+    getExportedDirectoriesForFernFilepath
+} from "@fern-typescript/commons";
+
+import { SubpackageId } from "@fern-fern/ir-sdk/api";
+
+import { AbstractSdkClientClassDeclarationReferencer } from "./AbstractSdkClientClassDeclarationReferencer";
+import { DeclarationReferencer } from "./DeclarationReferencer";
+
+const UTILS_DIRECTORY = "utils";
+
+export class SdkClientUtilsDeclarationReferencer extends AbstractSdkClientClassDeclarationReferencer<SubpackageId> {
+    public getExportedFilepath(subpackageId: SubpackageId, filename?: string): ExportedFilePath {
+        return {
+            directories: this.getExportedDirectory(subpackageId),
+            file: {
+                nameOnDisk: filename ?? this.getFilename()
+            }
+        };
+    }
+
+    public getAllExportedFilepaths(subpackageId: SubpackageId): Record<string, ExportedFilePath> {
+        const baseDir = this.getExportedDirectory(subpackageId);
+        return {
+            "createWebSocket.ts": { directories: baseDir, file: { nameOnDisk: "createWebSocket.ts" } },
+            "getAuthHeaders.ts": { directories: baseDir, file: { nameOnDisk: "getAuthHeaders.ts" } },
+            "getAuthProtocols.ts": { directories: baseDir, file: { nameOnDisk: "getAuthProtocols.ts" } },
+            "getHeaders.ts": { directories: baseDir, file: { nameOnDisk: "getHeaders.ts" } }
+        };
+    }
+
+    protected getExportedDirectory(subpackageId: SubpackageId): ExportedDirectory[] {
+        const fernFilepath = this.packageResolver.resolvePackage(this.getPackageIdFromName(subpackageId)).fernFilepath;
+
+        return [
+            ...this.containingDirectory,
+            ...getExportedDirectoriesForFernFilepath({
+                fernFilepath
+            }),
+            {
+                nameOnDisk: UTILS_DIRECTORY,
+                exportDeclaration: { exportAll: true }
+            }
+        ];
+    }
+
+    public getFilename(): string {
+        return "index.ts";
+    }
+
+    public getExportedName(subpackageId: SubpackageId): string {
+        const subpackage = this.packageResolver.resolveSubpackage(subpackageId);
+        return `${subpackage.name.pascalCase.safeName}Utils`;
+    }
+
+    public getReferenceToUtils(args: DeclarationReferencer.getReferenceTo.Options<SubpackageId>): Reference {
+        return this.getReferenceTo(this.getExportedName(args.name), args);
+    }
+
+    protected getPackageIdFromName(subpackageId: SubpackageId): PackageId {
+        return { isRoot: false, subpackageId };
+    }
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/.depcheckrc.json
+++ b/generators/typescript/sdk/sdk-client-utils-generator/.depcheckrc.json
@@ -1,0 +1,14 @@
+{
+  "ignores": [
+    "@fern-api/configs",
+    "@types/jest",
+    "@types/lodash-es",
+    "@types/node",
+    "depcheck",
+    "eslint",
+    "prettier",
+    "@trivago/prettier-plugin-sort-imports",
+    "typescript",
+    "vitest"
+  ]
+} 

--- a/generators/typescript/sdk/sdk-client-utils-generator/.prettierrc.cjs
+++ b/generators/typescript/sdk/sdk-client-utils-generator/.prettierrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require("../../../../.prettierrc.json");

--- a/generators/typescript/sdk/sdk-client-utils-generator/package.json
+++ b/generators/typescript/sdk/sdk-client-utils-generator/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@fern-typescript/sdk-client-utils-generator",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fern-api/fern.git",
+    "directory": "generators/typescript/sdk/sdk-client-utils-generator"
+  },
+  "files": [
+    "lib"
+  ],
+  "type": "module",
+  "source": "src/index.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -rf ./lib && tsc --build --clean",
+    "compile": "tsc --build",
+    "test": "vitest --passWithNoTests --run",
+    "test:update": "vitest --passWithNoTests --run -u",
+    "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../../../.eslintignore",
+    "lint:eslint:fix": "yarn lint:eslint --fix",
+    "format": "prettier --write --ignore-unknown --ignore-path ../../../../shared/.prettierignore \"**\"",
+    "format:check": "prettier --check --ignore-unknown --ignore-path ../../../../shared/.prettierignore \"**\"",
+    "depcheck": "depcheck"
+  },
+  "dependencies": {
+    "@fern-api/core-utils": "workspace:*",
+    "@fern-fern/ir-sdk": "57.0.0",
+    "@fern-typescript/commons": "workspace:*",
+    "@fern-typescript/contexts": "workspace:*",
+    "@fern-typescript/resolvers": "workspace:*",
+    "lodash-es": "^4.17.21",
+    "ts-morph": "^15.1.0",
+    "ts-poet": "^6.7.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/lodash-es": "^4.17.12",
+    "@fern-api/configs": "workspace:*",
+    "@types/node": "18.15.3",
+    "depcheck": "^1.4.7",
+    "eslint": "^8.56.0",
+    "prettier": "^3.4.2",
+    "@trivago/prettier-plugin-sort-imports": "^5.2.1",
+    "typescript": "5.7.2",
+    "vitest": "^2.1.9"
+  }
+} 

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedCreateWebSocketImpl.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedCreateWebSocketImpl.ts
@@ -1,0 +1,248 @@
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { SdkContext } from "@fern-typescript/contexts";
+import { CodeBlockWriter, WriterFunction, ts } from "ts-morph";
+
+import { BaseGeneratedUtilsFileImpl } from "./GeneratedUtilsFileImpl";
+
+// createWebSocket.ts
+export class GeneratedCreateWebSocketImpl extends BaseGeneratedUtilsFileImpl {
+    public writeToFile(context: SdkContext): void {
+        // Add all necessary imports
+        this.addImports();
+
+        // Generate the createWebSocket function using proper AST patterns
+        this.generateCreateWebSocketFunction(context);
+    }
+
+    private addImports(): void {
+        this.importsManager.addImport("../../../../core", {
+            namedImports: ["Supplier", "WebSocketLike"]
+        });
+
+        this.importsManager.addImport("../../../../core/runtime", {
+            namedImports: ["RUNTIME"]
+        });
+
+        this.importsManager.addImport("../../../../core/websocket/ws", {
+            namedImports: ["WebSocketClientOptions"]
+        });
+
+        this.importsManager.addImport("./getAuthHeaders", {
+            namedImports: ["getAuthHeaders"]
+        });
+
+        this.importsManager.addImport("./getAuthProtocols", {
+            namedImports: ["getAuthProtocols"]
+        });
+
+        this.importsManager.addImport("./getHeaders", {
+            namedImports: ["getHeaders"]
+        });
+    }
+
+    private generateCreateWebSocketFunction(context: SdkContext): void {
+        const functionBody: WriterFunction = (writer) => {
+            // Use AST for the resolved key statement
+            const resolvedKeyStmt = this.createResolvedKeyStatement();
+            writer.write(getTextOfTsNode(resolvedKeyStmt));
+            writer.newLine();
+
+            // Use structured approach for switch statement
+            this.writeSwitchStatement(writer);
+        };
+
+        context.sourceFile.addFunction({
+            name: "createWebSocket",
+            isExported: true,
+            isAsync: true,
+            typeParameters: [this.createOptionsTypeParameter()],
+            parameters: [this.createUrlParameter(), this.createOptionsParameter()],
+            returnType: this.createReturnType(),
+            statements: functionBody
+        });
+    }
+
+    private createOptionsTypeParameter() {
+        return {
+            name: "Options",
+            constraint: "WebSocketClientOptions"
+        };
+    }
+
+    private createUrlParameter() {
+        return {
+            name: "url",
+            type: this.createStringType()
+        };
+    }
+
+    private createOptionsParameter() {
+        return {
+            name: "options",
+            type: "Options"
+        };
+    }
+
+    private createReturnType() {
+        return "Promise<WebSocketLike>";
+    }
+
+    private createResolvedKeyStatement() {
+        return ts.factory.createVariableStatement(
+            undefined,
+            ts.factory.createVariableDeclarationList(
+                [
+                    ts.factory.createVariableDeclaration(
+                        ts.factory.createIdentifier("resolvedKey"),
+                        undefined,
+                        undefined,
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createPropertyAccessExpression(
+                                    ts.factory.createIdentifier("Supplier"),
+                                    ts.factory.createIdentifier("get")
+                                ),
+                                undefined,
+                                [
+                                    ts.factory.createPropertyAccessExpression(
+                                        ts.factory.createIdentifier("options"),
+                                        ts.factory.createIdentifier("apiKey")
+                                    )
+                                ]
+                            )
+                        )
+                    )
+                ],
+                ts.NodeFlags.Const
+            )
+        );
+    }
+
+    private writeSwitchStatement(writer: CodeBlockWriter): void {
+        writer.writeLine("switch (RUNTIME.type) {");
+        writer.indent(() => {
+            this.writeBrowserCases(writer);
+            this.writeNodeCase(writer);
+            this.writeUnsupportedRuntimeCases(writer);
+        });
+        writer.writeLine("}");
+    }
+
+    private writeBrowserCases(writer: CodeBlockWriter): void {
+        const browserRuntimes = ["browser", "react-native", "web-worker", "deno", "bun"];
+
+        browserRuntimes.forEach((runtime) => {
+            writer.writeLine(`case "${runtime}":`);
+        });
+
+        writer.indent(() => {
+            const webSocketCreation = this.createBrowserWebSocketExpression();
+            writer.writeLine(`return ${getTextOfTsNode(webSocketCreation)};`);
+        });
+        writer.newLine();
+    }
+
+    private createBrowserWebSocketExpression() {
+        return ts.factory.createNewExpression(ts.factory.createIdentifier("WebSocket"), undefined, [
+            ts.factory.createIdentifier("url"),
+            ts.factory.createArrayLiteralExpression([
+                ts.factory.createSpreadElement(
+                    ts.factory.createCallExpression(ts.factory.createIdentifier("getAuthProtocols"), undefined, [
+                        ts.factory.createIdentifier("resolvedKey")
+                    ])
+                ),
+                ts.factory.createSpreadElement(
+                    ts.factory.createParenthesizedExpression(
+                        ts.factory.createBinaryExpression(
+                            ts.factory.createPropertyAccessExpression(
+                                ts.factory.createIdentifier("options"),
+                                ts.factory.createIdentifier("protocols")
+                            ),
+                            ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                            ts.factory.createArrayLiteralExpression()
+                        )
+                    )
+                )
+            ])
+        ]);
+    }
+
+    private writeNodeCase(writer: CodeBlockWriter): void {
+        writer.writeLine('case "node": {');
+        writer.indent(() => {
+            // Dynamic import for WebSocket
+            writer.writeLine("const WebSocket = await import('ws').then(m => m.default || m.WebSocket);");
+            writer.writeLine("// @ts-expect-error");
+
+            const nodeWebSocketCreation = this.createNodeWebSocketExpression();
+            writer.writeLine(`return ${getTextOfTsNode(nodeWebSocketCreation)};`);
+        });
+        writer.writeLine("}");
+        writer.newLine();
+    }
+
+    private createNodeWebSocketExpression() {
+        return ts.factory.createNewExpression(ts.factory.createIdentifier("WebSocket"), undefined, [
+            ts.factory.createIdentifier("url"),
+            ts.factory.createObjectLiteralExpression([
+                ts.factory.createSpreadAssignment(ts.factory.createIdentifier("options")),
+                ts.factory.createPropertyAssignment(
+                    ts.factory.createIdentifier("headers"),
+                    ts.factory.createObjectLiteralExpression([
+                        ts.factory.createSpreadAssignment(
+                            ts.factory.createCallExpression(ts.factory.createIdentifier("getHeaders"), undefined, [])
+                        ),
+                        ts.factory.createSpreadAssignment(
+                            ts.factory.createCallExpression(ts.factory.createIdentifier("getAuthHeaders"), undefined, [
+                                ts.factory.createIdentifier("resolvedKey")
+                            ])
+                        ),
+                        ts.factory.createSpreadAssignment(
+                            ts.factory.createParenthesizedExpression(
+                                ts.factory.createBinaryExpression(
+                                    ts.factory.createPropertyAccessExpression(
+                                        ts.factory.createIdentifier("options"),
+                                        ts.factory.createIdentifier("headers")
+                                    ),
+                                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                    ts.factory.createObjectLiteralExpression()
+                                )
+                            )
+                        )
+                    ])
+                )
+            ])
+        ]);
+    }
+
+    private writeUnsupportedRuntimeCases(writer: CodeBlockWriter): void {
+        const unsupportedRuntimes = ["workerd", "edge-runtime", "unknown"];
+
+        unsupportedRuntimes.forEach((runtime) => {
+            writer.writeLine(`case "${runtime}":`);
+        });
+        writer.writeLine("default:");
+
+        writer.indent(() => {
+            const errorExpression = this.createUnsupportedRuntimeError();
+            writer.writeLine(`throw ${getTextOfTsNode(errorExpression)};`);
+        });
+    }
+
+    private createUnsupportedRuntimeError() {
+        return ts.factory.createNewExpression(ts.factory.createIdentifier("Error"), undefined, [
+            ts.factory.createTemplateExpression(
+                ts.factory.createTemplateHead("websocket client not supported in runtime: "),
+                [
+                    ts.factory.createTemplateSpan(
+                        ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier("RUNTIME"),
+                            ts.factory.createIdentifier("type")
+                        ),
+                        ts.factory.createTemplateTail("")
+                    )
+                ]
+            )
+        ]);
+    }
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedGetAuthHeadersImpl.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedGetAuthHeadersImpl.ts
@@ -1,0 +1,42 @@
+import { FernWriters } from "@fern-typescript/commons";
+import { SdkContext } from "@fern-typescript/contexts";
+import { WriterFunction } from "ts-morph";
+
+import { BaseGeneratedUtilsFileImpl } from "./GeneratedUtilsFileImpl";
+
+// getAuthHeaders.ts
+export class GeneratedGetAuthHeadersImpl extends BaseGeneratedUtilsFileImpl {
+    public writeToFile(context: SdkContext): void {
+        // Create the getAuthHeaders function using proper Fern patterns
+        this.generateGetAuthHeadersFunction(context);
+    }
+
+    private generateGetAuthHeadersFunction(context: SdkContext): void {
+        const authHeadersObjectWriter = this.createAuthHeadersObject();
+
+        const functionBody: WriterFunction = (writer) => {
+            writer.write("return ");
+            authHeadersObjectWriter.toFunction()(writer);
+            writer.write(";");
+        };
+
+        context.sourceFile.addFunction({
+            name: "getAuthHeaders",
+            isExported: true,
+            parameters: [this.createApiKeyParameter()],
+            returnType: this.createStringRecordType(),
+            statements: functionBody
+        });
+    }
+
+    private createAuthHeadersObject() {
+        const authHeadersObjectWriter = FernWriters.object.writer({ asConst: false });
+        authHeadersObjectWriter.addProperty({
+            key: "Authorization",
+            value: "`token ${apiKey}`"
+        });
+        return authHeadersObjectWriter;
+    }
+
+    // Using shared utility methods from base class
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedGetAuthProtocolsImpl.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedGetAuthProtocolsImpl.ts
@@ -1,0 +1,28 @@
+import { SdkContext } from "@fern-typescript/contexts";
+import { WriterFunction } from "ts-morph";
+
+import { BaseGeneratedUtilsFileImpl } from "./GeneratedUtilsFileImpl";
+
+// getAuthProtocols.ts
+export class GeneratedGetAuthProtocolsImpl extends BaseGeneratedUtilsFileImpl {
+    public writeToFile(context: SdkContext): void {
+        // Generate the getAuthProtocols function using proper Fern patterns
+        this.generateGetAuthProtocolsFunction(context);
+    }
+
+    private generateGetAuthProtocolsFunction(context: SdkContext): void {
+        const functionBody: WriterFunction = (writer) => {
+            writer.write("return [apiKey];");
+        };
+
+        context.sourceFile.addFunction({
+            name: "getAuthProtocols",
+            isExported: true,
+            parameters: [this.createApiKeyParameter()],
+            returnType: this.createStringArrayType(),
+            statements: functionBody
+        });
+    }
+
+    // Using shared utility methods from base class
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedGetHeadersImpl.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedGetHeadersImpl.ts
@@ -1,0 +1,99 @@
+import { FernWriters } from "@fern-typescript/commons";
+import { SdkContext } from "@fern-typescript/contexts";
+import { VariableDeclarationKind, WriterFunction } from "ts-morph";
+
+import { BaseGeneratedUtilsFileImpl } from "./GeneratedUtilsFileImpl";
+
+// getHeaders.ts
+export class GeneratedGetHeadersImpl extends BaseGeneratedUtilsFileImpl {
+    private static readonly CORS_SENSITIVE_RUNTIMES = [
+        "browser",
+        "web-worker",
+        "workerd",
+        "edge-runtime",
+        "react-native"
+    ];
+
+    // hardcoding these because i think they've already been moved to core
+    private static readonly SDK_HEADERS = {
+        "User-Agent": "deepgram/1.0.4",
+        "X-Fern-Language": "JavaScript",
+        "X-Fern-SDK-Name": "deepgram",
+        "X-Fern-SDK-Version": "1.0.4",
+        "X-Fern-Runtime": "RUNTIME.type",
+        "X-Fern-Runtime-Version": 'RUNTIME.version ?? "unknown"'
+    };
+
+    public writeToFile(context: SdkContext): void {
+        this.addRuntimeImport();
+        this.generateRuntimeIsCorsSensitiveFunction(context);
+        this.generateGetHeadersFunction(context);
+    }
+
+    private addRuntimeImport(): void {
+        this.importsManager.addImport("../../../../core/runtime", {
+            namedImports: ["RUNTIME"]
+        });
+    }
+
+    private generateRuntimeIsCorsSensitiveFunction(context: SdkContext): void {
+        const functionBody: WriterFunction = (writer) => {
+            const runtimeList = GeneratedGetHeadersImpl.CORS_SENSITIVE_RUNTIMES.map((runtime) => `"${runtime}"`).join(
+                ", "
+            );
+            writer.writeLine(`return [${runtimeList}].includes(RUNTIME.type);`);
+        };
+
+        const arrowFunction: WriterFunction = (writer) => {
+            writer.write("(): boolean => ");
+            writer.block(() => {
+                functionBody(writer);
+            });
+        };
+
+        context.sourceFile.addVariableStatement({
+            declarationKind: VariableDeclarationKind.Const,
+            declarations: [
+                {
+                    name: "_runtimeIsCorsSensitive",
+                    initializer: arrowFunction
+                }
+            ]
+        });
+    }
+
+    private generateGetHeadersFunction(context: SdkContext): void {
+        const headersObjectWriter = this.createHeadersObject();
+
+        const functionBody: WriterFunction = (writer) => {
+            writer.write("return (_runtimeIsCorsSensitive() ? {} : ");
+            headersObjectWriter.toFunction()(writer);
+            writer.write(");");
+        };
+
+        context.sourceFile.addFunction({
+            name: "getHeaders",
+            isExported: true,
+            returnType: this.createStringRecordType(),
+            statements: functionBody
+        });
+    }
+
+    private createHeadersObject() {
+        const headersObjectWriter = FernWriters.object.writer({ asConst: false });
+
+        Object.entries(GeneratedGetHeadersImpl.SDK_HEADERS).forEach(([key, value]) => {
+            const quotedKey = key.startsWith('"') ? key : `"${key}"`;
+            const quotedValue = value.startsWith('"') || value.includes("RUNTIME") ? value : `"${value}"`;
+
+            headersObjectWriter.addProperty({
+                key: quotedKey,
+                value: quotedValue
+            });
+        });
+
+        return headersObjectWriter;
+    }
+
+    // Using shared utility methods from base class
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedUtilsFileImpl.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/GeneratedUtilsFileImpl.ts
@@ -1,0 +1,126 @@
+import {
+    ImportsManager,
+    JavaScriptRuntime,
+    NpmPackage,
+    PackageId,
+    getExportedDirectoriesForFernFilepath
+} from "@fern-typescript/commons";
+import { GeneratedSdkClientUtils, SdkContext } from "@fern-typescript/contexts";
+import { ErrorResolver, PackageResolver } from "@fern-typescript/resolvers";
+
+import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
+
+export declare namespace BaseGeneratedUtilsFileImpl {
+    export interface Init {
+        importsManager: ImportsManager;
+        intermediateRepresentation: IntermediateRepresentation;
+        packageId: PackageId;
+        packageResolver: PackageResolver;
+        errorResolver: ErrorResolver;
+        targetRuntime: JavaScriptRuntime;
+        npmPackage: NpmPackage | undefined;
+        includeSerdeLayer: boolean;
+        retainOriginalCasing: boolean;
+        omitUndefined: boolean;
+        allowExtraFields: boolean;
+        filename: string;
+    }
+}
+
+export abstract class BaseGeneratedUtilsFileImpl {
+    protected importsManager: ImportsManager;
+    protected intermediateRepresentation: IntermediateRepresentation;
+    protected packageId: PackageId;
+    protected packageResolver: PackageResolver;
+    protected errorResolver: ErrorResolver;
+    protected targetRuntime: JavaScriptRuntime;
+    protected npmPackage: NpmPackage | undefined;
+    protected includeSerdeLayer: boolean;
+    protected retainOriginalCasing: boolean;
+    protected omitUndefined: boolean;
+    protected allowExtraFields: boolean;
+    protected _filename: string;
+
+    constructor({
+        importsManager,
+        intermediateRepresentation,
+        packageId,
+        packageResolver,
+        errorResolver,
+        targetRuntime,
+        npmPackage,
+        includeSerdeLayer,
+        retainOriginalCasing,
+        omitUndefined,
+        allowExtraFields,
+        filename
+    }: BaseGeneratedUtilsFileImpl.Init) {
+        this.importsManager = importsManager;
+        this.intermediateRepresentation = intermediateRepresentation;
+        this.packageId = packageId;
+        this.packageResolver = packageResolver;
+        this.errorResolver = errorResolver;
+        this.targetRuntime = targetRuntime;
+        this.npmPackage = npmPackage;
+        this.includeSerdeLayer = includeSerdeLayer;
+        this.retainOriginalCasing = retainOriginalCasing;
+        this.omitUndefined = omitUndefined;
+        this.allowExtraFields = allowExtraFields;
+        this._filename = filename;
+    }
+
+    public get filename(): string {
+        return this._filename;
+    }
+
+    public get outputDirectory(): string {
+        const package_ = this.packageResolver.resolvePackage(this.packageId);
+        const exportedDirectories = getExportedDirectoriesForFernFilepath({
+            fernFilepath: package_.fernFilepath
+        });
+
+        const pathParts = ["api"];
+
+        if (!this.packageId.isRoot) {
+            pathParts.push("resources");
+            if (exportedDirectories.length > 0) {
+                pathParts.push(...exportedDirectories.map((dir) => dir.nameOnDisk));
+            } else {
+                pathParts.push(this.packageId.subpackageId);
+            }
+        } else if (exportedDirectories.length > 0) {
+            pathParts.push("resources");
+            pathParts.push(...exportedDirectories.map((dir) => dir.nameOnDisk));
+        }
+
+        pathParts.push("utils");
+
+        return pathParts.join("/");
+    }
+
+    public abstract writeToFile(context: SdkContext): void;
+
+    // Common AST utility methods for consistent type definitions
+    protected createApiKeyParameter(): { name: string; type: string } {
+        return {
+            name: "apiKey",
+            type: "string"
+        };
+    }
+
+    protected createStringRecordType(): string {
+        return "Record<string, string>";
+    }
+
+    protected createStringArrayType(): string {
+        return "string[]";
+    }
+
+    protected createStringType(): string {
+        return "string";
+    }
+
+    protected createBooleanType(): string {
+        return "boolean";
+    }
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/SdkClientUtilsGenerator.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/SdkClientUtilsGenerator.ts
@@ -1,0 +1,111 @@
+import { ImportsManager, JavaScriptRuntime, NpmPackage, PackageId } from "@fern-typescript/commons";
+import { GeneratedSdkClientUtils } from "@fern-typescript/contexts";
+import { ErrorResolver, PackageResolver } from "@fern-typescript/resolvers";
+
+import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
+
+import { GeneratedCreateWebSocketImpl } from "./GeneratedCreateWebSocketImpl";
+import { GeneratedGetAuthHeadersImpl } from "./GeneratedGetAuthHeadersImpl";
+import { GeneratedGetAuthProtocolsImpl } from "./GeneratedGetAuthProtocolsImpl";
+import { GeneratedGetHeadersImpl } from "./GeneratedGetHeadersImpl";
+
+export declare namespace SdkClientUtilsGenerator {
+    export interface Init {
+        intermediateRepresentation: IntermediateRepresentation;
+        errorResolver: ErrorResolver;
+        packageResolver: PackageResolver;
+        targetRuntime: JavaScriptRuntime;
+        npmPackage: NpmPackage | undefined;
+        includeSerdeLayer: boolean;
+        retainOriginalCasing: boolean;
+        omitUndefined: boolean;
+        allowExtraFields: boolean;
+    }
+}
+
+export class SdkClientUtilsGenerator {
+    private intermediateRepresentation: IntermediateRepresentation;
+    private errorResolver: ErrorResolver;
+    private packageResolver: PackageResolver;
+    private targetRuntime: JavaScriptRuntime;
+    private npmPackage: NpmPackage | undefined;
+    private includeSerdeLayer: boolean;
+    private retainOriginalCasing: boolean;
+    private omitUndefined: boolean;
+    private allowExtraFields: boolean;
+
+    constructor({
+        intermediateRepresentation,
+        errorResolver,
+        packageResolver,
+        targetRuntime,
+        npmPackage,
+        includeSerdeLayer,
+        retainOriginalCasing,
+        omitUndefined,
+        allowExtraFields
+    }: SdkClientUtilsGenerator.Init) {
+        this.intermediateRepresentation = intermediateRepresentation;
+        this.errorResolver = errorResolver;
+        this.packageResolver = packageResolver;
+        this.targetRuntime = targetRuntime;
+        this.npmPackage = npmPackage;
+        this.includeSerdeLayer = includeSerdeLayer;
+        this.retainOriginalCasing = retainOriginalCasing;
+        this.omitUndefined = omitUndefined;
+        this.allowExtraFields = allowExtraFields;
+    }
+
+    private getCommonProps(packageId: PackageId, importsManager: ImportsManager) {
+        return {
+            importsManager,
+            intermediateRepresentation: this.intermediateRepresentation,
+            packageId,
+            packageResolver: this.packageResolver,
+            errorResolver: this.errorResolver,
+            targetRuntime: this.targetRuntime,
+            npmPackage: this.npmPackage,
+            includeSerdeLayer: this.includeSerdeLayer,
+            retainOriginalCasing: this.retainOriginalCasing,
+            omitUndefined: this.omitUndefined,
+            allowExtraFields: this.allowExtraFields
+        };
+    }
+
+    public generateUtilsFile({
+        packageId,
+        filename,
+        importsManager
+    }: {
+        packageId: PackageId;
+        filename: string;
+        importsManager: ImportsManager;
+    }): GeneratedSdkClientUtils {
+        const commonProps = this.getCommonProps(packageId, importsManager);
+
+        switch (filename) {
+            case "createWebSocket.ts":
+                return new GeneratedCreateWebSocketImpl({
+                    ...commonProps,
+                    filename
+                });
+            case "getAuthHeaders.ts":
+                return new GeneratedGetAuthHeadersImpl({
+                    ...commonProps,
+                    filename
+                });
+            case "getAuthProtocols.ts":
+                return new GeneratedGetAuthProtocolsImpl({
+                    ...commonProps,
+                    filename
+                });
+            case "getHeaders.ts":
+                return new GeneratedGetHeadersImpl({
+                    ...commonProps,
+                    filename
+                });
+            default:
+                throw new Error(`Unknown utils filename: ${filename}`);
+        }
+    }
+}

--- a/generators/typescript/sdk/sdk-client-utils-generator/src/index.ts
+++ b/generators/typescript/sdk/sdk-client-utils-generator/src/index.ts
@@ -1,0 +1,1 @@
+export { SdkClientUtilsGenerator } from "./SdkClientUtilsGenerator";

--- a/generators/typescript/sdk/sdk-client-utils-generator/tsconfig.json
+++ b/generators/typescript/sdk/sdk-client-utils-generator/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@fern-api/configs/tsconfig/main.json",
+  "compilerOptions": { "composite": true, "outDir": "lib", "rootDir": "src" },
+  "include": ["./src/**/*"],
+  "references": [
+    { "path": "../../../../packages/commons/core-utils" },
+    { "path": "../../utils/commons" },
+    { "path": "../../utils/contexts" },
+    { "path": "../../utils/resolvers" }
+  ]
+} 

--- a/generators/typescript/utils/contexts/src/sdk-context/SdkContext.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/SdkContext.ts
@@ -13,6 +13,7 @@ import { EnvironmentsContext } from "./environments";
 import { GenericAPISdkErrorContext } from "./generic-api-sdk-error";
 import { RequestWrapperContext } from "./request-wrapper";
 import { SdkClientClassContext } from "./sdk-client-class";
+import { SdkClientUtilsContext } from "./sdk-client-utils";
 import { SdkEndpointTypeSchemasContext } from "./sdk-endpoint-type-schemas";
 import { SdkErrorContext } from "./sdk-error";
 import { SdkErrorSchemaContext } from "./sdk-error-schema";
@@ -41,6 +42,7 @@ export interface SdkContext extends BaseContext {
     timeoutSdkError: TimeoutSdkErrorContext;
     requestWrapper: RequestWrapperContext;
     sdkClientClass: SdkClientClassContext;
+    sdkClientUtils: SdkClientUtilsContext;
     websocket: WebsocketClassContext;
     websocketTypeSchema: WebsocketTypeSchemaContext;
     versionContext: VersionContext;

--- a/generators/typescript/utils/contexts/src/sdk-context/index.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/index.ts
@@ -3,6 +3,7 @@ export * from "./environments";
 export * from "./generic-api-sdk-error";
 export * from "./request-wrapper";
 export * from "./sdk-client-class";
+export * from "./sdk-client-utils";
 export * from "./sdk-endpoint-type-schemas";
 export * from "./sdk-error";
 export * from "./sdk-error-schema";

--- a/generators/typescript/utils/contexts/src/sdk-context/sdk-client-utils/GeneratedSdkClientUtils.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/sdk-client-utils/GeneratedSdkClientUtils.ts
@@ -1,0 +1,7 @@
+import { SdkContext } from "..";
+import { GeneratedFile } from "../../commons/GeneratedFile";
+
+export interface GeneratedSdkClientUtils extends GeneratedFile<SdkContext> {
+    readonly filename: string;
+    readonly outputDirectory: string;
+}

--- a/generators/typescript/utils/contexts/src/sdk-context/sdk-client-utils/SdkClientUtilsContext.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/sdk-client-utils/SdkClientUtilsContext.ts
@@ -1,0 +1,11 @@
+import { NpmPackage, PackageId, Reference } from "@fern-typescript/commons";
+
+import { GeneratedSdkClientUtils } from "./GeneratedSdkClientUtils";
+
+export interface SdkClientUtilsContext {
+    getGeneratedUtilsFile: (packageId: PackageId, filename: string) => GeneratedSdkClientUtils;
+    getReferenceToUtils: (
+        packageId: PackageId,
+        options?: { importAlias?: string; npmPackage?: NpmPackage }
+    ) => Reference;
+}

--- a/generators/typescript/utils/contexts/src/sdk-context/sdk-client-utils/index.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/sdk-client-utils/index.ts
@@ -1,0 +1,2 @@
+export { type GeneratedSdkClientUtils } from "./GeneratedSdkClientUtils";
+export { type SdkClientUtilsContext } from "./SdkClientUtilsContext";

--- a/generators/typescript/utils/core-utilities/fetcher/src/websocket/ws.ts
+++ b/generators/typescript/utils/core-utilities/fetcher/src/websocket/ws.ts
@@ -1,7 +1,10 @@
 import { WebSocket as NodeWebSocket } from "ws";
 
+import { Supplier } from "../fetcher";
 import { RUNTIME } from "../runtime";
 import * as Events from "./events";
+
+const ABNORMAL_CLOSURE_CODE = 1006;
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
     if (typeof WebSocket !== "undefined") {
@@ -58,6 +61,17 @@ export type ListenersMap = {
     close: Array<Events.WebSocketEventListenerMap["close"]>;
 };
 
+export type WebSocketLike = typeof WebSocket extends { new (...args: any): infer W } ? W : never;
+export type WebSocketFactory = <Options extends { apiKey: Supplier<string> }>(
+    url: string,
+    options: Options
+) => Promise<WebSocketLike>;
+export type WebSocketClientOptions = Record<string, unknown> & {
+    apiKey: Supplier<string>;
+    protocols?: string[];
+    headers?: Record<string, unknown>;
+};
+
 export class ReconnectingWebSocket {
     private _ws?: WebSocket;
     private _listeners: ListenersMap = {
@@ -75,15 +89,20 @@ export class ReconnectingWebSocket {
     private _closeCalled = false;
     private _messageQueue: Message[] = [];
 
+    private readonly _websocketFactory: WebSocketFactory;
     private readonly _url: UrlProvider;
-    private readonly _protocols?: string | string[];
     private readonly _options: Options;
-    private readonly _headers?: Record<string, any>;
-    constructor(url: UrlProvider, protocols?: string | string[], options: Options = {}, headers?: Record<string, any>) {
+    private readonly _clientOptions: WebSocketClientOptions;
+    constructor(
+        websocketFactory: WebSocketFactory,
+        url: UrlProvider,
+        clientOptions: WebSocketClientOptions,
+        options: Options
+    ) {
+        this._websocketFactory = websocketFactory;
         this._url = url;
-        this._protocols = protocols;
+        this._clientOptions = clientOptions;
         this._options = options;
-        this._headers = headers;
         if (this._options.startClosed) {
             this._shouldReconnect = false;
         }
@@ -308,6 +327,25 @@ export class ReconnectingWebSocket {
         }
     }
 
+    private _shutdown(error: Error, ...args: any[]) {
+        this._debug("shutting down:", error.message, ...args);
+
+        // Ensure state prevents further attempts
+        this._connectLock = false;
+        this._shouldReconnect = false;
+
+        // Dispatch error event
+        const errorEvent = this._adaptError(error);
+        if (this.onerror) {this.onerror(errorEvent);}
+        this._listeners.error.forEach((listener) => this._callEventListener(errorEvent, listener));
+
+        // Dispatch close event
+        const closeEvent = new Events.CloseEvent(1000, error.message, this);
+
+        if (this.onclose) {this.onclose(closeEvent);}
+        this._listeners.close.forEach((listener) => this._callEventListener(closeEvent, listener));
+    }
+
     private _getNextDelay() {
         const {
             reconnectionDelayGrowFactor = DEFAULT.reconnectionDelayGrowFactor,
@@ -349,9 +387,17 @@ export class ReconnectingWebSocket {
     }
 
     private _connect() {
-        if (this._connectLock || !this._shouldReconnect) {
+        // Check locks and intent
+        if (this._connectLock) {
+            this._debug("connection attempt already in progress.");
             return;
         }
+        if (!this._shouldReconnect) {
+            this._debug("reconnection disabled, skipping connect attempt.");
+            return;
+        }
+
+        // Set lock for this attempt
         this._connectLock = true;
 
         const {
@@ -360,34 +406,44 @@ export class ReconnectingWebSocket {
             WebSocket = getGlobalWebSocket()
         } = this._options;
 
+        // max retries reached
         if (this._retryCount >= maxRetries) {
-            this._debug("max retries reached", this._retryCount, ">=", maxRetries);
+            this._shutdown(new Error(`max retries (${maxRetries}) reached`), this._retryCount, ">=", maxRetries);
             return;
         }
 
+        // prepare connection attempt
         this._retryCount++;
-
         this._debug("connect", this._retryCount);
         this._removeListeners();
-        if (!isWebSocket(WebSocket)) {
-            throw Error("No valid WebSocket class provided");
+
+        if (!this._websocketFactory) {
+            throw Error("no valid websocket factory provided");
         }
+
         this._wait()
             .then(() => this._getNextUrl(this._url))
-            .then((url) => {
+            .then(async (url) => {
+                // Close could be called before creating the ws
                 if (this._closeCalled) {
+                    this._connectLock = false;
+                    this._debug("Connection cancelled: ReconnectingWebSocket.close() called during setup.");
                     return;
                 }
-                const options: Record<string, unknown> = {};
-                if (this._headers) {
-                    options.headers = this._headers;
-                }
-                this._ws = new WebSocket(url, this._protocols, options);
+
+                this._debug("create websocket from factory", { url, clientOptions: this._clientOptions });
+                this._ws = await this._websocketFactory(url, this._clientOptions);
                 this._ws!.binaryType = this._binaryType;
+
                 this._connectLock = false;
                 this._addListeners();
 
                 this._connectTimeout = setTimeout(() => this._handleTimeout(), connectionTimeout);
+            })
+            .catch((error: any) => {
+                this._debug("connection setup failed", error);
+                this._connectLock = false;
+                this._handleError(error);
             });
     }
 
@@ -456,35 +512,104 @@ export class ReconnectingWebSocket {
         this._listeners.message.forEach((listener) => this._callEventListener(event, listener));
     };
 
-    private _handleError = (event: Events.ErrorEvent) => {
-        this._debug("error event", event.message);
-        this._disconnect(undefined, event.message === "TIMEOUT" ? "timeout" : undefined);
+    /**
+     * Adapts a raw error or event input into a standardized `Events.ErrorEvent`.
+     * This utility is called by `_handleError` to ensure it operates on a
+     * consistent error structure.
+     * @param rawErrorOrEventInput - The raw error data (e.g., Error instance, DOM Event, Events.ErrorEvent).
+     * @returns A standardized `Events.ErrorEvent` containing an underlying `Error` instance.
+     */
+    private _adaptError(rawErrorOrEventInput: unknown): Events.ErrorEvent {
+        this._debug("adapting raw error or event via _adaptError", rawErrorOrEventInput);
+        let underlyingError: Error;
 
-        if (this.onerror) {
-            this.onerror(event);
+        if (rawErrorOrEventInput instanceof Events.ErrorEvent && rawErrorOrEventInput.error instanceof Error) {
+            return rawErrorOrEventInput;
         }
+
+        if (rawErrorOrEventInput instanceof Error) {
+            underlyingError = rawErrorOrEventInput;
+        } else if (
+            typeof Event !== "undefined" &&
+            rawErrorOrEventInput instanceof Event &&
+            rawErrorOrEventInput.type === "error"
+        ) {
+            underlyingError = new Error(
+                "websocket low-level error occurred: see browser/runtime console for native event details"
+            );
+        } else {
+            underlyingError = new Error(
+                `unknown WebSocket error. raw data: ${String(rawErrorOrEventInput ?? "undefined")}`
+            );
+        }
+
+        return new Events.ErrorEvent(underlyingError, this);
+    }
+
+    /**
+     * Core handler for all errors. It first standardizes the error input using `_adaptError`,
+     * then manages disconnection, dispatches the standardized error event, and initiates reconnection.
+     * @param rawErrorOrEventInput - The error data from any internal source.
+     */
+    private _handleError = (rawErrorOrEventInput: any): void => {
+        this._debug("raw error or event received by _handleError", rawErrorOrEventInput);
+
+        const adaptedError = this._adaptError(rawErrorOrEventInput);
+        const { error, message } = adaptedError;
+
+        // Close with abnormal closure code so _handleClose will reconnect if there's a socket
+        this._disconnect(ABNORMAL_CLOSURE_CODE, message);
+
+        this._debug("processed error; dispatching event", message, error);
+        if (this.onerror) {this.onerror(adaptedError);}
+
         this._debug("exec error listeners");
-        this._listeners.error.forEach((listener) => this._callEventListener(event, listener));
+        this._listeners.error.forEach((listener) => this._callEventListener(adaptedError, listener));
 
-        this._connect();
-    };
-
-    private _handleClose = (event: Events.CloseEvent) => {
-        this._debug("close event");
-        this._clearTimeouts();
-
-        if (event.code === 1000) {
-            this._shouldReconnect = false;
-        }
-
-        if (this._shouldReconnect) {
+        // If we never even got a ws instance, _disconnect returned early so we need to explicitly retry here
+        if (!this._ws && this._shouldReconnect) {
+            this._debug("error before socket created; scheduling initial reconnect");
             this._connect();
         }
+    };
 
-        if (this.onclose) {
-            this.onclose(event);
+    /**
+     * Handles WebSocket close events, either native or synthesized internally.
+     *
+     * Adapts the event if necessary, manages state, dispatches standardized close events,
+     * and initiates reconnection if appropriate.
+     *
+     * @param eventInfo - Either an internal Events.CloseEvent or a native DOM CloseEvent.
+     */
+    private _handleClose = (event: Events.CloseEvent | CloseEvent) => {
+        this._debug("close event received by _handleClose", event);
+
+        // Adapt event if event is an instance of the (browser) native CloseEvent
+        const isNativeCloseEvent = typeof CloseEvent !== "undefined" && event instanceof CloseEvent;
+        const adaptedEvent: Events.CloseEvent = isNativeCloseEvent
+            ? new Events.CloseEvent(event.code, event.reason, this)
+            : (event as Events.CloseEvent);
+
+        // Clean up state
+        this._clearTimeouts();
+        this._ws = undefined;
+        this._connectLock = false;
+
+        // Determine reconnection intent
+        if (this._closeCalled) {
+            this._shouldReconnect = false;
+            this._debug("reconnection stopped intentionally", "_closeCalled", this._closeCalled);
+        } else if (adaptedEvent.code === 1000) {
+            this._shouldReconnect = false;
+            this._debug("reconnection stopped intentionally", "close code", adaptedEvent.code);
         }
-        this._listeners.close.forEach((listener) => this._callEventListener(event, listener));
+
+        // Dispatch event to listeners
+        if (this.onclose) {this.onclose(adaptedEvent);}
+        this._listeners.close.forEach((listener) => this._callEventListener(adaptedEvent, listener));
+
+        // Conditionally attempt reconnection
+        if (this._shouldReconnect) {this._connect();}
     };
 
     private _removeListeners() {
@@ -507,7 +632,6 @@ export class ReconnectingWebSocket {
         this._ws.addEventListener("open", this._handleOpen);
         this._ws.addEventListener("close", this._handleClose);
         this._ws.addEventListener("message", this._handleMessage);
-        // @ts-ignore
         this._ws.addEventListener("error", this._handleError);
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4009,6 +4009,9 @@ importers:
       '@fern-typescript/sdk-client-class-generator':
         specifier: workspace:*
         version: link:../client-class-generator
+      '@fern-typescript/sdk-client-utils-generator':
+        specifier: workspace:*
+        version: link:../sdk-client-utils-generator
       '@fern-typescript/sdk-endpoint-type-schemas-generator':
         specifier: workspace:*
         version: link:../sdk-endpoint-type-schemas-generator
@@ -4171,6 +4174,64 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
+      typescript:
+        specifier: 5.7.2
+        version: 5.7.2
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@18.15.3)(jsdom@20.0.3)(sass@1.72.0)(terser@5.31.5)
+
+  generators/typescript/sdk/sdk-client-utils-generator:
+    dependencies:
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../../../../packages/commons/core-utils
+      '@fern-fern/ir-sdk':
+        specifier: 57.0.0
+        version: 57.0.0
+      '@fern-typescript/commons':
+        specifier: workspace:*
+        version: link:../../utils/commons
+      '@fern-typescript/contexts':
+        specifier: workspace:*
+        version: link:../../utils/contexts
+      '@fern-typescript/resolvers':
+        specifier: workspace:*
+        version: link:../../utils/resolvers
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
+      ts-morph:
+        specifier: ^15.1.0
+        version: 15.1.0
+      ts-poet:
+        specifier: ^6.7.0
+        version: 6.7.0
+    devDependencies:
+      '@fern-api/configs':
+        specifier: workspace:*
+        version: link:../../../../packages/configs
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^5.2.1
+        version: 5.2.2(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
+      '@types/node':
+        specifier: 18.15.3
+        version: 18.15.3
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      prettier:
+        specifier: ^3.4.2
+        version: 3.5.3
       typescript:
         specifier: 5.7.2
         version: 5.7.2


### PR DESCRIPTION
## Description
This PR adds utility functions to the generated TS SDK, improving WebSocket support in different runtimes (specifically the browser).

TODOs:
- Generates the utils whether web sockets are required or not
- probably more ...

### **New Utility Functions Added:**

#### 🔌 **WebSocket Support**
- **`createWebSocket(url, options)`** - Creates WebSocket connections with runtime-specific handling:
  - **Browser/Web Worker/Deno/Bun**: Uses native `WebSocket` with auth protocols
  - **Node.js**: Dynamically imports `ws` library with proper headers
  - **Unsupported runtimes**: Throws descriptive error messages

#### 🔐 **Authentication Utilities**  
- **`getAuthHeaders(apiKey)`** - Generates authorization headers with token format
- **`getAuthProtocols(apiKey)`** - Creates WebSocket auth protocols array

#### 📋 **SDK Headers Management**
- **`getHeaders()`** - Provides standardized SDK headers with runtime detection:
  - User-Agent, X-Fern-Language, X-Fern-SDK-Name/Version
  - X-Fern-Runtime and X-Fern-Runtime-Version
  - CORS-aware: Returns empty object for CORS-sensitive runtimes

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed

