### PR TITLE
fix(internal): Mirror World typo in docs

### DIFF
--- a/fern/pages/docs/integrations/postman.mdx
+++ b/fern/pages/docs/integrations/postman.mdx
@@ -17,7 +17,7 @@ subtitle: "Generate a postman collection full of example requests and responses"
 />
 
 <Card
-  title="MirrorWOrld"
+  title="Mirror World"
   href="https://developer.mirrorworld.fun/"
   horizontal
   icon={<img src="https://cdn.brandfetch.io/idLEJUb6Vb/w/400/h/400/theme/dark/icon.jpeg" />}


### PR DESCRIPTION
## Description

Fix typo in docs 
<img width="666" alt="image" src="https://github.com/user-attachments/assets/803c0ac5-e79a-4e0e-b87b-56404f3e5c8b" />

