### PR TITLE
chore(php): setup readme generation

### DIFF
--- a/generators/base/package.json
+++ b/generators/base/package.json
@@ -32,7 +32,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.23",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
     "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",
     "tmp-promise": "^3.0.3"

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -38,7 +38,7 @@
     "@fern-api/fern-csharp-model": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.23",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.1",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -39,7 +39,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.23",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.1",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -39,7 +39,7 @@
     "@fern-api/dynamic-ir-sdk": "^58.2.0",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.23",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@types/node": "18.15.3",

--- a/generators/php/sdk/features.yml
+++ b/generators/php/sdk/features.yml
@@ -1,4 +1,33 @@
 features:
+  - id: USAGE
+    description: |
+      Instantiate and use the client with the following:
+
+  - id: EXCEPTION_HANDLING
+    description: |
+      When the API returns a non-success status code (4xx or 5xx response), a subclass of the following error
+      will be thrown.
+
   - id: PAGINATION
     description: |
       List endpoints return a `Pager<T>` which lets you loop over all items and the SDK will automatically make multiple HTTP requests for you.
+
+  - id: RETRIES
+    advanced: true
+    description: |
+      The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+      as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+      retry limit (default: 2).
+
+      A request is deemed retryable when any of the following HTTP status codes is returned:
+
+      - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+      - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+      Use the `maxRetries` request option to configure this behavior.
+
+  - id: TIMEOUTS
+    advanced: true
+    description: |
+      The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -31,6 +31,9 @@
   "devDependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
+    "@fern-api/logger": "workspace:*",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-api/php-dynamic-snippets": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/php-base": "workspace:*",

--- a/generators/php/sdk/src/PhpGeneratorAgent.ts
+++ b/generators/php/sdk/src/PhpGeneratorAgent.ts
@@ -1,0 +1,70 @@
+import { AbstractGeneratorAgent } from "@fern-api/base-generator";
+import { Logger } from "@fern-api/logger";
+
+import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
+import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
+import { IntermediateRepresentation, PublishingConfig } from "@fern-fern/ir-sdk/api";
+
+import { SdkGeneratorContext } from "./SdkGeneratorContext";
+import { ReadmeConfigBuilder } from "./readme/ReadmeConfigBuilder";
+
+export class PhpGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorContext> {
+    private readmeConfigBuilder: ReadmeConfigBuilder;
+    private publishConfig: PublishingConfig | undefined;
+
+    public constructor({
+        logger,
+        config,
+        readmeConfigBuilder,
+        ir
+    }: {
+        logger: Logger;
+        config: FernGeneratorExec.GeneratorConfig;
+        readmeConfigBuilder: ReadmeConfigBuilder;
+        ir: IntermediateRepresentation;
+    }) {
+        super({ logger, config, selfHosted: ir.selfHosted });
+        this.readmeConfigBuilder = readmeConfigBuilder;
+        this.publishConfig = ir.publishConfig;
+    }
+
+    public getReadmeConfig(
+        args: AbstractGeneratorAgent.ReadmeConfigArgs<SdkGeneratorContext>
+    ): FernGeneratorCli.ReadmeConfig {
+        return this.readmeConfigBuilder.build({
+            context: args.context,
+            remote: args.remote,
+            featureConfig: args.featureConfig,
+            endpointSnippets: args.endpointSnippets
+        });
+    }
+
+    public getLanguage(): FernGeneratorCli.Language {
+        return FernGeneratorCli.Language.Php;
+    }
+
+    public getGitHubConfig(
+        args: AbstractGeneratorAgent.GitHubConfigArgs<SdkGeneratorContext>
+    ): FernGeneratorCli.GitHubConfig {
+        if (this.publishConfig == null) {
+            args.context.logger.error("Publishing config is missing");
+            throw new Error("Publishing config is required for GitHub actions");
+        }
+
+        if (this.publishConfig.type !== "github") {
+            args.context.logger.error(`Publishing type ${this.publishConfig.type} is not supported`);
+            throw new Error("Only GitHub publishing is supported");
+        }
+
+        if (this.publishConfig.uri == null || this.publishConfig.token == null) {
+            args.context.logger.error("GitHub URI or token is missing in publishing config");
+            throw new Error("GitHub URI and token are required in publishing config");
+        }
+
+        return {
+            sourceDirectory: "fern/output",
+            uri: this.publishConfig.uri,
+            token: this.publishConfig.token
+        };
+    }
+}

--- a/generators/php/sdk/src/SdkGeneratorCli.ts
+++ b/generators/php/sdk/src/SdkGeneratorCli.ts
@@ -1,4 +1,4 @@
-import { GeneratorNotificationService } from "@fern-api/base-generator";
+import { File, GeneratorNotificationService } from "@fern-api/base-generator";
 import { AbstractPhpGeneratorCli } from "@fern-api/php-base";
 import { generateModels, generateTraits } from "@fern-api/php-model";
 
