### PR TITLE
feat(typescript) [DRAFT] Add support for undiscriminated unions in Python v2 generator

### DIFF
--- a/generators/python-v2/pydantic-model/src/v2/UndiscriminatedUnionGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/UndiscriminatedUnionGenerator.ts
@@ -1,0 +1,46 @@
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { python } from "@fern-api/python-ast";
+import { WriteablePythonFile } from "@fern-api/python-base";
+
+import { TypeDeclaration, TypeId, UndiscriminatedUnionTypeDeclaration } from "@fern-fern/ir-sdk/api";
+
+import { PydanticModelGeneratorContext } from "../ModelGeneratorContext";
+
+export class UndiscriminatedUnionGenerator {
+    constructor(
+        private readonly typeId: TypeId,
+        private readonly context: PydanticModelGeneratorContext,
+        private readonly typeDeclaration: TypeDeclaration,
+        private readonly undiscriminatedUnionDeclaration: UndiscriminatedUnionTypeDeclaration
+    ) {}
+
+    public doGenerate(): WriteablePythonFile {
+        const path = this.context.getModulePathForId(this.typeId);
+        const filename = this.context.getSnakeCaseSafeName(this.typeDeclaration.name.name);
+        const file = python.file({ path });
+
+        // Add imports
+        file.addReference(python.reference({ name: "Union", modulePath: ["typing"] }));
+
+        // Add union type
+        file.addStatement(
+            python.codeBlock((writer) => {
+                writer.write(`${this.context.getPascalCaseSafeName(this.typeDeclaration.name.name)} = `);
+                writer.write("[");
+                this.undiscriminatedUnionDeclaration.members.forEach((member, index) => {
+                    if (index > 0) {
+                        writer.write(", ");
+                    }
+                    writer.write(this.context.pythonTypeMapper.convert({ reference: member.type }).toString());
+                });
+                writer.write("]");
+            })
+        );
+
+        return new WriteablePythonFile({
+            contents: file,
+            directory: RelativeFilePath.of(path.join("/")),
+            filename
+        });
+    }
+}

--- a/generators/python-v2/pydantic-model/src/v2/generateV2Models.ts
+++ b/generators/python-v2/pydantic-model/src/v2/generateV2Models.ts
@@ -2,6 +2,7 @@ import { WriteablePythonFile } from "@fern-api/python-base";
 
 import { PydanticModelGeneratorContext } from "../ModelGeneratorContext";
 import { ObjectGenerator } from "./ObjectGenerator";
