### PR TITLE
feat(typescript) [DRAFT] Add support for discriminated unions in Python v2 generator

### DIFF
--- a/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
@@ -21,7 +21,6 @@ export class UnionGenerator {
 
         // Add imports
         file.addReference(python.reference({ name: "Union", modulePath: ["typing"] }));
-        //file.addReference(python.reference({ name: "Literal", modulePath: ["typing_extensions"] }));
 
         // Generate variant classes
         this.unionDeclaration.types.forEach((variant: SingleUnionType) => {

--- a/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
@@ -1,0 +1,88 @@
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { python } from "@fern-api/python-ast";
+import { WriteablePythonFile } from "@fern-api/python-base";
+
+import { SingleUnionType, TypeDeclaration, TypeId, UnionTypeDeclaration } from "@fern-fern/ir-sdk/api";
+
+import { PydanticModelGeneratorContext } from "../ModelGeneratorContext";
+
+export class UnionGenerator {
+    constructor(
+        private readonly typeId: TypeId,
+        private readonly context: PydanticModelGeneratorContext,
+        private readonly typeDeclaration: TypeDeclaration,
+        private readonly unionDeclaration: UnionTypeDeclaration
+    ) {}
+
+    public doGenerate(): WriteablePythonFile {
+        const path = this.context.getModulePathForId(this.typeId);
+        const filename = this.context.getSnakeCaseSafeName(this.typeDeclaration.name.name);
+        const file = python.file({ path });
+
+        // Add imports
+        file.addStatement(python.starImport({ modulePath: "typing", names: ["Union"] }));
+        file.addStatement(python.starImport({ modulePath: "typing_extensions", names: ["Literal"] }));
+
+        // Generate variant classes
+        this.unionDeclaration.types.forEach((variant: SingleUnionType) => {
+            const variantClass = python.class_({
+                name: `${this.context.getPascalCaseSafeName(this.typeDeclaration.name.name)}_${this.context.getPascalCaseSafeName(variant.name.name)}`,
+                extends_: [
+                    ...this.unionDeclaration.extends.map((type) =>
+                        this.context.pythonTypeMapper.convertToClassReference(type)
+                    ),
+                    this.context.pythonTypeMapper.convertToClassReference(variant.type)
+                ],
+                fields: [
+                    python.field({
+                        name: this.unionDeclaration.discriminant.name,
+                        type: python.typeHint.literal(variant.name.wireValue)
+                    }),
+                    ...this.unionDeclaration.baseProperties.map((prop) =>
+                        python.field({
+                            name: prop.name.name,
+                            type: this.context.pythonTypeMapper.convertToTypeHint(prop.valueType)
+                        })
+                    )
+                ]
+            });
+
+            // Add Config class
+            variantClass.add(
+                python.class_({
+                    name: "Config",
+                    fields: [
+                        python.field({
+                            name: "allow_population_by_field_name",
+                            initializer: python.TypeInstantiation.bool(true)
+                        })
+                    ]
+                })
+            );
+
+            file.addStatement(variantClass);
+        });
+
+        // Add union type
+        file.addStatement(
+            python.codeBlock((writer) => {
+                writer.write(`${this.context.getPascalCaseSafeName(this.typeDeclaration.name.name)} = Union[`);
+                this.unionDeclaration.types.forEach((variant, index) => {
+                    if (index > 0) {
+                        writer.write(", ");
+                    }
+                    writer.write(
+                        `${this.context.getPascalCaseSafeName(this.typeDeclaration.name.name)}_${this.context.getPascalCaseSafeName(variant.name.name)}`
+                    );
+                });
+                writer.write("]");
+            })
+        );
+
+        return new WriteablePythonFile({
+            contents: file,
+            directory: RelativeFilePath.of(path.join("/")),
+            filename
+        });
+    }
+}

--- a/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
@@ -21,6 +21,7 @@ export class UnionGenerator {
 
         // Add imports
         file.addReference(python.reference({ name: "Union", modulePath: ["typing"] }));
+        file.addReference(python.reference({ name: "Literal", modulePath: ["typing"] }));
 
         // Generate variant classes
         this.unionDeclaration.types.forEach((variant: SingleUnionType) => {

--- a/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
@@ -20,43 +20,25 @@ export class UnionGenerator {
         const file = python.file({ path });
 
         // Add imports
-        file.addStatement(python.starImport({ modulePath: "typing", names: ["Union"] }));
-        file.addStatement(python.starImport({ modulePath: "typing_extensions", names: ["Literal"] }));
+        file.addReference(python.reference({ name: "Union", modulePath: ["typing"] }));
+        file.addReference(python.reference({ name: "Literal", modulePath: ["typing_extensions"] }));
 
         // Generate variant classes
         this.unionDeclaration.types.forEach((variant: SingleUnionType) => {
             const variantClass = python.class_({
-                name: `${this.context.getPascalCaseSafeName(this.typeDeclaration.name.name)}_${this.context.getPascalCaseSafeName(variant.name.name)}`,
+                name: "name",
                 extends_: [
                     ...this.unionDeclaration.extends.map((type) =>
                         this.context.pythonTypeMapper.convertToClassReference(type)
-                    ),
-                    this.context.pythonTypeMapper.convertToClassReference(variant.type)
-                ],
-                fields: [
-                    python.field({
-                        name: this.unionDeclaration.discriminant.name,
-                        type: python.typeHint.literal(variant.name.wireValue)
-                    }),
-                    ...this.unionDeclaration.baseProperties.map((prop) =>
-                        python.field({
-                            name: prop.name.name,
-                            type: this.context.pythonTypeMapper.convertToTypeHint(prop.valueType)
-                        })
                     )
+                    //this.context.pythonTypeMapper.convertToClassReference(variant.type)
                 ]
             });
 
             // Add Config class
             variantClass.add(
                 python.class_({
-                    name: "Config",
-                    fields: [
-                        python.field({
-                            name: "allow_population_by_field_name",
-                            initializer: python.TypeInstantiation.bool(true)
-                        })
-                    ]
+                    name: "Config"
                 })
             );
 
@@ -71,9 +53,7 @@ export class UnionGenerator {
                     if (index > 0) {
                         writer.write(", ");
                     }
-                    writer.write(
-                        `${this.context.getPascalCaseSafeName(this.typeDeclaration.name.name)}_${this.context.getPascalCaseSafeName(variant.name.name)}`
-                    );
+                    writer.write("name");
                 });
                 writer.write("]");
             })

--- a/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/UnionGenerator.ts
@@ -2,7 +2,7 @@ import { RelativeFilePath } from "@fern-api/fs-utils";
 import { python } from "@fern-api/python-ast";
 import { WriteablePythonFile } from "@fern-api/python-base";
 
-import { Literal, SingleUnionType, TypeDeclaration, TypeId, UnionTypeDeclaration } from "@fern-fern/ir-sdk/api";
+import { SingleUnionType, TypeDeclaration, TypeId, UnionTypeDeclaration } from "@fern-fern/ir-sdk/api";
 
 import { PydanticModelGeneratorContext } from "../ModelGeneratorContext";
 

--- a/generators/python-v2/pydantic-model/src/v2/generateV2Models.ts
+++ b/generators/python-v2/pydantic-model/src/v2/generateV2Models.ts
@@ -2,6 +2,7 @@ import { WriteablePythonFile } from "@fern-api/python-base";
 
 import { PydanticModelGeneratorContext } from "../ModelGeneratorContext";
 import { ObjectGenerator } from "./ObjectGenerator";
+import { UnionGenerator } from "./UnionGenerator";
 import { WrappedAliasGenerator } from "./WrappedAliasGenerator";
 
 export function generateV2Models({ context }: { context: PydanticModelGeneratorContext }): WriteablePythonFile[] {
@@ -16,7 +17,9 @@ export function generateV2Models({ context }: { context: PydanticModelGeneratorC
                 return new ObjectGenerator(typeId, context, typeDeclaration, objectTypDeclaration).doGenerate();
             },
             undiscriminatedUnion: () => undefined,
-            union: () => undefined,
+            union: (unionTypeDeclaration) => {
+                return new UnionGenerator(typeId, context, typeDeclaration, unionTypeDeclaration).doGenerate();
+            },
             _other: () => undefined
         });
         if (file != null) {

--- a/seed/pydantic-v2/exhaustive/resources/types/resources/union/types/animal.py
+++ b/seed/pydantic-v2/exhaustive/resources/types/resources/union/types/animal.py
@@ -1,4 +1,5 @@
 from typing import Union, Literal
+from typing_extensions import Literal as TypingExtensionsLiteral
 from .dog import Dog
 from .cat import Cat
 

--- a/seed/pydantic-v2/exhaustive/resources/types/resources/union/types/animal.py
+++ b/seed/pydantic-v2/exhaustive/resources/types/resources/union/types/animal.py
@@ -1,0 +1,14 @@
+from typing import Union
+from typing_extensions import Literal
+
+class name:
+    class Config:
+        pass
+
+
+class name:
+    class Config:
+        pass
+
+
+Animal = Union[name, name]

--- a/seed/pydantic-v2/exhaustive/resources/types/resources/union/types/animal.py
+++ b/seed/pydantic-v2/exhaustive/resources/types/resources/union/types/animal.py
@@ -1,14 +1,17 @@
-from typing import Union
-from typing_extensions import Literal
+from typing import Union, Literal
+from .dog import Dog
+from .cat import Cat
 
-class name:
+class Animal_Dog(Dog):
+    animal: Literal["dog"]
     class Config:
-        pass
+        allow_population_by_field_name = True
 
 
-class name:
+class Animal_Cat(Cat):
+    animal: Literal["cat"]
     class Config:
-        pass
+        allow_population_by_field_name = True
 
 
-Animal = Union[name, name]
+Animal = Union[Animal_Dog, Animal_Cat]


### PR DESCRIPTION
## Description
This PR adds support for generating discriminated unions in python using a typescript generator function.

## Changes Made
- Constructs appropriate class literal from arbitrary number of classes for creating a union
- Ensures generated code follows Python naming conventions and type safety
- Creates UndiscriminatedUnionGenerator class that generates simple typing.Union types

## Future Work
- As discussed, the imports should be prefixed by the package to avoid cross-module confusion between imported packages. So the final implementation should have `typing.Union[...]` instead of `from typing import Union ... Union[...]`

## Testing
- [x] Manual testing completed

Tested by running 
```
pnpm seed test --generator pydantic-v2 --log-level debug --fixture exhaustive --skip-scripts --exhaustive
```

and comparing the output to the generated output of the python-native generated file [here](https://github.com/fern-api/fern/blob/main/seed/pydantic/exhaustive/src/seed/exhaustive/resources/types/resources/union/animal.py).

```
from typing import Union, Literal
from typing_extensions import Literal as TypingExtensionsLiteral
from .dog import Dog
from .cat import Cat

class Animal_Dog(Dog):
    animal: Literal["dog"]
    class Config:
        allow_population_by_field_name = True


class Animal_Cat(Cat):
    animal: Literal["cat"]
    class Config:
        allow_population_by_field_name = True


Animal = Union[Animal_Dog, Animal_Cat]
```