@@ -13,6 +13,11 @@ import { BaseApiExceptionGenerator } from "./error/BaseApiExceptionGenerator";
 import { BaseExceptionGenerator } from "./error/BaseExceptionGenerator";
 import { RootClientGenerator } from "./root-client/RootClientGenerator";
 import { SubPackageClientGenerator } from "./subpackage-client/SubPackageClientGenerator";
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { Endpoint } from "@fern-fern/generator-exec-sdk/api";
+import { DynamicSnippetsGenerator } from "@fern-api/php-dynamic-snippets";
+import { convertDynamicEndpointSnippetRequest } from "./utils/convertEndpointSnippetRequest";
+import { convertIr } from "./utils/convertIr";
 
 export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSchema, SdkGeneratorContext> {
     protected constructContext({
@@ -56,6 +61,20 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
         this.generateSubpackages(context);
         this.generateEnvironment(context);
         this.generateErrors(context);
+
+        if (context.config.output.snippetFilepath != null) {
+            const snippets = await this.generateSnippets({ context });
+
+            try {
+                await this.generateReadme({
+                    context,
+                    endpointSnippets: snippets,
+                });
+            } catch (e) {
+                context.logger.warn("Failed to generate README.md, this is OK.");
+            }
+        }
+
         await context.project.persist();
     }
 
@@ -120,5 +139,67 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
 
         const baseApiException = new BaseApiExceptionGenerator(context);
         context.project.addSourceFiles(baseApiException.generate());
+    }
+
+    private async generateReadme({
+        context,
+        endpointSnippets
+    }: {
+        context: SdkGeneratorContext;
+        endpointSnippets: FernGeneratorExec.Endpoint[];
+    }): Promise<void> {
+        if (endpointSnippets.length === 0) {
+            context.logger.debug("No snippets were produced; skipping README.md generation.");
+            return;
+        }
+        const content = await context.generatorAgent.generateReadme({ context, endpointSnippets });
+        context.project.addRawFiles(
+            new File(context.generatorAgent.README_FILENAME, RelativeFilePath.of("."), content)
+        );
+    }
+
+    private async generateSnippets({ context }: { context: SdkGeneratorContext }): Promise<Endpoint[]> {
+        const endpointSnippets: Endpoint[] = [];
+        const dynamicIr = context.ir.dynamic;
+
+        if (!dynamicIr) {
+            throw new Error("Cannot generate dynamic snippets without dynamic IR");
+        }
+
+        const dynamicSnippetsGenerator = new DynamicSnippetsGenerator({
+            // NOTE: This will eventually become a shared library. See the generators/go-v2/sdk/src/SdkGeneratorCli.ts
+            ir: convertIr(dynamicIr),
+            config: context.config
+        });
+
+        for (const [endpointId, endpoint] of Object.entries(dynamicIr.endpoints)) {
+            const method = endpoint.location.method;
+            const path = FernGeneratorExec.EndpointPath(endpoint.location.path);
+
+            for (const endpointExample of endpoint.examples ?? []) {
+                const generatedSnippet = await dynamicSnippetsGenerator.generate(
+                    convertDynamicEndpointSnippetRequest(endpointExample)
+                );
+
+                const syncClient = generatedSnippet.snippet + "\n";
+                // TODO: Properly generate async client; this is a placeholder for now.
+                const asyncClient = generatedSnippet.snippet + "\n";
+
+                endpointSnippets.push({
+                    exampleIdentifier: endpointExample.id,
+                    id: {
+                        method,
+                        path,
+                        identifierOverride: endpointId
+                    },
+                    snippet: FernGeneratorExec.EndpointSnippet.java({
+                        syncClient,
+                        asyncClient
+                    })
+                });
+            }
+        }
+
+        return endpointSnippets;
     }
 }

--- a/generators/php/sdk/src/SdkGeneratorCli.ts
+++ b/generators/php/sdk/src/SdkGeneratorCli.ts
@@ -71,7 +71,7 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
                     endpointSnippets: snippets,
                 });
             } catch (e) {
-                context.logger.warn("Failed to generate README.md, this is OK.");
+                context.logger.warn(`Failed to generate README.md: ${e instanceof Error ? e.message : 'Unknown error'}. This is non-critical and generation will continue.`);
             }
         }
 
@@ -167,7 +167,6 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
         }
 
         const dynamicSnippetsGenerator = new DynamicSnippetsGenerator({
-            // NOTE: This will eventually become a shared library. See the generators/go-v2/sdk/src/SdkGeneratorCli.ts
             ir: convertIr(dynamicIr),
             config: context.config
         });
@@ -181,8 +180,8 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
                     convertDynamicEndpointSnippetRequest(endpointExample)
                 );
 
+                // TODO: We are shimming the PHP snippet into Java Generator Exec snippet as a short term hack
                 const syncClient = generatedSnippet.snippet + "\n";