+import { UndiscriminatedUnionGenerator } from "./UndiscriminatedUnionGenerator";
 import { WrappedAliasGenerator } from "./WrappedAliasGenerator";
 
 export function generateV2Models({ context }: { context: PydanticModelGeneratorContext }): WriteablePythonFile[] {
@@ -15,7 +16,14 @@ export function generateV2Models({ context }: { context: PydanticModelGeneratorC
             object: (objectTypDeclaration) => {
                 return new ObjectGenerator(typeId, context, typeDeclaration, objectTypDeclaration).doGenerate();
             },
-            undiscriminatedUnion: () => undefined,
+            undiscriminatedUnion: (UndiscriminatedUnionTypeDeclaration) => {
+                return new UndiscriminatedUnionGenerator(
+                    typeId,
+                    context,
+                    typeDeclaration,
+                    UndiscriminatedUnionTypeDeclaration
+                ).doGenerate();
+            },
             union: () => undefined,
             _other: () => undefined
         });

--- a/seed/pydantic-v2/undiscriminated-unions/.mock/definition/union.yml
+++ b/seed/pydantic-v2/undiscriminated-unions/.mock/definition/union.yml
@@ -19,8 +19,23 @@ service:
               value: exampleValue
               default: exampleDefault
 
+    updateMetadata:
+      path: "/metadata"
+      method: PUT
+      request: MetadataUnion
+      response: boolean
+
+    call:
+      path: "/call"
+      method: POST
+      request: Request
+      response: boolean
 
 types:
+  Request:
+    properties:
+      union: optional<MetadataUnion>
+
   TypeWithOptionalUnion:
     properties:
       myUnion: optional<MyUnion>
@@ -36,6 +51,20 @@ types:
       - list<integer>
       - list<list<integer>>
       - set<string>
+
+  MetadataUnion:
+    discriminated: false
+    union:
+      - OptionalMetadata
+      - NamedMetadata
+
+  NamedMetadata:
+    properties:
+      name: string
+      value: map<string, unknown>
+
+  OptionalMetadata:
+    type: optional<map<string, unknown>>
 
   Metadata:
     docs: |

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/key.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/key.py
@@ -1,3 +1,3 @@
-from typing import Union, KeyType, str
+import typing
 
-Key = Union[KeyType, str]
+Key = typing.Union[typing.KeyType, str]

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/key.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/key.py
@@ -1,0 +1,3 @@
+from typing import Union, KeyType, str
+
+Key = Union[KeyType, str]

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/metadata.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/metadata.py
@@ -1,12 +1,14 @@
 from pydantic import RootModel
 from typing import Dict
-from resources.union.types.key import Key
+from .key import Key
+from uuid import UUID
 from dt import datetime
 from core.datetime_utils import serialize_datetime
+
 class Metadata(RootModel[Dict[Key, str]]):
-"""Undiscriminated unions can act as a map key
-as long as all of their values are valid keys
-(i.e. do they have a valid string representation)."""
+    """Undiscriminated unions can act as a map key
+    as long as all of their values are valid keys
+    (i.e. do they have a valid string representation)."""
     root: Dict[Key, str]
     def get_as_map() -> UUID:
         return self.root

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/metadata_union.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/metadata_union.py
@@ -1,0 +1,3 @@
+from typing import Union, Optional[Dict[str, Any]], NamedMetadata
+
+MetadataUnion = Union[Optional[Dict[str, Any]], NamedMetadata]

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/metadata_union.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/metadata_union.py
@@ -1,3 +1,3 @@
-from typing import Union, Optional[Dict[str, Any]], NamedMetadata
+import typing
 
-MetadataUnion = Union[Optional[Dict[str, Any]], NamedMetadata]
+MetadataUnion = typing.Union[typing.Optional[Dict[str, Any]], typing.NamedMetadata]

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/my_union.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/my_union.py
@@ -1,0 +1,3 @@
+from typing import Union, str, List[str], int, List[int], List[List[int]], Set[str]
+
+MyUnion = Union[str, List[str], int, List[int], List[List[int]], Set[str]]

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/my_union.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/my_union.py
@@ -1,3 +1,3 @@
-from typing import Union, str, List[str], int, List[int], List[List[int]], Set[str]
+import typing
 
-MyUnion = Union[str, List[str], int, List[int], List[List[int]], Set[str]]
+MyUnion = typing.Union[str, typing.List[str], int, typing.List[int], typing.List[typing.List[int]], typing.Set[str]]

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/named_metadata.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/named_metadata.py
@@ -1,11 +1,11 @@
 from pydantic import BaseModel
-from typing import Optional
-from .my_union import MyUnion
+from typing import Dict, Any
 from dt import datetime
 from core.datetime_utils import serialize_datetime
 
-class TypeWithOptionalUnion(BaseModel):
-    my_union: Optional[MyUnion]
+class NamedMetadata(BaseModel):
+    name: str
+    value: Dict[str, Any]
     class Config:
         frozen = True
         smart_union = True

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/optional_metadata.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/optional_metadata.py
@@ -1,0 +1,18 @@
+from pydantic import RootModel
+from typing import Optional, Dict, Any
+from uuid import UUID
+from dt import datetime
+from core.datetime_utils import serialize_datetime
+
+class OptionalMetadata(RootModel[Optional[Dict[str, Any]]]):
+    root: Optional[Dict[str, Any]]
+    def get_as_map() -> UUID:
+        return self.root
+    @staticmethod
+    def from_map(value: Optional[Dict[str, Any]]) -> OptionalMetadata:
+        OptionalMetadata(root=value)
+    class Config:
+        frozen = True
+        smart_union = True
+        json_encoders = {datetime: serialize_datetime}
+

--- a/seed/pydantic-v2/undiscriminated-unions/resources/union/types/request.py
+++ b/seed/pydantic-v2/undiscriminated-unions/resources/union/types/request.py
@@ -1,11 +1,11 @@
 from pydantic import BaseModel
 from typing import Optional
-from .my_union import MyUnion
+from .metadata_union import MetadataUnion
 from dt import datetime
 from core.datetime_utils import serialize_datetime
 
-class TypeWithOptionalUnion(BaseModel):
-    my_union: Optional[MyUnion]
+class Request(BaseModel):
+    union: Optional[MetadataUnion] = None
     class Config:
         frozen = True
         smart_union = True


### PR DESCRIPTION
## Description
This PR adds support for generating undiscriminated unions in python using a typescript generator function.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Creates `UndiscriminatedUnionGenerator` class that generates simple `typing.UndiscriminatedUnion` types
- Generates clean union syntax: `MyUnion = typing.Union[str, typing.List[str], int]`
- Integrates with existing generateV2Models function

## Future Work
Ran out of time to finish all the features needed to perfectly replicate the existing implementation from the python-native generator. Ideally:
- the generator would robustly detect nested types in order to prepend the `typing` package

## Testing
Changes tested by running 
- [x] Manual testing completed

Tested by running 
```
pnpm seed test --generator pydantic-v2 --log-level debug --fixture exhaustive --skip-scripts --undiscriminated-unions
```
and comparing the output to the generated output of the python-native generated file [here](https://github.com/fern-api/fern/blob/main/seed/pydantic/undiscriminated-unions/src/seed/undiscriminated_unions/resources/union/my_union.py).

```
import typing

MyUnion = typing.Union[str, typing.List[str], int, typing.List[int], typing.List[typing.List[int]], typing.Set[str]]

```