### PR TITLE
feat: Adding compatibility options for str enums in python 3.11

### DIFF
--- a/generators/python/src/fern_python/generators/pydantic_model/custom_config.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/custom_config.py
@@ -50,6 +50,17 @@ class BasePydanticModelCustomConfig(pydantic.BaseModel):
 
     use_pydantic_field_aliases: bool = True
 
+    generate_enum_format_str_methods: Literal[False, "like_pre_311", "like_311", "like_strenum"] = False
+    """
+    Where to override __format__ and __str__ methods of enums in order to ensure consistent behavior
+    in the face of python3.11 changes to Enums with str mixins.
+    
+    False        = no override, behavior depends on environment
+    like_pre_311 = __str__ returns unqualified form, __format__ returns qualified form
+    like_311     = both return qualified form
+    like_strenum = both return unqualified form
+    """
+
     @pydantic.model_validator(mode="after")
     def check_wrapped_aliases_v1_or_v2_only(self) -> Self:
         version_compat = self.version

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/enum_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/enum_generator.py
@@ -181,8 +181,7 @@ class EnumGenerator(AbstractTypeGenerator):
             ),
             body=[
                 AST.ReturnStatement(
-                    expression="f\"{qualification}{self.value}\""
-                )
+                    f"f\"{qualification}{{self.value}}\""
                 )
             ]
         )

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/enum_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/enum_generator.py
@@ -181,7 +181,8 @@ class EnumGenerator(AbstractTypeGenerator):
             ),
             body=[
                 AST.ReturnStatement(
-                    f"return f\"{qualification}{{self.value}}\""
+                    expression="f\"{qualification}{self.value}\""
+                )
                 )
             ]
         )


### PR DESCRIPTION
## Description

With `class X(str, Enum)` there is unfortunate breaking behavior in python 3.11 in the way `__format__` is implemented.  In truth, `Enum` always had inconsistent behavior with how `__str__` and `__format__` were implemented.  [Here's](https://blog.pecar.me/python-enum) a great blog describing the issue further.  Currently using fern's python Enum classes risks inconsistent behavior with python >= 3.11, which is blocking upgrades.

## Changes Made

A [previous approach](https://github.com/fern-api/fern/pull/4090) from @jochs tried to conditionally use `StrEnum`, which is introduced in python 3.11, but makes behavior conditional on the python environment of a client consuming the SDK, which isn't ideal.

This approach is simpler.  It provides the optional ability to control precisely how each of the `str` and `format` metamethods work in the output SDK via overriding their implementations, ensuring consistent behavior regardless of consuming python version.  `like_pre_311` captures Python 3.10 and earlier's inconsistent behavior, but ensures no effective change in behavior for projects upgrading from Python 3.10.  `like_311` ensures that both `str` and `format` return qualified enum values, which is how Python 3.11 changed its `__format__` implementation.  Lastly, `like_strenum` provides consistency that same way that `StrEnum` does in python 3.11 by ensuring both methods are unqualified.

SDK developers can decide clearly which behavior they want and ensure all python versions behave identically.

## Testing

I would love to add unit tests, but I'll be honest, I am unsure how to do so!  Would expand on it with some direction.
- [ ] Unit tests added/updated