-                // TODO: Properly generate async client; this is a placeholder for now.
                 const asyncClient = generatedSnippet.snippet + "\n";
 
                 endpointSnippets.push({

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -26,11 +26,15 @@ import { EXCEPTIONS_DIRECTORY, REQUESTS_DIRECTORY, RESERVED_METHOD_NAMES, TYPES_
 import { RawClient } from "./core/RawClient";
 import { EndpointGenerator } from "./endpoint/EndpointGenerator";
 import { GuzzleClient } from "./external/GuzzleClient";
+import { PhpGeneratorAgent } from "./PhpGeneratorAgent";
+import { ReadmeConfigBuilder } from "./readme/ReadmeConfigBuilder";
 
 export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomConfigSchema> {
     public endpointGenerator: EndpointGenerator;
     public guzzleClient: GuzzleClient;
     public rawClient: RawClient;
+    public generatorAgent: PhpGeneratorAgent;
+    
     public constructor(
         public readonly ir: IntermediateRepresentation,
         public readonly config: FernGeneratorExec.config.GeneratorConfig,
@@ -41,6 +45,12 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
         this.endpointGenerator = new EndpointGenerator(this);
         this.guzzleClient = new GuzzleClient(this);
         this.rawClient = new RawClient(this);
+        this.generatorAgent = new PhpGeneratorAgent({
+            logger: this.logger,
+            config: this.config,
+            readmeConfigBuilder: new ReadmeConfigBuilder(),
+            ir: this.ir
+        });
     }
 
     public shouldGenerateSubpackageClient(subpackage: Subpackage): boolean {

--- a/generators/php/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -1,0 +1,56 @@
+import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
+import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
+
+import { SdkGeneratorContext } from "../SdkGeneratorContext";
+import { ReadmeSnippetBuilder } from "./ReadmeSnippetBuilder";
+
+export class ReadmeConfigBuilder {
+    public build({
+        context,
+        remote,
+        featureConfig,
+        endpointSnippets
+    }: {
+        context: SdkGeneratorContext;
+        remote: FernGeneratorCli.Remote | undefined;
+        featureConfig: FernGeneratorCli.FeatureConfig;
+        endpointSnippets: FernGeneratorExec.Endpoint[];
+    }): FernGeneratorCli.ReadmeConfig {
+        const readmeSnippetBuilder = new ReadmeSnippetBuilder({
+            context,
+            endpointSnippets
+        });
+        const snippets = readmeSnippetBuilder.buildReadmeSnippets();
+        const features: FernGeneratorCli.ReadmeFeature[] = [];
+        for (const feature of featureConfig.features) {
+            const featureSnippets = snippets[feature.id];
+            if (!featureSnippets) {
+                continue;
+            }
+            features.push({
+                id: feature.id,
+                advanced: feature.advanced,
+                description: feature.description,
+                snippets: featureSnippets,
+                snippetsAreOptional: false
+            });
+        }
+        return {
+            remote,
+            language: this.getLanguageInfo({ context }),
+            organization: context.config.organization,
+            apiReferenceLink: context.ir.readmeConfig?.apiReferenceLink,
+            bannerLink: context.ir.readmeConfig?.bannerLink,
+            introduction: context.ir.readmeConfig?.introduction,
+            features
+        };
+    }
+
+    private getLanguageInfo({ context }: { context: SdkGeneratorContext }): FernGeneratorCli.LanguageInfo {
+        return FernGeneratorCli.LanguageInfo.php({
+            publishInfo: {
+                packageName: context.getPackageName()
+            }
+        });
+    }
+}

--- a/generators/php/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -4,6 +4,12 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext";
 import { ReadmeSnippetBuilder } from "./ReadmeSnippetBuilder";
 
+export interface Snippet {
+    id: string;
+    snippet: string;
+}
+
+
 export class ReadmeConfigBuilder {
     public build({
         context,

--- a/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -41,12 +41,6 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     public buildReadmeSnippets(): Record<FernGeneratorCli.FeatureId, string[]> {
         const snippets: Record<FernGeneratorCli.FeatureId, string[]> = {};
         snippets[FernGeneratorCli.StructuredFeatureId.Usage] = this.buildUsageSnippets();
-        // snippets[FernGeneratorCli.StructuredFeatureId.Retries] = this.buildRetrySnippets();
-        // snippets[FernGeneratorCli.StructuredFeatureId.Timeouts] = this.buildTimeoutSnippets();
-        // snippets[ReadmeSnippetBuilder.EXCEPTION_HANDLING_FEATURE_ID] = this.buildExceptionHandlingSnippets();
-        if (this.isPaginationEnabled) {
-            snippets[FernGeneratorCli.StructuredFeatureId.Pagination] = this.buildPaginationSnippets();
-        }
         return snippets;
     }
 
@@ -57,52 +51,6 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         }
         return [this.getSnippetForEndpointId(this.defaultEndpointId)];
     }
-
-//     private buildRetrySnippets(): string[] {
-//         const retryEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Retries);
-//         return retryEndpoints.map((retryEndpoint) =>
-//             this.writeCode(`
-// var response = await ${this.getMethodCall(retryEndpoint)}(
-//     ...,
-//     new ${this.requestOptionsName} {
-//         MaxRetries: 0 // Override MaxRetries at the request level
-//     }
-// );
-// `)
-//         );
-//     }
-
-//     private buildTimeoutSnippets(): string[] {
-//         const timeoutEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Timeouts);
-//         return timeoutEndpoints.map((timeoutEndpoint) =>
-//             this.writeCode(`
-// var response = await ${this.getMethodCall(timeoutEndpoint)}(
-//     ...,
-//     new ${this.requestOptionsName} {
-//         Timeout: TimeSpan.FromSeconds(3) // Override timeout to 3s
-//     }
-// );
-// `)
-//         );
-//     }
-
-//     private buildExceptionHandlingSnippets(): string[] {
-//         const exceptionHandlingEndpoints = this.getEndpointsForFeature(
-//             ReadmeSnippetBuilder.EXCEPTION_HANDLING_FEATURE_ID
-//         );
-//         return exceptionHandlingEndpoints.map((exceptionHandlingEndpoint) =>
-//             this.writeCode(`
-// using ${this.context.getNamespace()};
-
-// try {
-//     var response = await ${this.getMethodCall(exceptionHandlingEndpoint)}(...);
-// } catch (${this.context.getBaseApiExceptionClassReference().name} e) {
-//     System.Console.WriteLine(e.Body);
-//     System.Console.WriteLine(e.StatusCode);
-// }
-// `)
-//         );
-//     }
 
     private buildPaginationSnippets(): string[] {
         const explicitlyConfigured = this.getExplicitlyConfiguredSnippets(
@@ -198,19 +146,10 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     }
 
     private getEndpointSnippetString(endpoint: FernGeneratorExec.Endpoint): string {
-        if (endpoint.snippet.type !== "csharp") {
+        // Note: this is a shim since php snippets are not supported yet in FernGeneratorExec
+        if (endpoint.snippet.type !== "java") {
             throw new Error(`Internal error; expected csharp snippet but got: ${endpoint.snippet.type}`);
         }
-        return endpoint.snippet.client;
-    }
-
-    // private getMethodCall(endpoint: EndpointWithFilepath): string {
-    //     return `${this.context.getAccessFromRootClient(endpoint.fernFilepath)}.${this.context.getEndpointMethodName(
-    //         endpoint.endpoint
-    //     )}`;
-    // }
-
-    private writeCode(s: string): string {
-        return s.trim() + "\n";
+        return endpoint.snippet.syncClient;
     }
 }

--- a/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -1,0 +1,216 @@
+import { AbstractReadmeSnippetBuilder } from "@fern-api/base-generator";
+
+import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
+import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
+import { EndpointId, FeatureId, FernFilepath, HttpEndpoint } from "@fern-fern/ir-sdk/api";
+
+import { SdkGeneratorContext } from "../SdkGeneratorContext";
+
+interface EndpointWithFilepath {
+    endpoint: HttpEndpoint;
+    fernFilepath: FernFilepath;
+}
+
+export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
+    private static EXCEPTION_HANDLING_FEATURE_ID: FernGeneratorCli.FeatureId = "EXCEPTION_HANDLING";
+
+    private readonly context: SdkGeneratorContext;
+    private readonly endpoints: Record<EndpointId, EndpointWithFilepath> = {};
+    private readonly snippets: Record<EndpointId, string> = {};
+    private readonly defaultEndpointId: EndpointId;
+    private readonly isPaginationEnabled: boolean;
+
+    constructor({
+        context,
+        endpointSnippets
+    }: {
+        context: SdkGeneratorContext;
+        endpointSnippets: FernGeneratorExec.Endpoint[];
+    }) {
+        super({ endpointSnippets });
+        this.context = context;
+        this.isPaginationEnabled = context.config.generatePaginatedClients ?? false;
+        this.endpoints = this.buildEndpoints();
+        this.snippets = this.buildSnippets(endpointSnippets);
+        this.defaultEndpointId =
+            this.context.ir.readmeConfig?.defaultEndpoint != null
+                ? this.context.ir.readmeConfig.defaultEndpoint
+                : this.getDefaultEndpointId();
+    }
+
+    public buildReadmeSnippets(): Record<FernGeneratorCli.FeatureId, string[]> {
+        const snippets: Record<FernGeneratorCli.FeatureId, string[]> = {};
+        snippets[FernGeneratorCli.StructuredFeatureId.Usage] = this.buildUsageSnippets();
+        // snippets[FernGeneratorCli.StructuredFeatureId.Retries] = this.buildRetrySnippets();
+        // snippets[FernGeneratorCli.StructuredFeatureId.Timeouts] = this.buildTimeoutSnippets();
+        // snippets[ReadmeSnippetBuilder.EXCEPTION_HANDLING_FEATURE_ID] = this.buildExceptionHandlingSnippets();
+        if (this.isPaginationEnabled) {
+            snippets[FernGeneratorCli.StructuredFeatureId.Pagination] = this.buildPaginationSnippets();
+        }
+        return snippets;
+    }
+
+    private buildUsageSnippets(): string[] {
+        const usageEndpointIds = this.getEndpointIdsForFeature(FernGeneratorCli.StructuredFeatureId.Usage);
+        if (usageEndpointIds != null) {
+            return usageEndpointIds.map((endpointId) => this.getSnippetForEndpointId(endpointId));
+        }
+        return [this.getSnippetForEndpointId(this.defaultEndpointId)];
+    }
+
+//     private buildRetrySnippets(): string[] {
+//         const retryEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Retries);
+//         return retryEndpoints.map((retryEndpoint) =>
+//             this.writeCode(`
+// var response = await ${this.getMethodCall(retryEndpoint)}(
+//     ...,
+//     new ${this.requestOptionsName} {
+//         MaxRetries: 0 // Override MaxRetries at the request level
+//     }
+// );
+// `)
+//         );
+//     }
+
+//     private buildTimeoutSnippets(): string[] {
+//         const timeoutEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Timeouts);
+//         return timeoutEndpoints.map((timeoutEndpoint) =>
+//             this.writeCode(`
+// var response = await ${this.getMethodCall(timeoutEndpoint)}(
+//     ...,
+//     new ${this.requestOptionsName} {
+//         Timeout: TimeSpan.FromSeconds(3) // Override timeout to 3s
+//     }
+// );
+// `)
+//         );
+//     }
+
+//     private buildExceptionHandlingSnippets(): string[] {
+//         const exceptionHandlingEndpoints = this.getEndpointsForFeature(
+//             ReadmeSnippetBuilder.EXCEPTION_HANDLING_FEATURE_ID
+//         );
+//         return exceptionHandlingEndpoints.map((exceptionHandlingEndpoint) =>
+//             this.writeCode(`
+// using ${this.context.getNamespace()};
+
+// try {
+//     var response = await ${this.getMethodCall(exceptionHandlingEndpoint)}(...);
+// } catch (${this.context.getBaseApiExceptionClassReference().name} e) {
+//     System.Console.WriteLine(e.Body);
+//     System.Console.WriteLine(e.StatusCode);
+// }
+// `)
+//         );
+//     }
+
+    private buildPaginationSnippets(): string[] {
+        const explicitlyConfigured = this.getExplicitlyConfiguredSnippets(
+            FernGeneratorCli.StructuredFeatureId.Pagination
+        );
+        if (explicitlyConfigured != null) {
+            return explicitlyConfigured;
+        }
+        const paginationEndpoint = this.getEndpointWithPagination();
+        if (paginationEndpoint != null) {
+            const snippet = this.getSnippetForEndpointId(paginationEndpoint.endpoint.id);
+            return snippet != null ? [snippet] : [];
+        }
+        return [];
+    }
+
+    private getEndpointWithPagination(): EndpointWithFilepath | undefined {
+        return this.filterEndpoint((endpointWithFilepath) => {
+            if (endpointWithFilepath.endpoint.pagination != null) {
+                return endpointWithFilepath;
+            }
+            return undefined;
+        });
+    }
+
+    private filterEndpoint<T>(transform: (endpoint: EndpointWithFilepath) => T | undefined): T | undefined {
+        for (const endpointWithFilepath of Object.values(this.endpoints)) {
+            const result = transform(endpointWithFilepath);
+            if (result !== undefined) {
+                return result;
+            }
+        }
+        return undefined;
+    }
+
+    private getExplicitlyConfiguredSnippets(featureId: FeatureId): string[] | undefined {
+        const endpointIds = this.getEndpointIdsForFeature(featureId);
+        if (endpointIds != null) {
+            return endpointIds.map((endpointId) => this.getSnippetForEndpointId(endpointId)).filter((e) => e != null);
+        }
+        return undefined;
+    }
+
+    private buildEndpoints(): Record<EndpointId, EndpointWithFilepath> {
+        const endpoints: Record<EndpointId, EndpointWithFilepath> = {};
+        for (const service of Object.values(this.context.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                endpoints[endpoint.id] = {
+                    endpoint,
+                    fernFilepath: service.name.fernFilepath
+                };
+            }
+        }
+        return endpoints;
+    }
+
+    private buildSnippets(endpointSnippets: FernGeneratorExec.Endpoint[]): Record<EndpointId, string> {
+        const snippets: Record<EndpointId, string> = {};
+        for (const endpointSnippet of Object.values(endpointSnippets)) {
+            if (endpointSnippet.id.identifierOverride == null) {
+                throw new Error("Internal error; snippets must define the endpoint id to generate README.md");
+            }
+            snippets[endpointSnippet.id.identifierOverride] = this.getEndpointSnippetString(endpointSnippet);
+        }
+        return snippets;
+    }
+
+    private getSnippetForEndpointId(endpointId: EndpointId): string {
+        const snippet = this.snippets[endpointId];
+        if (snippet == null) {
+            throw new Error(`Internal error; missing snippet for endpoint ${endpointId}`);
+        }
+        return snippet;
+    }
+
+    private getEndpointsForFeature(featureId: FeatureId): EndpointWithFilepath[] {
+        const endpointIds = this.getEndpointIdsForFeature(featureId);
+        return endpointIds != null ? this.getEndpoints(endpointIds) : this.getEndpoints([this.defaultEndpointId]);
+    }
+
+    private getEndpointIdsForFeature(featureId: FeatureId): EndpointId[] | undefined {
+        return this.context.ir.readmeConfig?.features?.[this.getFeatureKey(featureId)];
+    }
+
+    private getEndpoints(endpointIds: EndpointId[]): EndpointWithFilepath[] {
+        return endpointIds.map((endpointId) => {
+            const endpoint = this.endpoints[endpointId];
+            if (endpoint == null) {
+                throw new Error(`Internal error; missing endpoint ${endpointId}`);
+            }
+            return endpoint;
+        });
+    }
+
+    private getEndpointSnippetString(endpoint: FernGeneratorExec.Endpoint): string {
+        if (endpoint.snippet.type !== "csharp") {
+            throw new Error(`Internal error; expected csharp snippet but got: ${endpoint.snippet.type}`);
+        }
+        return endpoint.snippet.client;
+    }
+
+    // private getMethodCall(endpoint: EndpointWithFilepath): string {
+    //     return `${this.context.getAccessFromRootClient(endpoint.fernFilepath)}.${this.context.getEndpointMethodName(
+    //         endpoint.endpoint
+    //     )}`;
+    // }
+
+    private writeCode(s: string): string {
+        return s.trim() + "\n";
+    }
+}

--- a/generators/php/sdk/src/utils/convertEndpointSnippetRequest.ts
+++ b/generators/php/sdk/src/utils/convertEndpointSnippetRequest.ts
@@ -1,0 +1,16 @@
+import { dynamic } from "@fern-fern/ir-sdk/api";
+
+export type EndpointSnippetRequest = Omit<dynamic.EndpointSnippetRequest, "baseUrl"> & {
+    baseURL: string | undefined;
+};
+
+/**
+ * The @fern-api/dynamic-ir-sdk doesn't include the serialization layer, so the casing
+ * convention doesn't match.
+ */
+export function convertDynamicEndpointSnippetRequest(request: dynamic.EndpointSnippetRequest): EndpointSnippetRequest {
+    return {
+        ...request,
+        baseURL: request.baseUrl
+    };
+}

--- a/generators/php/sdk/src/utils/convertEndpoints.ts
+++ b/generators/php/sdk/src/utils/convertEndpoints.ts
@@ -1,0 +1,33 @@
+import { mapValues } from "@fern-api/core-utils";
+
+import { dynamic } from "@fern-fern/ir-sdk/api";
+
+export type Endpoint = Omit<dynamic.Endpoint, "examples"> & {
+    examples: EndpointExample[] | undefined;
+};
+
+export type EndpointExample = Omit<dynamic.EndpointExample, "baseUrl"> & {
+    baseURL: string | undefined;
+};
+
+export function convertEndpoints(endpoints: Record<string, dynamic.Endpoint>): Record<string, Endpoint> {
+    return mapValues(endpoints, (endpoint) => convertEndpoint(endpoint));
+}
+
+function convertEndpoint(endpoint: dynamic.Endpoint): Endpoint {
+    return {
+        ...endpoint,
+        examples: endpoint.examples != null ? convertExamples(endpoint.examples) : undefined
+    };
+}
+
+function convertExamples(examples: dynamic.EndpointExample[]): EndpointExample[] {
+    return examples.map((example) => convertExample(example));
+}
+
+function convertExample(example: dynamic.EndpointExample): EndpointExample {
+    return {
+        ...example,
+        baseURL: example.baseUrl
+    };
+}

--- a/generators/php/sdk/src/utils/convertIr.ts
+++ b/generators/php/sdk/src/utils/convertIr.ts
@@ -1,0 +1,18 @@
+import { EndpointId, dynamic } from "@fern-fern/ir-sdk/api";
+
+import { Endpoint, convertEndpoints } from "./convertEndpoints";
+
+export type DynamicIntermediateRepresentation = Omit<dynamic.DynamicIntermediateRepresentation, "endpoints"> & {
+    endpoints: Record<EndpointId, Endpoint>;
+};
+
+/**
+ * The @fern-api/dynamic-ir-sdk doesn't include the serialization layer, so the casing
+ * convention doesn't match.
+ */
+export function convertIr(ir: dynamic.DynamicIntermediateRepresentation): DynamicIntermediateRepresentation {
+    return {
+        ...ir,
+        endpoints: convertEndpoints(ir.endpoints)
+    };
+}

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.16.0
+  changelogEntry:
+    - summary: Introduce initial version of README generation for the PHP SDK with Installation, Usage, and Contributing sections.
+      type: feat
+  createdAt: '2025-06-03'
+  irVersion: 58
+
 - version: 1.15.1
   changelogEntry:
     - summary: Update the IR to v58.

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -35,7 +35,7 @@
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.23",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
     "@trivago/prettier-plugin-sort-imports": "^5.2.1",
     "@types/node": "18.15.3",
     "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.14",

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -31,7 +31,7 @@
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.23",
+    "@fern-fern/generator-cli-sdk": "0.0.28",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",
     "@fern-fern/snippet-sdk": "^0.0.6434",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/logging-execa
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.23
-        version: 0.0.23(encoding@0.1.13)
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -564,8 +564,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cli/logger
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.23
-        version: 0.0.23(encoding@0.1.13)
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045(encoding@0.1.13)
@@ -878,8 +878,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.23
-        version: 0.0.23(encoding@0.1.13)
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045(encoding@0.1.13)
@@ -1098,8 +1098,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cli/logger
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.23
-        version: 0.0.23(encoding@0.1.13)
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045(encoding@0.1.13)
@@ -1436,15 +1436,24 @@ importers:
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
+      '@fern-api/logger':
+        specifier: workspace:*
+        version: link:../../../packages/cli/logger
       '@fern-api/php-base':
         specifier: workspace:*
         version: link:../base
       '@fern-api/php-codegen':
         specifier: workspace:*
         version: link:../codegen
+      '@fern-api/php-dynamic-snippets':
+        specifier: workspace:*
+        version: link:../dynamic-snippets
       '@fern-api/php-model':
         specifier: workspace:*
         version: link:../model
+      '@fern-fern/generator-cli-sdk':
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045(encoding@0.1.13)
@@ -1894,8 +1903,8 @@ importers:
         specifier: workspace:*
         version: link:../base
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.23
-        version: 0.0.23(encoding@0.1.13)
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045(encoding@0.1.13)
@@ -3977,8 +3986,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/ast
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.23
-        version: 0.0.23(encoding@0.1.13)
+        specifier: 0.0.28
+        version: 0.0.28(encoding@0.1.13)
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045(encoding@0.1.13)
@@ -7695,64 +7704,6 @@ importers:
 
   packages/cli/generation/protoc-gen-fern/bin: {}
 
-  packages/cli/generation/protoc-gen-fern/dist/cjs:
-    dependencies:
-      '@bufbuild/protobuf':
-        specifier: ^2.2.5
-        version: 2.2.5
-      '@bufbuild/protoplugin':
-        specifier: 2.2.5
-        version: 2.2.5
-      '@fern-api/casings-generator':
-        specifier: workspace:*
-        version: link:../../../../../commons/casings-generator
-      '@fern-api/configs':
-        specifier: workspace:*
-        version: link:../../../../../configs
-      '@fern-api/configuration':
-        specifier: workspace:*
-        version: link:../../../../configuration
-      '@fern-api/ir-sdk':
-        specifier: workspace:*
-        version: link:../../../../../ir-sdk
-      '@fern-api/ir-utils':
-        specifier: workspace:*
-        version: link:../../../../../commons/ir-utils
-      '@fern-api/logger':
-        specifier: workspace:*
-        version: link:../../../../logger
-      '@fern-api/v2-importer-commons':
-        specifier: workspace:*
-        version: link:../../../../api-importers/v2-importer-commons
-      openapi-types:
-        specifier: ^12.1.3
-        version: 12.1.3
-    devDependencies:
-      '@trivago/prettier-plugin-sort-imports':
-        specifier: ^5.2.1
-        version: 5.2.2(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)
-      '@types/jest':
-        specifier: ^29.5.14
-        version: 29.5.14
-      '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
-      depcheck:
-        specifier: ^1.4.7
-        version: 1.4.7
-      eslint:
-        specifier: ^8.56.0
-        version: 8.57.1
-      prettier:
-        specifier: ^3.4.2
-        version: 3.5.3
-      typescript:
-        specifier: 5.7.2
-        version: 5.7.2
-      vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@18.15.3)(jsdom@20.0.3)(msw@2.8.4(@types/node@18.15.3)(typescript@5.7.2))(sass@1.72.0)(terser@5.31.5)
-
   packages/cli/generation/remote-generation/remote-workspace-runner:
     dependencies:
       '@fern-api/auth':
@@ -11126,8 +11077,8 @@ packages:
   '@fern-fern/fiddle-sdk@0.0.584':
     resolution: {integrity: sha512-92z/Pwo7EDV7PCLwNdxtZiTQpaUpbeXCqKWSLUQwTwFAQEAp+8QKYAA6VJXVQtHLrZg0NqPTXEnE5XF8NbluYA==}
 
-  '@fern-fern/generator-cli-sdk@0.0.23':
-    resolution: {integrity: sha512-UGJWwnN1h4fcuRiu5XREE3vHiyuSgob6/4Sr6PNODFNC1wHczF2/2eqEWejC6mzmBdcDziPhk0ecZqZDuLkXVg==}
+  '@fern-fern/generator-cli-sdk@0.0.28':
+    resolution: {integrity: sha512-KNf9vBkFAV8oEmD/U4ss75d3JIm50fpa+Pq5cVs0fr/e8m1xWVuG189gzfQ9wrkH3Z85B2U/Pxl3cb7KPB4qrw==}
 
   '@fern-fern/generator-exec-sdk@0.0.1045':
     resolution: {integrity: sha512-V9SXkuyY/LdrwBYh9MYNny4CaAc8o9i7DgYYiL2yzoMA/FR9AUcBOl1I/ykJH1CRs0oGycp5zBZrO0qmLHpPVA==}
@@ -19466,7 +19417,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fern-fern/generator-cli-sdk@0.0.23(encoding@0.1.13)':
+  '@fern-fern/generator-cli-sdk@0.0.28(encoding@0.1.13)':
     dependencies:
       form-data: 4.0.1
       formdata-node: 6.0.3

--- a/seed/php-sdk/imdb/clientName/README.md
+++ b/seed/php-sdk/imdb/clientName/README.md
@@ -1,0 +1,46 @@
+# Seed PHP Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPHP)
+[![php shield](https://img.shields.io/badge/php-packagist-pink)](https://packagist.org/packages/seed/seed)
+
+The Seed PHP library provides convenient access to the Seed API from PHP.
+
+## Installation
+
+```sh
+composer require seed/seed
+```
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```php
+<?php
+
+namespace Example;
+
+use Seed\FernClient;
+use Seed\Imdb\Types\CreateMovieRequest;
+
+$client = new FernClient(
+    token: '<token>',
+);
+$client->imdb->createMovie(
+    new CreateMovieRequest([
+        'title' => 'title',
+        'rating' => 1.1,
+    ]),
+);
+
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/php-sdk/imdb/namespace/README.md
+++ b/seed/php-sdk/imdb/namespace/README.md
@@ -1,0 +1,46 @@
+# Seed PHP Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPHP)
+[![php shield](https://img.shields.io/badge/php-packagist-pink)](https://packagist.org/packages/seed/seed)
+
+The Seed PHP library provides convenient access to the Seed API from PHP.
+
+## Installation
+
+```sh
+composer require seed/seed
+```
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```php
+<?php
+
+namespace Example;
+
+use Fern\SeedClient;
+use Fern\Imdb\Types\CreateMovieRequest;
+
+$client = new SeedClient(
+    token: '<token>',
+);
+$client->imdb->createMovie(
+    new CreateMovieRequest([
+        'title' => 'title',
+        'rating' => 1.1,
+    ]),
+);
+
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/php-sdk/imdb/no-custom-config/README.md
+++ b/seed/php-sdk/imdb/no-custom-config/README.md
@@ -1,0 +1,46 @@
+# Seed PHP Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPHP)
+[![php shield](https://img.shields.io/badge/php-packagist-pink)](https://packagist.org/packages/seed/seed)
+
+The Seed PHP library provides convenient access to the Seed API from PHP.
+
+## Installation
+
+```sh
+composer require seed/seed
+```
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```php
+<?php
+
+namespace Example;
+
+use Seed\SeedClient;
+use Seed\Imdb\Types\CreateMovieRequest;
+
+$client = new SeedClient(
+    token: '<token>',
+);
+$client->imdb->createMovie(
+    new CreateMovieRequest([
+        'title' => 'title',
+        'rating' => 1.1,
+    ]),
+);
+
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/php-sdk/imdb/package-path/README.md
+++ b/seed/php-sdk/imdb/package-path/README.md
@@ -1,0 +1,46 @@
+# Seed PHP Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPHP)
+[![php shield](https://img.shields.io/badge/php-packagist-pink)](https://packagist.org/packages/seed/seed)
+
+The Seed PHP library provides convenient access to the Seed API from PHP.
+
+## Installation
+
+```sh
+composer require seed/seed
+```
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```php
+<?php
+
+namespace Example;
+
+use Custom\Package\Path\SeedClient;
+use Custom\Package\Path\Imdb\Types\CreateMovieRequest;
+
+$client = new SeedClient(
+    token: '<token>',
+);
+$client->imdb->createMovie(
+    new CreateMovieRequest([
+        'title' => 'title',
+        'rating' => 1.1,
+    ]),
+);
+
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/php-sdk/imdb/packageName/README.md
+++ b/seed/php-sdk/imdb/packageName/README.md
@@ -1,0 +1,46 @@
+# Seed PHP Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPHP)
+[![php shield](https://img.shields.io/badge/php-packagist-pink)](https://packagist.org/packages/fern-api/imdb-php)
+
+The Seed PHP library provides convenient access to the Seed API from PHP.
+
+## Installation
+
+```sh
+composer require fern-api/imdb-php
+```
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```php
+<?php
+
+namespace Example;
+
+use Seed\SeedClient;
+use Seed\Imdb\Types\CreateMovieRequest;
+
+$client = new SeedClient(
+    token: '<token>',
+);
+$client->imdb->createMovie(
+    new CreateMovieRequest([
+        'title' => 'title',
+        'rating' => 1.1,
+    ]),
+);
+
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/php-sdk/imdb/private/README.md
+++ b/seed/php-sdk/imdb/private/README.md
@@ -1,0 +1,46 @@
+# Seed PHP Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPHP)
+[![php shield](https://img.shields.io/badge/php-packagist-pink)](https://packagist.org/packages/seed/seed)
+
+The Seed PHP library provides convenient access to the Seed API from PHP.
+
+## Installation
+
+```sh
+composer require seed/seed
+```
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```php
+<?php
+
+namespace Example;
+
+use Seed\SeedClient;
+use Seed\Imdb\Types\CreateMovieRequest;
+
+$client = new SeedClient(
+    token: '<token>',
+);
+$client->imdb->createMovie(
+    new CreateMovieRequest([
+        'title' => 'title',
+        'rating' => 1.1,
+    ]),
+);
+
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!


### PR DESCRIPTION
## Description
This PR adds basic PHP readme generation to remove manual work

## Changes Made
- Bump generator CLI SDK 
- Setup PHP's generator agent
- Copy how Java uses dynamic snippets to create code snippets

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

