### PR TITLE
fix(cli): Update protoc-gen-fern settings

### DIFF
--- a/packages/cli/generation/protoc-gen-fern/src/generateIr.ts
+++ b/packages/cli/generation/protoc-gen-fern/src/generateIr.ts
@@ -22,7 +22,8 @@ export function generateIr({ req, options }: { req: CodeGeneratorRequest; option
         breadcrumbs: [],
         context: new ProtobufConverterContext({
             spec: req,
-            settings: undefined,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            settings: {} as any,
             errorCollector: new ErrorCollector({
                 logger: {
                     log: (level, ...args) => {}


### PR DESCRIPTION
This fixes the `settings` field in `protoc-gen-fern`, which previously caused a compile failure.
