### PR TITLE
feat(cli): remove v3 parser config from docs.yml default init

### DIFF
--- a/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
@@ -93,8 +93,6 @@ navigation:
 colors:
   accentPrimary: '#ffffff'
   background: '#000000'
-experimental:
-  openapiParserV3: true
 ",
         "name": "docs.yml",
         "type": "file",

--- a/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
@@ -94,7 +94,7 @@ colors:
   accentPrimary: '#ffffff'
   background: '#000000'
 experimental:
-  openapi-parser-v3: true
+  openapiParserV3: true
 ",
         "name": "docs.yml",
         "type": "file",

--- a/packages/cli/init/src/initializeDocs.ts
+++ b/packages/cli/init/src/initializeDocs.ts
@@ -37,10 +37,7 @@ export async function initializeDocs({
             return;
         } else {
             try {
-                await writeFile(
-                    docsYmlPath,
-                    yaml.dump(convertExperimentalToKebabCase(getDocsConfig(createDirectoryResponse.organization)))
-                );
+                await writeFile(docsYmlPath, yaml.dump(getDocsConfig(createDirectoryResponse.organization)));
                 taskContext.logger.info(chalk.green("Created docs configuration"));
                 return;
             } catch (writeError) {
@@ -68,29 +65,6 @@ function getDocsConfig(organization: string): docsYml.RawSchemas.DocsConfigurati
         },
         experimental: {
             openapiParserV3: true
-        }
-    };
-}
-
-type KebabCaseExperimentalConfig = {
-    experimental: {
-        "mdx-components"?: string[];
-        "disable-stream-toggle"?: boolean;
-        "openapi-parser-v2"?: boolean;
-        "openapi-parser-v3": boolean;
-    };
-};
-
-function convertExperimentalToKebabCase(
-    config: docsYml.RawSchemas.DocsConfiguration
-): Omit<docsYml.RawSchemas.DocsConfiguration, "experimental"> & KebabCaseExperimentalConfig {
-    const { experimental, ...restConfig } = config;
-    const { openapiParserV3 = true } = experimental ?? {};
-
-    return {
-        ...restConfig,
-        experimental: {
-            "openapi-parser-v3": openapiParserV3
         }
     };
 }

--- a/packages/cli/init/src/initializeDocs.ts
+++ b/packages/cli/init/src/initializeDocs.ts
@@ -62,9 +62,6 @@ function getDocsConfig(organization: string): docsYml.RawSchemas.DocsConfigurati
         colors: {
             accentPrimary: "#ffffff",
             background: "#000000"
-        },
-        experimental: {
-            openapiParserV3: true
         }
     };
 }


### PR DESCRIPTION
## Description
- remove `experimental: openapi-parser-v3: true` from `docs.yml` initialization

## Testing
- [X] Unit tests added/updated
- [X] Manual testing completed

