### PR TITLE
chore(php): document timeout and max retry overrides

### DIFF
--- a/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -41,6 +41,8 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     public buildReadmeSnippets(): Record<FernGeneratorCli.FeatureId, string[]> {
         const snippets: Record<FernGeneratorCli.FeatureId, string[]> = {};
         snippets[FernGeneratorCli.StructuredFeatureId.Usage] = this.buildUsageSnippets();
+        snippets[FernGeneratorCli.StructuredFeatureId.Retries] = this.buildRetrySnippets();
+        snippets[FernGeneratorCli.StructuredFeatureId.Timeouts] = this.buildTimeoutSnippets();
         snippets[ReadmeSnippetBuilder.EXCEPTION_HANDLING_FEATURE_ID] = this.buildExceptionHandlingSnippets();
         return snippets;
     }
@@ -70,6 +72,34 @@ try {
     echo 'Response Body: ' . $e->getBody() . "\\n";
     // Optionally, rethrow the exception or handle accordingly.
 }
+`)
+        );
+    }
+
+    private buildRetrySnippets(): string[] {
+        const retryEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Retries);
+        return retryEndpoints.map((retryEndpoint) =>
+            this.writeCode(`
+$response = ${this.getMethodCall(retryEndpoint)}(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+`)
+        );
+    }
+
+    private buildTimeoutSnippets(): string[] {
+        const timeoutEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Timeouts);
+        return timeoutEndpoints.map((timeoutEndpoint) =>
+            this.writeCode(`
+$response = ${this.getMethodCall(timeoutEndpoint)}(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
 `)
         );
     }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.16.2
+  changelogEntry:
+    - summary: | 
+        Add documentation for retries and timeout parameters in the README, including examples of how 
+        to configure maxRetries and timeout options at the request level
+      type: feat
+  createdAt: '2025-06-03'
+  irVersion: 58
+
 - version: 1.16.1
   changelogEntry:
     - summary: Add exception handling documentation to README with examples of catching and handling API exceptions

--- a/seed/php-sdk/imdb/clientName/README.md
+++ b/seed/php-sdk/imdb/clientName/README.md
@@ -57,6 +57,44 @@ try {
 }
 ```
 
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+```
+
+### Timeouts
+
+The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/php-sdk/imdb/namespace/README.md
+++ b/seed/php-sdk/imdb/namespace/README.md
@@ -57,6 +57,44 @@ try {
 }
 ```
 
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+```
+
+### Timeouts
+
+The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/php-sdk/imdb/no-custom-config/README.md
+++ b/seed/php-sdk/imdb/no-custom-config/README.md
@@ -57,6 +57,44 @@ try {
 }
 ```
 
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+```
+
+### Timeouts
+
+The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/php-sdk/imdb/package-path/README.md
+++ b/seed/php-sdk/imdb/package-path/README.md
@@ -57,6 +57,44 @@ try {
 }
 ```
 
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+```
+
+### Timeouts
+
+The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/php-sdk/imdb/packageName/README.md
+++ b/seed/php-sdk/imdb/packageName/README.md
@@ -57,6 +57,44 @@ try {
 }
 ```
 
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+```
+
+### Timeouts
+
+The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/php-sdk/imdb/private/README.md
+++ b/seed/php-sdk/imdb/private/README.md
@@ -57,6 +57,44 @@ try {
 }
 ```
 
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'maxRetries' => 0 // Override maxRetries at the request level
+    ]
+);
+```
+
+### Timeouts
+
+The SDK defaults to a 30 second timeout. Use the `timeout` option to configure this behavior.
+
+```php
+$response = $client->imdb->createMovie(
+    ...,
+    options: [
+        'timeout' => 3.0 // Override timeout to 3 seconds
+    ]
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.


### PR DESCRIPTION
## Description
Document retries and timeouts in the PHP SDK. 

## Changes Made
- See READMEs changed in tests. 

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

