### PR TITLE
fix(python): Lazily validate model serialization

### DIFF
--- a/fern/pages/changelogs/python-sdk/2025-06-20.mdx
+++ b/fern/pages/changelogs/python-sdk/2025-06-20.mdx
@@ -1,4 +1,4 @@
-## 4.22.1
+## 4.22.1-rc0
 **`(feat):`** Lazily validate model serialization.
 
 

--- a/fern/pages/changelogs/python-sdk/2025-06-20.mdx
+++ b/fern/pages/changelogs/python-sdk/2025-06-20.mdx
@@ -1,4 +1,9 @@
 ## 4.22.1-rc0
-**`(feat):`** Lazily validate model serialization.
+**`(feat):`** Lazily validate model serialization to reduce memory consumption. Pydantic 2.11.0 introduced an issue where the model_serializer 
+decorator set to wrap mode forced it to eagerly do schema validation at import time. Because we had this decorator on the UniversalBaseModel,
+it would try to validate the schemas of all the Model types at import time. This caused massive memory spikes for more complex SDKs, upto 2.6GB
+in some cases. This change essentially accomplishes the same logic of wrapping the serialization process and modifying the serialization
+structure of datetime fields. The difference is that we manually wrap, so we're able to defer model validation until runtime, drastically
+reducing our memory consumption.
 
 

--- a/fern/pages/changelogs/python-sdk/2025-06-20.mdx
+++ b/fern/pages/changelogs/python-sdk/2025-06-20.mdx
@@ -1,0 +1,4 @@
+## 4.22.1
+**`(feat):`** Lazily validate model serialization.
+
+

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -57,9 +57,9 @@ class UniversalBaseModel(pydantic.BaseModel):
             protected_namespaces=(),
         )
 
-        @pydantic.model_serializer(mode="wrap", when_used="json")  # type: ignore[attr-defined]
-        def serialize_model(self, handler: pydantic.SerializerFunctionWrapHandler) -> Any:  # type: ignore[name-defined]
-            serialized = handler(self)
+        @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
+        def serialize_model(self) -> Any:  # type: ignore[name-defined]
+            serialized = super().model_dump()
             data = {k: serialize_datetime(v) if isinstance(v, dt.datetime) else v for k, v in serialized.items()}
             return data
 

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -59,7 +59,7 @@ class UniversalBaseModel(pydantic.BaseModel):
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
-            serialized = super().model_dump()
+            serialized = self.model_dump()
             data = {k: serialize_datetime(v) if isinstance(v, dt.datetime) else v for k, v in serialized.items()}
             return data
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.22.1
+  changelogEntry:
+    - summary: |
+        Lazily validate model serialization.
+      type: feat
+  createdAt: '2025-06-20'
+  irVersion: 58
+
 - version: 4.22.0
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -3,7 +3,12 @@
 - version: 4.22.1-rc0
   changelogEntry:
     - summary: |
-        Lazily validate model serialization.
+        Lazily validate model serialization to reduce memory consumption. Pydantic 2.11.0 introduced an issue where the model_serializer 
+        decorator set to wrap mode forced it to eagerly do schema validation at import time. Because we had this decorator on the UniversalBaseModel,
+        it would try to validate the schemas of all the Model types at import time. This caused massive memory spikes for more complex SDKs, upto 2.6GB
+        in some cases. This change essentially accomplishes the same logic of wrapping the serialization process and modifying the serialization
+        structure of datetime fields. The difference is that we manually wrap, so we're able to defer model validation until runtime, drastically
+        reducing our memory consumption.
       type: feat
   createdAt: '2025-06-20'
   irVersion: 58

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
-- version: 4.22.1
+- version: 4.22.1-rc0
   changelogEntry:
     - summary: |
         Lazily validate model serialization.

--- a/generators/python/tests/utils/unaliased_models/types/core/pydantic_utilities.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/pydantic_utilities.py
@@ -87,7 +87,7 @@ class UniversalBaseModel(pydantic.BaseModel):
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore # Pydantic v2
         def serialize_model(self) -> typing.Any:  # type: ignore # Pydantic v2
-            serialized = super().model_dump()
+            serialized = self.model_dump()
             data = {
                 k: serialize_datetime(v) if isinstance(v, dt.datetime) else v
                 for k, v in serialized.items()

--- a/generators/python/tests/utils/unaliased_models/types/core/pydantic_utilities.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/pydantic_utilities.py
@@ -85,11 +85,9 @@ class UniversalBaseModel(pydantic.BaseModel):
             protected_namespaces=(),
         )  # type: ignore # Pydantic v2
 
-        @pydantic.model_serializer(mode="wrap", when_used="json")  # type: ignore # Pydantic v2
-        def serialize_model(
-            self, handler: pydantic.SerializerFunctionWrapHandler
-        ) -> typing.Any:  # type: ignore # Pydantic v2
-            serialized = handler(self)
+        @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore # Pydantic v2
+        def serialize_model(self) -> typing.Any:  # type: ignore # Pydantic v2
+            serialized = super().model_dump()
             data = {
                 k: serialize_datetime(v) if isinstance(v, dt.datetime) else v
                 for k, v in serialized.items()

--- a/seed/python-sdk/imdb/poetry.lock
+++ b/seed/python-sdk/imdb/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
-    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
 ]
 
 [[package]]

--- a/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
@@ -59,9 +59,9 @@ class UniversalBaseModel(pydantic.BaseModel):
             protected_namespaces=(),
         )
 
-        @pydantic.model_serializer(mode="wrap", when_used="json")  # type: ignore[attr-defined]
-        def serialize_model(self, handler: pydantic.SerializerFunctionWrapHandler) -> Any:  # type: ignore[name-defined]
-            serialized = handler(self)
+        @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
+        def serialize_model(self) -> Any:  # type: ignore[name-defined]
+            serialized = super().model_dump()
             data = {k: serialize_datetime(v) if isinstance(v, dt.datetime) else v for k, v in serialized.items()}
             return data
 

--- a/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
@@ -61,7 +61,7 @@ class UniversalBaseModel(pydantic.BaseModel):
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
-            serialized = super().model_dump()
+            serialized = self.model_dump()
             data = {k: serialize_datetime(v) if isinstance(v, dt.datetime) else v for k, v in serialized.items()}
             return data
 


### PR DESCRIPTION
## Description
We've been seeing very large memory consumption (>2gb) for complex python sdks just by importing the lib.


## Changes Made
We've modified our UniversalBaseModel's @pydantic.model_serializer method to manually wrap the pydantic.BaseModel serializer. This allows us to do lazy schema validation instead of doing schema validation on import.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
  - Manually generated elevenlabs python sdk with seed
  - Manually added .fernignored files where necessary
  - Wrote a script to do their [developer quickstart](https://elevenlabs.io/docs/quickstart) with the generated sdk. the request worked, implying serialization is still working.

