### PR TITLE
chore(cli): disable snippet option

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-16.mdx
+++ b/fern/pages/changelogs/cli/2025-06-16.mdx
@@ -1,3 +1,7 @@
+## 0.64.10
+**`(feat):`** Add configuration option to disable snippets in docs generation, speeding up generation time.
+
+
 ## 0.64.9
 **`(fix):`** Update CLI for sites pinned to the legacy deployment.
 

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -505,6 +505,11 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                         "Throw an error (rather than logging a warning) if there are broken links in the docs.",
                     default: false
                 })
+                .option("disable-snippets", {
+                    boolean: true,
+                    description: "Disable snippets in docs generation.",
+                    default: false
+                })
                 .option("runner", {
                     choices: ["docker", "podman"],
                     description: "Choose the container runtime to use for local generation.",
@@ -555,7 +560,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     instance: argv.instance,
                     preview: argv.preview,
                     brokenLinks: argv.brokenLinks,
-                    strictBrokenLinks: argv.strictBrokenLinks
+                    strictBrokenLinks: argv.strictBrokenLinks,
+                    disableTemplates: argv.disableSnippets
                 });
             }
             // default to loading api workspace to preserve legacy behavior

--- a/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
@@ -5,7 +5,7 @@ import { Project } from "@fern-api/project-loader";
 import { CliContext } from "../../cli-context/CliContext";
 import { validateDocsWorkspaceWithoutExiting } from "../validate/validateDocsWorkspaceAndLogIssues";
 
-const legacyPin = ["cohere", "devrev", "deriv"];
+const legacyPin = ["devrev"];
 
 export async function previewDocsWorkspace({
     loadProject,

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -14,7 +14,8 @@ export async function generateDocsWorkspace({
     instance,
     preview,
     brokenLinks,
-    strictBrokenLinks
+    strictBrokenLinks,
+    disableTemplates
 }: {
     project: Project;
     cliContext: CliContext;
@@ -22,6 +23,7 @@ export async function generateDocsWorkspace({
     preview: boolean;
     brokenLinks: boolean;
     strictBrokenLinks: boolean;
+    disableTemplates: boolean | undefined;
 }): Promise<void> {
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
@@ -85,7 +87,8 @@ export async function generateDocsWorkspace({
             context,
             token,
             instanceUrl: instance,
-            preview
+            preview,
+            disableTemplates
         });
     });
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Update CLI for sites pinned to the legacy deployment.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-16"
+  version: 0.64.9
+
+- changelogEntry:
+    - summary: |
         Support hot-reloading for changes to OpenRPC specs in local development mode.
       type: fix
   irVersion: 58

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add configuration option to disable snippets in docs generation, speeding up generation time.
+      type: feat
+  irVersion: 58
+  createdAt: "2025-06-16"
+  version: 0.64.10
+
+- changelogEntry:
+    - summary: |
         Update CLI for sites pinned to the legacy deployment.
       type: fix
   irVersion: 58

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -40,7 +40,8 @@ export async function publishDocs({
     context,
     preview,
     editThisPage,
-    isPrivate = false
+    isPrivate = false,
+    disableTemplates = false
 }: {
     token: FernToken;
     organization: string;
@@ -53,6 +54,7 @@ export async function publishDocs({
     preview: boolean;
     editThisPage: docsYml.RawSchemas.FernDocsConfig.EditThisPageConfig | undefined;
     isPrivate: boolean | undefined;
+    disableTemplates: boolean | undefined;
 }): Promise<void> {
     const fdr = createFdrService({ token: token.value });
     const authConfig: CjsFdrSdk.docs.v2.write.AuthConfig = isPrivate
@@ -163,7 +165,10 @@ export async function publishDocs({
             const response = await fdr.api.v1.register.registerApiDefinition({
                 orgId: CjsFdrSdk.OrgId(organization),
                 apiId: CjsFdrSdk.ApiId(ir.apiName.originalName),
-                definition: apiDefinition,
+                definition: {
+                    ...apiDefinition,
+                    snippetsConfiguration: preview ? undefined : apiDefinition.snippetsConfiguration
+                },
                 definitionV2: undefined
             });
 
@@ -197,7 +202,10 @@ export async function publishDocs({
                 orgId: CjsFdrSdk.OrgId(organization),
                 apiId: CjsFdrSdk.ApiId(apiName ?? api.id),
                 definition: undefined,
-                definitionV2: api
+                definitionV2: {
+                    ...api,
+                    snippetsConfiguration: preview ? undefined : api.snippetsConfiguration
+                }
             });
 
             if (response.ok) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -14,7 +14,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     context,
     token,
     instanceUrl,
-    preview
+    preview,
+    disableTemplates
 }: {
     organization: string;
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
@@ -24,6 +25,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     token: FernToken;
     instanceUrl: string | undefined;
     preview: boolean;
+    disableTemplates: boolean | undefined;
 }): Promise<void> {
     const instances = docsWorkspace.config.instances;
 
@@ -83,7 +85,8 @@ export async function runRemoteGenerationForDocsWorkspace({
             ossWorkspaces,
             preview,
             editThisPage: maybeInstance.editThisPage,
-            isPrivate: maybeInstance.private
+            isPrivate: maybeInstance.private,
+            disableTemplates
         });
     });
     return;


### PR DESCRIPTION
add option to disable snippet generation. this is a temporary solution to decrease preview link generation time, while we ship the dynamic snippets generator