### PR TITLE
fix(cli): bug with ExampleTypeFactory

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-21.mdx
+++ b/fern/pages/changelogs/cli/2025-06-21.mdx
@@ -1,0 +1,4 @@
+## 0.64.15
+**`(fix):`** Fixed ExampleTypeFactory to ignore generating parameters in example when that parameter is both optional and deprecated
+
+

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/apiture.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/apiture.json
@@ -15659,13 +15659,11 @@ The default response lists only recent transactions. Normally, this is transacti
                           "check": {
                             "number": 1,
                           },
-                          "createdOn": "2023-05-18",
                           "description": "description",
                           "id": "d62c0701-0d74",
                           "memo": "memo",
                           "occurredOn": "2023-06-18",
                           "posted": true,
-                          "postedOn": "2023-05-18",
                           "subtype": "check",
                           "type": "balance",
                         },
@@ -15681,7 +15679,6 @@ The default response lists only recent transactions. Normally, this is transacti
                             "imageFront_url": "/accounts/1d16e438-18e0/transactions/88f5bf17-ecc4/images/front/content",
                             "number": 8412,
                           },
-                          "createdOn": "2023-05-18",
                           "description": "description",
                           "id": "88f5bf17-ecc4",
                           "memo": "Paid electric bill",
@@ -15692,7 +15689,6 @@ The default response lists only recent transactions. Normally, this is transacti
                           },
                           "occurredOn": "2023-06-18",
                           "posted": true,
-                          "postedOn": "2023-05-18",
                           "subtype": "check",
                           "type": "debit",
                         },
@@ -16013,8 +16009,6 @@ service:
                   type: balance
                   subtype: check
                   occurredOn: '2023-06-18'
-                  createdOn: '2023-05-18'
-                  postedOn: '2023-05-18'
                   amount: '0.00'
                   posted: true
                   balance: '8509.38'
@@ -16028,8 +16022,6 @@ service:
                   type: debit
                   subtype: check
                   occurredOn: '2023-06-18'
-                  createdOn: '2023-05-18'
-                  postedOn: '2023-05-18'
                   amount: '1276.21'
                   posted: true
                   balance: '8509.38'

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/assembly.json
@@ -6225,7 +6225,6 @@ docs: Real-time transcription
                       "speaker_labels": true,
                       "speakers_expected": 1,
                       "speech_threshold": 1.1,
-                      "speed_boost": true,
                       "status": "queued",
                       "summarization": true,
                       "summary": "summary",
@@ -6449,7 +6448,6 @@ docs: Real-time transcription
                       "speaker_labels": true,
                       "speakers_expected": 1,
                       "speech_threshold": 1.1,
-                      "speed_boost": true,
                       "status": "queued",
                       "summarization": true,
                       "summary": "summary",
@@ -6661,7 +6659,6 @@ docs: Real-time transcription
                       "speaker_labels": true,
                       "speakers_expected": 1,
                       "speech_threshold": 1.1,
-                      "speed_boost": true,
                       "status": "queued",
                       "summarization": true,
                       "summary": "summary",
@@ -7249,7 +7246,6 @@ service:
               webhook_status_code: 1
               webhook_auth: true
               webhook_auth_header_name: webhook_auth_header_name
-              speed_boost: true
               auto_highlights: true
               auto_highlights_result:
                 results:
@@ -7402,7 +7398,6 @@ service:
               webhook_status_code: 1
               webhook_auth: true
               webhook_auth_header_name: webhook_auth_header_name
-              speed_boost: true
               auto_highlights: true
               auto_highlights_result:
                 results:
@@ -7553,7 +7548,6 @@ service:
               webhook_status_code: 1
               webhook_auth: true
               webhook_auth_header_name: webhook_auth_header_name
-              speed_boost: true
               auto_highlights: true
               auto_highlights_result:
                 results:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/belvo.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/belvo.json
@@ -29454,11 +29454,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -29476,28 +29473,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -29615,7 +29604,6 @@ client.connect()
                         "collected_at": "2022-02-09T08:45:50Z",
                         "credit_limit": 15600,
                         "cutting_date": "2021-04-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
                         "minimum_payment": 690,
                         "next_payment_date": "2021-03-31",
@@ -29635,28 +29623,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -29774,11 +29754,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -29796,16 +29773,12 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "ER8072930097",
                         "contract_start_date": "2018-01-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
@@ -29813,12 +29786,8 @@ client.connect()
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "SFH",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 41,
                         "number_of_installments_total": 50,
                         "outstanding_balance": 164000,
@@ -29936,11 +29905,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -29994,28 +29960,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -30133,11 +30091,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -30155,28 +30110,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -30365,7 +30312,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -30388,7 +30334,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -30745,11 +30690,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -30767,28 +30709,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -30926,7 +30860,6 @@ client.connect()
                           "collected_at": "2022-02-09T08:45:50Z",
                           "credit_limit": 15600,
                           "cutting_date": "2021-04-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
                           "minimum_payment": 690,
                           "next_payment_date": "2021-03-31",
@@ -30946,28 +30879,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -31105,11 +31030,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -31127,16 +31049,12 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "ER8072930097",
                           "contract_start_date": "2018-01-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
@@ -31144,12 +31062,8 @@ client.connect()
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "SFH",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 41,
                           "number_of_installments_total": 50,
                           "outstanding_balance": 164000,
@@ -31287,11 +31201,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -31345,28 +31256,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -31504,11 +31407,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -31526,28 +31426,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -31730,11 +31622,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -31752,28 +31641,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -31902,7 +31783,6 @@ client.connect()
                           "collected_at": "2022-02-09T08:45:50Z",
                           "credit_limit": 15600,
                           "cutting_date": "2021-04-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
                           "minimum_payment": 690,
                           "next_payment_date": "2021-03-31",
@@ -31922,28 +31802,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -32072,11 +31944,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -32094,16 +31963,12 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "ER8072930097",
                           "contract_start_date": "2018-01-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
@@ -32111,12 +31976,8 @@ client.connect()
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "SFH",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 41,
                           "number_of_installments_total": 50,
                           "outstanding_balance": 164000,
@@ -32245,11 +32106,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -32303,28 +32161,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -32453,11 +32303,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -32475,28 +32322,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -32865,8 +32704,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
           code-samples:
             - language: cURL
               code: |
@@ -33020,9 +32857,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33043,14 +32877,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -33162,7 +32988,6 @@ service:
                   minimum_payment: 690
                   no_interest_payment: 11550.15
                   interest_rate: 4
-                  end_date: end_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33183,14 +33008,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -33302,9 +33119,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33326,14 +33140,6 @@ service:
                   contract_start_date: '2018-01-01'
                   contract_end_date: '2027-10-01'
                   contract_number: ER8072930097
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -33445,9 +33251,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33468,14 +33271,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2022-02-09T08:45:50Z'
                     name: CICLO DE VIDA 2040 I
@@ -33608,9 +33403,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33631,14 +33423,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -33805,9 +33589,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33828,14 +33609,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -33956,7 +33729,6 @@ service:
                   minimum_payment: 690
                   no_interest_payment: 11550.15
                   interest_rate: 4
-                  end_date: end_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -33977,14 +33749,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -34105,9 +33869,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -34129,14 +33890,6 @@ service:
                   contract_start_date: '2018-01-01'
                   contract_end_date: '2027-10-01'
                   contract_number: ER8072930097
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -34257,9 +34010,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -34280,14 +34030,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2022-02-09T08:45:50Z'
                     name: CICLO DE VIDA 2040 I
@@ -34429,9 +34171,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -34452,14 +34191,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -34631,9 +34362,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -34654,14 +34382,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -34764,7 +34484,6 @@ service:
                 minimum_payment: 690
                 no_interest_payment: 11550.15
                 interest_rate: 4
-                end_date: end_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -34785,14 +34504,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -34895,9 +34606,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -34919,14 +34627,6 @@ service:
                 contract_start_date: '2018-01-01'
                 contract_end_date: '2027-10-01'
                 contract_number: ER8072930097
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -35029,9 +34729,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -35052,14 +34749,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               funds_data:
                 - collected_at: '2022-02-09T08:45:50Z'
                   name: CICLO DE VIDA 2040 I
@@ -35183,9 +34872,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -35206,14 +34892,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -35813,11 +35491,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -35832,7 +35507,6 @@ client.connect()
                           "name": "erebor_br_retail",
                           "type": "bank",
                         },
-                        "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                         "last_accessed_at": "2021-03-09T10:28:40Z",
                         "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                         "loan_data": {
@@ -35841,28 +35515,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -35883,8 +35549,6 @@ client.connect()
                         "type": "Cuentas de efectivo",
                       },
                       "balance": 4.25,
-                      "collected_at": "2022-04-06T23:30:51Z",
-                      "current_balance": 4.25,
                       "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                       "value_date": "2022-04-04",
                     },
@@ -36058,7 +35722,6 @@ client.connect()
                               "name": "erebor_br_retail",
                               "type": "bank",
                             },
-                            "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                             "last_accessed_at": "2021-03-09T10:28:40Z",
                             "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                             "loan_data": {
@@ -36075,8 +35738,6 @@ client.connect()
                             "type": "Cuentas de efectivo",
                           },
                           "balance": 4.25,
-                          "collected_at": "2022-04-06T23:30:51Z",
-                          "current_balance": 4.25,
                           "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                           "value_date": "2022-04-04",
                         },
@@ -36387,7 +36048,6 @@ client.connect()
                             "name": "erebor_br_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                           "loan_data": {
@@ -36410,8 +36070,6 @@ client.connect()
                           "type": "Cuentas de efectivo",
                         },
                         "balance": 4.25,
-                        "collected_at": "2022-04-06T23:30:51Z",
-                        "current_balance": 4.25,
                         "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                         "value_date": "2022-04-04",
                       },
@@ -36592,7 +36250,6 @@ client.connect()
                             "name": "erebor_br_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                           "loan_data": {
@@ -36615,8 +36272,6 @@ client.connect()
                           "type": "Cuentas de efectivo",
                         },
                         "balance": 4.25,
-                        "collected_at": "2022-04-06T23:30:51Z",
-                        "current_balance": 4.25,
                         "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                         "value_date": "2022-04-04",
                       },
@@ -36945,11 +36600,8 @@ service:
                       outstanding_balance: 182000
                       monthly_payment: 1000
                       contract_end_date: '2027-10-01'
-                    internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
                   value_date: '2022-04-04'
                   balance: 4.25
-                  current_balance: 4.25
-                  collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -37154,11 +36806,8 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
                 value_date: '2022-04-04'
                 balance: 4.25
-                current_balance: 4.25
-                collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -37330,11 +36979,8 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
                 value_date: '2022-04-04'
                 balance: 4.25
-                current_balance: 4.25
-                collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -37488,9 +37134,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -37511,14 +37154,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2020-04-23T21:32:55Z'
                 receivables_data:
@@ -37526,11 +37161,8 @@ service:
                   available: 800.37
                   anticipated: 1393.46
                   collected_at: '2022-02-09T08:45:50Z'
-                internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
               value_date: '2022-04-04'
               balance: 4.25
-              current_balance: 4.25
-              collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -45509,7 +45141,6 @@ client.connect()
                       "invoice_type": "Ingreso",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                       "payment_method": "PUE",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "04",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -45549,11 +45180,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "ACNE SA DE CV",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "Roberto Martinez Diaz",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -45695,7 +45324,6 @@ client.connect()
                       "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                       "invoice_type": "Pago",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "99",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -45735,11 +45363,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "ACNE SA DE CV",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "Roberto Martinez Diaz",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -45882,7 +45508,6 @@ client.connect()
                       "invoice_type": "Nómina",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                       "payment_method": "PUE",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "99",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -45922,11 +45547,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "Roberto Martinez Diaz",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "ACNE SA DE CV",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -46069,7 +45692,6 @@ client.connect()
                       "invoice_type": "Egreso",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                       "payment_method": "PUE",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "04",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -46109,11 +45731,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "ACNE SA DE CV",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "Roberto Martinez Diaz",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -46255,7 +45875,6 @@ client.connect()
                       "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                       "invoice_type": "Traslado",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "99",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -46295,11 +45914,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "CARGOS S.A. DE C.V.",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "ACNE SA DE CV",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -46512,7 +46129,6 @@ client.connect()
                           "invoice_type": "Ingreso",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                           "payment_method": "PUE",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "04",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -46550,11 +46166,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "ACNE SA DE CV",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "Roberto Martinez Diaz",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -46728,7 +46342,6 @@ client.connect()
                           "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                           "invoice_type": "Pago",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "99",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -46767,11 +46380,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "ACNE SA DE CV",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "Roberto Martinez Diaz",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -46946,7 +46557,6 @@ client.connect()
                           "invoice_type": "Nómina",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                           "payment_method": "PUE",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "99",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -46985,11 +46595,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "Roberto Martinez Diaz",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "ACNE SA DE CV",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -47164,7 +46772,6 @@ client.connect()
                           "invoice_type": "Egreso",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                           "payment_method": "PUE",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "04",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -47202,11 +46809,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "ACNE SA DE CV",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "Roberto Martinez Diaz",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -47380,7 +46985,6 @@ client.connect()
                           "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                           "invoice_type": "Traslado",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "99",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -47418,11 +47022,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "CARGOS S.A. DE C.V.",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "ACNE SA DE CV",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -47749,7 +47351,6 @@ client.connect()
                         "invoice_type": "Egreso",
                         "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -47788,11 +47389,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "01165",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "BBB222222BB22",
                         "receiver_name": "BELVO CORP",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "AAA111111AA11",
                         "sender_name": "ACME CORP",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -47995,7 +47594,6 @@ client.connect()
                         "invoice_type": "Ingreso",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "04",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -48034,11 +47632,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "ACNE SA DE CV",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "Roberto Martinez Diaz",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -48199,7 +47795,6 @@ client.connect()
                         "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                         "invoice_type": "Pago",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -48239,11 +47834,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "ACNE SA DE CV",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "Roberto Martinez Diaz",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -48405,7 +47998,6 @@ client.connect()
                         "invoice_type": "Nómina",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -48444,11 +48036,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "Roberto Martinez Diaz",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "ACNE SA DE CV",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -48610,7 +48200,6 @@ client.connect()
                         "invoice_type": "Egreso",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "04",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -48649,11 +48238,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "ACNE SA DE CV",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "Roberto Martinez Diaz",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -48814,7 +48401,6 @@ client.connect()
                         "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                         "invoice_type": "Traslado",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -48853,11 +48439,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "CARGOS S.A. DE C.V.",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "ACNE SA DE CV",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -49255,7 +48839,6 @@ service:
                   payment_type: '04'
                   payment_type_description: payment_type_description
                   payment_method: PUE
-                  payment_method_description: payment_method_description
                   usage: G03
                   version: '3.3'
                   place_of_issue: '11000'
@@ -49313,8 +48896,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -49442,7 +49023,6 @@ service:
                   certification_authority: FGV330542BG6
                   payment_type: '99'
                   payment_type_description: payment_type_description
-                  payment_method_description: payment_method_description
                   usage: P01
                   version: '3.3'
                   place_of_issue: '11000'
@@ -49501,8 +49081,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -49631,7 +49209,6 @@ service:
                   payment_type: '99'
                   payment_type_description: payment_type_description
                   payment_method: PUE
-                  payment_method_description: payment_method_description
                   usage: P01
                   version: '3.3'
                   place_of_issue: '11000'
@@ -49690,8 +49267,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -49820,7 +49395,6 @@ service:
                   payment_type: '04'
                   payment_type_description: payment_type_description
                   payment_method: PUE
-                  payment_method_description: payment_method_description
                   usage: G03
                   version: '3.3'
                   place_of_issue: '11000'
@@ -49878,8 +49452,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -50007,7 +49579,6 @@ service:
                   certification_authority: FGV330542BG6
                   payment_type: '99'
                   payment_type_description: payment_type_description
-                  payment_method_description: payment_method_description
                   usage: G03
                   version: '3.3'
                   place_of_issue: '11000'
@@ -50065,8 +49636,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -50256,7 +49825,6 @@ service:
                 payment_type: '04'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: G03
                 version: '3.3'
                 place_of_issue: '11000'
@@ -50315,8 +49883,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -50428,7 +49994,6 @@ service:
                 certification_authority: FGV330542BG6
                 payment_type: '99'
                 payment_type_description: payment_type_description
-                payment_method_description: payment_method_description
                 usage: P01
                 version: '3.3'
                 place_of_issue: '11000'
@@ -50488,8 +50053,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -50602,7 +50165,6 @@ service:
                 payment_type: '99'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: P01
                 version: '3.3'
                 place_of_issue: '11000'
@@ -50661,8 +50223,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -50775,7 +50335,6 @@ service:
                 payment_type: '04'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: G03
                 version: '3.3'
                 place_of_issue: '11000'
@@ -50834,8 +50393,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -50947,7 +50504,6 @@ service:
                 certification_authority: FGV330542BG6
                 payment_type: '99'
                 payment_type_description: payment_type_description
-                payment_method_description: payment_method_description
                 usage: G03
                 version: '3.3'
                 place_of_issue: '11000'
@@ -51006,8 +50562,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -51158,7 +50712,6 @@ service:
                 payment_type: '99'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: P01
                 version: '3.3'
                 place_of_issue: '01165'
@@ -51216,8 +50769,6 @@ service:
                     this invoice might be missing data. Please check
                     https://tinyurl.com/yydzhy5d for more information on this
                     error.
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -51363,7 +50914,6 @@ service:
               payment_type: '04'
               payment_type_description: payment_type_description
               payment_method: PUE
-              payment_method_description: payment_method_description
               usage: G03
               version: '3.3'
               place_of_issue: '11000'
@@ -51424,8 +50974,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -51519,7 +51067,6 @@ service:
               certification_authority: FGV330542BG6
               payment_type: '99'
               payment_type_description: payment_type_description
-              payment_method_description: payment_method_description
               usage: P01
               version: '3.3'
               place_of_issue: '11000'
@@ -51580,8 +51127,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -51676,7 +51221,6 @@ service:
               payment_type: '99'
               payment_type_description: payment_type_description
               payment_method: PUE
-              payment_method_description: payment_method_description
               usage: P01
               version: '3.3'
               place_of_issue: '11000'
@@ -51737,8 +51281,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -51833,7 +51375,6 @@ service:
               payment_type: '04'
               payment_type_description: payment_type_description
               payment_method: PUE
-              payment_method_description: payment_method_description
               usage: G03
               version: '3.3'
               place_of_issue: '11000'
@@ -51894,8 +51435,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -51989,7 +51528,6 @@ service:
               certification_authority: FGV330542BG6
               payment_type: '99'
               payment_type_description: payment_type_description
-              payment_method_description: payment_method_description
               usage: G03
               version: '3.3'
               place_of_issue: '11000'
@@ -52050,8 +51588,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -56973,47 +56509,6 @@ A payment intent captures all payment information (such as the amount to be char
                         "open_finance",
                       ],
                       "amount": "350000.00",
-                      "charges": [
-                        {
-                          "amount": "100.12",
-                          "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                          "created_at": "2022-02-09T08:45:50Z",
-                          "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "currency": "BRL",
-                          "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                          "description": "Training shoes",
-                          "failure_code": "failure_code",
-                          "failure_message": "failure_message",
-                          "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "metadata": {
-                            "internal_reference_id": "GGq73487w2",
-                          },
-                          "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                          "payment_method_details": {},
-                          "payment_method_information": {},
-                          "payment_method_type": "open_finance",
-                          "provider": "belvo",
-                          "status": "PENDING",
-                          "transactions": [
-                            {
-                              "amount": "1020.00",
-                              "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "currency": "BRL",
-                              "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                              "description": "Training shoes",
-                              "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                              "payer": {
-                                "key": "value",
-                              },
-                              "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                              "transaction_type": "INFLOW",
-                            },
-                          ],
-                          "updated_at": "2022-02-09T08:45:50Z",
-                        },
-                      ],
                       "created_at": "2022-02-09T08:45:50Z",
                       "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                       "currency": "BRL",
@@ -57161,47 +56656,6 @@ A payment intent captures all payment information (such as the amount to be char
                         "open_finance",
                       ],
                       "amount": "350000.00",
-                      "charges": [
-                        {
-                          "amount": "100.12",
-                          "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                          "created_at": "2022-02-09T08:45:50Z",
-                          "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "currency": "BRL",
-                          "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                          "description": "Training shoes",
-                          "failure_code": "failure_code",
-                          "failure_message": "failure_message",
-                          "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "metadata": {
-                            "internal_reference_id": "GGq73487w2",
-                          },
-                          "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                          "payment_method_details": {},
-                          "payment_method_information": {},
-                          "payment_method_type": "open_finance",
-                          "provider": "belvo",
-                          "status": "PENDING",
-                          "transactions": [
-                            {
-                              "amount": "1020.00",
-                              "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "currency": "BRL",
-                              "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                              "description": "Training shoes",
-                              "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                              "payer": {
-                                "key": "value",
-                              },
-                              "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                              "transaction_type": "INFLOW",
-                            },
-                          ],
-                          "updated_at": "2022-02-09T08:45:50Z",
-                        },
-                      ],
                       "created_at": "2022-02-09T08:45:50Z",
                       "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                       "currency": "BRL",
@@ -57329,43 +56783,6 @@ A payment intent captures all payment information (such as the amount to be char
                             "open_finance",
                           ],
                           "amount": "350000.00",
-                          "charges": [
-                            {
-                              "amount": "100.12",
-                              "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                              "description": "Training shoes",
-                              "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "metadata": {
-                                "internal_reference_id": "GGq73487w2",
-                              },
-                              "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                              "payment_method_details": {},
-                              "payment_method_information": {},
-                              "provider": "belvo",
-                              "status": "PENDING",
-                              "transactions": [
-                                {
-                                  "amount": "1020.00",
-                                  "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                                  "created_at": "2022-02-09T08:45:50Z",
-                                  "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                                  "currency": "BRL",
-                                  "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                                  "description": "Training shoes",
-                                  "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                                  "payer": {
-                                    "key": "value",
-                                  },
-                                  "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                                  "transaction_type": "INFLOW",
-                                },
-                              ],
-                              "updated_at": "2022-02-09T08:45:50Z",
-                            },
-                          ],
                           "created_at": "2022-02-09T08:45:50Z",
                           "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                           "currency": "BRL",
@@ -57524,47 +56941,6 @@ During the payment intent flow, you need to fill in the payment intent with requ
                         "open_finance",
                       ],
                       "amount": "350000.00",
-                      "charges": [
-                        {
-                          "amount": "100.12",
-                          "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                          "created_at": "2022-02-09T08:45:50Z",
-                          "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "currency": "BRL",
-                          "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                          "description": "Training shoes",
-                          "failure_code": "failure_code",
-                          "failure_message": "failure_message",
-                          "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "metadata": {
-                            "internal_reference_id": "GGq73487w2",
-                          },
-                          "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                          "payment_method_details": {},
-                          "payment_method_information": {},
-                          "payment_method_type": "open_finance",
-                          "provider": "belvo",
-                          "status": "PENDING",
-                          "transactions": [
-                            {
-                              "amount": "1020.00",
-                              "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "currency": "BRL",
-                              "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                              "description": "Training shoes",
-                              "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                              "payer": {
-                                "key": "value",
-                              },
-                              "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                              "transaction_type": "INFLOW",
-                            },
-                          ],
-                          "updated_at": "2022-02-09T08:45:50Z",
-                        },
-                      ],
                       "created_at": "2022-02-09T08:45:50Z",
                       "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                       "currency": "BRL",
@@ -57849,35 +57225,6 @@ service:
                       callback_url: https://www.acmecorp.com/checkout/3487321
                       belvo_flow: true
                   payment_method_information: {}
-                  charges:
-                    - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                      status: PENDING
-                      amount: '100.12'
-                      description: Training shoes
-                      metadata:
-                        internal_reference_id: GGq73487w2
-                      beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                      provider: belvo
-                      payment_method_details: {}
-                      payment_method_information: {}
-                      payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                      transactions:
-                        - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                          created_at: '2022-02-09T08:45:50Z'
-                          created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                          amount: '1020.00'
-                          currency: BRL
-                          description: Training shoes
-                          transaction_type: INFLOW
-                          beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                          payer:
-                            key: value
-                          payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                          customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                      updated_at: '2022-02-09T08:45:50Z'
                   provider: belvo
                   selected_payment_method_type: open_finance
                   status: REQUIRES_PAYMENT_METHOD
@@ -58011,39 +57358,6 @@ service:
                   redirect_url: https://wakandanational.com/
                   bank_payment_id: '456213985641233659874512459842'
                   end_to_end_id: '2007300520'
-              charges:
-                - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  created_at: '2022-02-09T08:45:50Z'
-                  created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                  failure_code: failure_code
-                  failure_message: failure_message
-                  status: PENDING
-                  amount: '100.12'
-                  currency: BRL
-                  description: Training shoes
-                  metadata:
-                    internal_reference_id: GGq73487w2
-                  beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                  provider: belvo
-                  payment_method_type: open_finance
-                  payment_method_details: {}
-                  payment_method_information: {}
-                  payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                  transactions:
-                    - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      amount: '1020.00'
-                      currency: BRL
-                      description: Training shoes
-                      transaction_type: INFLOW
-                      beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                      payer:
-                        key: value
-                      payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                      customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                  updated_at: '2022-02-09T08:45:50Z'
               provider: belvo
               selected_payment_method_type: open_finance
               status: REQUIRES_PAYMENT_METHOD
@@ -58124,39 +57438,6 @@ service:
                   redirect_url: https://wakandanational.com/
                   bank_payment_id: '456213985641233659874512459842'
                   end_to_end_id: '2007300520'
-              charges:
-                - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  created_at: '2022-02-09T08:45:50Z'
-                  created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                  failure_code: failure_code
-                  failure_message: failure_message
-                  status: PENDING
-                  amount: '100.12'
-                  currency: BRL
-                  description: Training shoes
-                  metadata:
-                    internal_reference_id: GGq73487w2
-                  beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                  provider: belvo
-                  payment_method_type: open_finance
-                  payment_method_details: {}
-                  payment_method_information: {}
-                  payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                  transactions:
-                    - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      amount: '1020.00'
-                      currency: BRL
-                      description: Training shoes
-                      transaction_type: INFLOW
-                      beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                      payer:
-                        key: value
-                      payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                      customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                  updated_at: '2022-02-09T08:45:50Z'
               provider: belvo
               selected_payment_method_type: open_finance
               status: REQUIRES_PAYMENT_METHOD
@@ -58267,39 +57548,6 @@ service:
                   redirect_url: https://wakandanational.com/
                   bank_payment_id: '456213985641233659874512459842'
                   end_to_end_id: '2007300520'
-              charges:
-                - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  created_at: '2022-02-09T08:45:50Z'
-                  created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                  failure_code: failure_code
-                  failure_message: failure_message
-                  status: PENDING
-                  amount: '100.12'
-                  currency: BRL
-                  description: Training shoes
-                  metadata:
-                    internal_reference_id: GGq73487w2
-                  beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                  provider: belvo
-                  payment_method_type: open_finance
-                  payment_method_details: {}
-                  payment_method_information: {}
-                  payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                  transactions:
-                    - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      amount: '1020.00'
-                      currency: BRL
-                      description: Training shoes
-                      transaction_type: INFLOW
-                      beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                      payer:
-                        key: value
-                      payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                      customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                  updated_at: '2022-02-09T08:45:50Z'
               provider: belvo
               selected_payment_method_type: open_finance
               status: REQUIRES_PAYMENT_METHOD
@@ -58394,43 +57642,6 @@ types:
                           "open_finance",
                         ],
                         "amount": "1234.12",
-                        "charges": [
-                          {
-                            "amount": "100.12",
-                            "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                            "created_at": "2022-02-09T08:45:50Z",
-                            "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                            "description": "Training shoes",
-                            "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "metadata": {
-                              "internal_reference_id": "GGq73487w2",
-                            },
-                            "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                            "payment_method_details": {},
-                            "payment_method_information": {},
-                            "provider": "belvo",
-                            "status": "PENDING",
-                            "transactions": [
-                              {
-                                "amount": "1020.00",
-                                "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                                "created_at": "2022-02-09T08:45:50Z",
-                                "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                                "currency": "BRL",
-                                "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                                "description": "Training shoes",
-                                "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                                "payer": {
-                                  "key": "value",
-                                },
-                                "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                                "transaction_type": "INFLOW",
-                              },
-                            ],
-                            "updated_at": "2022-02-09T08:45:50Z",
-                          },
-                        ],
                         "created_at": "2022-02-09T08:45:50Z",
                         "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                         "currency": "BRL",
@@ -58516,43 +57727,6 @@ types:
                           "open_finance",
                         ],
                         "amount": "1234.12",
-                        "charges": [
-                          {
-                            "amount": "100.12",
-                            "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                            "created_at": "2022-02-09T08:45:50Z",
-                            "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                            "description": "Training shoes",
-                            "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "metadata": {
-                              "internal_reference_id": "GGq73487w2",
-                            },
-                            "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                            "payment_method_details": {},
-                            "payment_method_information": {},
-                            "provider": "belvo",
-                            "status": "PENDING",
-                            "transactions": [
-                              {
-                                "amount": "1020.00",
-                                "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                                "created_at": "2022-02-09T08:45:50Z",
-                                "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                                "currency": "BRL",
-                                "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                                "description": "Training shoes",
-                                "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                                "payer": {
-                                  "key": "value",
-                                },
-                                "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                                "transaction_type": "INFLOW",
-                              },
-                            ],
-                            "updated_at": "2022-02-09T08:45:50Z",
-                          },
-                        ],
                         "created_at": "2022-02-09T08:45:50Z",
                         "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                         "currency": "BRL",
@@ -59047,35 +58221,6 @@ service:
                     payer_institution: 600f1b4a-1ef9-4f89-b341-1a35f0c32cc0
                     callback_url: https://www.acmecorp.com/checkout/3487321
                 payment_method_information: {}
-                charges:
-                  - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    created_at: '2022-02-09T08:45:50Z'
-                    created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                    status: PENDING
-                    amount: '100.12'
-                    description: Training shoes
-                    metadata:
-                      internal_reference_id: GGq73487w2
-                    beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                    provider: belvo
-                    payment_method_details: {}
-                    payment_method_information: {}
-                    payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                    transactions:
-                      - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                        created_at: '2022-02-09T08:45:50Z'
-                        created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                        amount: '1020.00'
-                        currency: BRL
-                        description: Training shoes
-                        transaction_type: INFLOW
-                        beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                        payer:
-                          key: value
-                        payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                        customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                    updated_at: '2022-02-09T08:45:50Z'
                 provider: belvo
                 selected_payment_method_type: open_finance
                 status: REQUIRES_PAYMENT_METHOD
@@ -59150,35 +58295,6 @@ service:
                     payer_institution: 600f1b4a-1ef9-4f89-b341-1a35f0c32cc0
                     callback_url: https://www.acmecorp.com/checkout/3487321
                 payment_method_information: {}
-                charges:
-                  - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    created_at: '2022-02-09T08:45:50Z'
-                    created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                    status: PENDING
-                    amount: '100.12'
-                    description: Training shoes
-                    metadata:
-                      internal_reference_id: GGq73487w2
-                    beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                    provider: belvo
-                    payment_method_details: {}
-                    payment_method_information: {}
-                    payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                    transactions:
-                      - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                        created_at: '2022-02-09T08:45:50Z'
-                        created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                        amount: '1020.00'
-                        currency: BRL
-                        description: Training shoes
-                        transaction_type: INFLOW
-                        beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                        payer:
-                          key: value
-                        payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                        customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                    updated_at: '2022-02-09T08:45:50Z'
                 provider: belvo
                 selected_payment_method_type: open_finance
                 status: REQUIRES_PAYMENT_METHOD
@@ -61095,7 +60211,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -61118,7 +60233,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -61520,7 +60634,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -61543,7 +60656,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -61708,7 +60820,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -61731,7 +60842,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -62198,8 +61308,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
                 name: Netflix
                 transactions:
                   - amount: 2145.45
@@ -62361,8 +61469,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
                 name: Netflix
                 transactions:
                   - amount: 2145.45
@@ -62528,8 +61634,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
                 name: Netflix
                 transactions:
                   - amount: 2145.45
@@ -80439,7 +79543,6 @@ client.connect()
                           "current": 0,
                         },
                         "balance_type": "ASSET",
-                        "bank_product_id": "46",
                         "category": "CHECKING_ACCOUNT",
                         "collected_at": "2022-02-09T08:45:50Z",
                         "created_at": "2022-02-09T08:46:20Z",
@@ -80447,11 +79550,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -80466,7 +79566,6 @@ client.connect()
                           "name": "erebor_mx_retail",
                           "type": "bank",
                         },
-                        "internal_identification": "996685090015",
                         "last_accessed_at": "2021-03-09T10:28:40Z",
                         "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                         "loan_data": {
@@ -80475,28 +79574,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -80644,11 +79735,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -80663,7 +79751,6 @@ client.connect()
                           "name": "erebor_mx_retail",
                           "type": "bank",
                         },
-                        "internal_identification": "996685090015",
                         "last_accessed_at": "2021-03-09T10:28:40Z",
                         "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                         "loan_data": {
@@ -80672,28 +79759,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -80860,28 +79939,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -81121,7 +80192,6 @@ client.connect()
                               "current": 0,
                             },
                             "balance_type": "ASSET",
-                            "bank_product_id": "46",
                             "category": "CHECKING_ACCOUNT",
                             "collected_at": "2022-02-09T08:45:50Z",
                             "created_at": "2022-02-09T08:46:20Z",
@@ -81131,7 +80201,6 @@ client.connect()
                               "name": "erebor_mx_retail",
                               "type": "bank",
                             },
-                            "internal_identification": "996685090015",
                             "last_accessed_at": "2021-03-09T10:28:40Z",
                             "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                             "loan_data": {
@@ -81331,7 +80400,6 @@ client.connect()
                               "name": "erebor_mx_retail",
                               "type": "bank",
                             },
-                            "internal_identification": "996685090015",
                             "last_accessed_at": "2021-03-09T10:28:40Z",
                             "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                             "loan_data": {
@@ -81986,7 +81054,6 @@ client.connect()
                             "current": 0,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "46",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2022-02-09T08:45:50Z",
                           "created_at": "2022-02-09T08:46:20Z",
@@ -82010,7 +81077,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -82196,7 +81262,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -82587,7 +81652,6 @@ client.connect()
                             "current": 0,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "46",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2022-02-09T08:45:50Z",
                           "created_at": "2022-02-09T08:46:20Z",
@@ -82611,7 +81675,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -82802,7 +81865,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -83650,8 +82712,6 @@ service:
                       outstanding_balance: 182000
                       monthly_payment: 1000
                       contract_end_date: '2027-10-01'
-                    bank_product_id: '46'
-                    internal_identification: '996685090015'
                   collected_at: '2022-07-20T22:09:33Z'
                   created_at: '2022-07-20T22:09:35Z'
                   value_date: '2022-07-11'
@@ -83829,7 +82889,6 @@ service:
                       outstanding_balance: 182000
                       monthly_payment: 1000
                       contract_end_date: '2027-10-01'
-                    internal_identification: '996685090015'
                   collected_at: '2022-07-20T22:09:33Z'
                   created_at: '2022-07-20T22:09:35Z'
                   value_date: '2022-07-11'
@@ -84206,8 +83265,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: '46'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -84368,7 +83425,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -84876,8 +83932,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: '46'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -85033,7 +84087,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -85365,9 +84418,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -85388,14 +84438,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2020-04-23T21:32:55Z'
                 receivables_data:
@@ -85403,8 +84445,6 @@ service:
                   available: 800.37
                   anticipated: 1393.46
                   collected_at: '2022-02-09T08:45:50Z'
-                bank_product_id: '46'
-                internal_identification: '996685090015'
               collected_at: '2022-07-20T22:09:33Z'
               created_at: '2022-07-20T22:09:35Z'
               value_date: '2022-07-11'
@@ -85529,9 +84569,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -85552,14 +84589,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2020-04-23T21:32:55Z'
                 receivables_data:
@@ -85567,7 +84596,6 @@ service:
                   available: 800.37
                   anticipated: 1393.46
                   collected_at: '2022-02-09T08:45:50Z'
-                internal_identification: '996685090015'
               collected_at: '2022-07-20T22:09:33Z'
               created_at: '2022-07-20T22:09:35Z'
               value_date: '2022-07-11'
@@ -85712,14 +84740,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/deepgram.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/deepgram.json
@@ -14598,7 +14598,6 @@ channel:
                           "model_uuid": "80ab3179-d113-4254-bd6b-4a2f96498695",
                           "output_tokens": 7,
                         },
-                        "transaction_key": "transaction_key",
                       },
                       "results": {
                         "channels": [
@@ -15563,7 +15562,6 @@ service:
           response:
             body:
               metadata:
-                transaction_key: transaction_key
                 request_id: a847f427-4ad5-4d67-9b95-db801e58251c
                 sha256: >-
                   154e291ecfa8be6ab8343560bcc109008fa7853eb5372533e8efdefc9b504c33

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/flexport.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/flexport.json
@@ -18119,7 +18119,6 @@ docs: Endpoints relating to Contact objects
                                 "product": {
                                   "_object": "/product",
                                   "client_verified": true,
-                                  "country_of_origin": "China",
                                   "description": "The best 12V AC Adapter on the market",
                                   "id": 84291,
                                   "name": "AC Adapter 12V",
@@ -18262,7 +18261,6 @@ docs: Endpoints relating to Contact objects
                             "product": {
                               "_object": "/product",
                               "client_verified": true,
-                              "country_of_origin": "China",
                               "description": "The best 12V AC Adapter on the market",
                               "id": 84291,
                               "name": "AC Adapter 12V",
@@ -18516,7 +18514,6 @@ service:
                           sku: WDVCDFD-RM00472
                           description: The best 12V AC Adapter on the market
                           product_category: Cosmetics
-                          country_of_origin: China
                           client_verified: true
     show:
       path: /ocean/shipment_containers/{id}
@@ -18599,7 +18596,6 @@ service:
                       sku: WDVCDFD-RM00472
                       description: The best 12V AC Adapter on the market
                       product_category: Cosmetics
-                      country_of_origin: China
                       client_verified: true
   source:
     openapi: ../openapi.yml
@@ -22861,15 +22857,7 @@ docs: Endpoints relating to Ports objects
                           },
                         ],
                         "client_verified": true,
-                        "country_of_origin": "China",
                         "description": "The best 12V AC Adapter on the market",
-                        "hs_codes": [
-                          {
-                            "_object": "/hs_code",
-                            "code": "0301:00",
-                            "country_code": "US",
-                          },
-                        ],
                         "id": 84291,
                         "name": "AC Adapter 12V",
                         "product_category": "Cosmetics",
@@ -22977,15 +22965,7 @@ docs: Endpoints relating to Ports objects
                               },
                             ],
                             "client_verified": true,
-                            "country_of_origin": "China",
                             "description": "The best 12V AC Adapter on the market",
-                            "hs_codes": [
-                              {
-                                "_object": "/hs_code",
-                                "code": "0301:00",
-                                "country_code": "US",
-                              },
-                            ],
                             "id": 84291,
                             "name": "AC Adapter 12V",
                             "product_category": "Cosmetics",
@@ -23066,15 +23046,7 @@ docs: Endpoints relating to Ports objects
                           },
                         ],
                         "client_verified": true,
-                        "country_of_origin": "China",
                         "description": "The best 12V AC Adapter on the market",
-                        "hs_codes": [
-                          {
-                            "_object": "/hs_code",
-                            "code": "0301:00",
-                            "country_code": "US",
-                          },
-                        ],
                         "id": 84291,
                         "name": "AC Adapter 12V",
                         "product_category": "Cosmetics",
@@ -23141,15 +23113,7 @@ docs: Endpoints relating to Ports objects
                           },
                         ],
                         "client_verified": true,
-                        "country_of_origin": "China",
                         "description": "The best 12V AC Adapter on the market",
-                        "hs_codes": [
-                          {
-                            "_object": "/hs_code",
-                            "code": "0301:00",
-                            "country_code": "US",
-                          },
-                        ],
                         "id": 84291,
                         "name": "AC Adapter 12V",
                         "product_category": "Cosmetics",
@@ -23408,16 +23372,11 @@ service:
                     description: The best 12V AC Adapter on the market
                     archived_at: '2019-01-18T22:08:38Z'
                     product_category: Cosmetics
-                    country_of_origin: China
                     client_verified: true
                     product_properties:
                       - _object: /product/property
                         type: color
                         value: blue
-                    hs_codes:
-                      - _object: /hs_code
-                        code: '0301:00'
-                        country_code: US
                     classifications:
                       - _object: /product/classification
                         codes:
@@ -23497,16 +23456,11 @@ service:
                 description: The best 12V AC Adapter on the market
                 archived_at: '2019-01-18T22:08:38Z'
                 product_category: Cosmetics
-                country_of_origin: China
                 client_verified: true
                 product_properties:
                   - _object: /product/property
                     type: color
                     value: blue
-                hs_codes:
-                  - _object: /hs_code
-                    code: '0301:00'
-                    country_code: US
                 classifications:
                   - _object: /product/classification
                     codes:
@@ -23547,16 +23501,11 @@ service:
                 description: The best 12V AC Adapter on the market
                 archived_at: '2019-01-18T22:08:38Z'
                 product_category: Cosmetics
-                country_of_origin: China
                 client_verified: true
                 product_properties:
                   - _object: /product/property
                     type: color
                     value: blue
-                hs_codes:
-                  - _object: /hs_code
-                    code: '0301:00'
-                    country_code: US
                 classifications:
                   - _object: /product/classification
                     codes:
@@ -23637,16 +23586,11 @@ service:
                 description: The best 12V AC Adapter on the market
                 archived_at: '2019-01-18T22:08:38Z'
                 product_category: Cosmetics
-                country_of_origin: China
                 client_verified: true
                 product_properties:
                   - _object: /product/property
                     type: color
                     value: blue
-                hs_codes:
-                  - _object: /hs_code
-                    code: '0301:00'
-                    country_code: US
                 classifications:
                   - _object: /product/classification
                     codes:
@@ -26477,7 +26421,6 @@ docs: >-
                                 "product": {
                                   "_object": "/product",
                                   "client_verified": true,
-                                  "country_of_origin": "China",
                                   "description": "The best 12V AC Adapter on the market",
                                   "id": 84291,
                                   "name": "AC Adapter 12V",
@@ -26993,7 +26936,6 @@ docs: >-
                             "product": {
                               "_object": "/product",
                               "client_verified": true,
-                              "country_of_origin": "China",
                               "description": "The best 12V AC Adapter on the market",
                               "id": 84291,
                               "name": "AC Adapter 12V",
@@ -27309,7 +27251,6 @@ docs: >-
                             "product": {
                               "_object": "/product",
                               "client_verified": true,
-                              "country_of_origin": "China",
                               "description": "The best 12V AC Adapter on the market",
                               "id": 84291,
                               "name": "AC Adapter 12V",
@@ -28043,7 +27984,6 @@ service:
                           sku: WDVCDFD-RM00472
                           description: The best 12V AC Adapter on the market
                           product_category: Cosmetics
-                          country_of_origin: China
                           client_verified: true
                     legs:
                       _object: /api/refs/collection
@@ -28287,7 +28227,6 @@ service:
                       sku: WDVCDFD-RM00472
                       description: The best 12V AC Adapter on the market
                       product_category: Cosmetics
-                      country_of_origin: China
                       client_verified: true
                 legs:
                   _object: /api/refs/collection
@@ -28551,7 +28490,6 @@ service:
                       sku: WDVCDFD-RM00472
                       description: The best 12V AC Adapter on the market
                       product_category: Cosmetics
-                      country_of_origin: China
                       client_verified: true
                 legs:
                   _object: /api/refs/collection

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/merge.json
@@ -11884,7 +11884,6 @@ service:
                         "groups": [
                           "21a54124-397f-494d-985e-3c5b330b8a68",
                         ],
-                        "hire_date": "2020-10-10T00:00:00Z",
                         "home_location": "d2f972d0-2526-434b-9409-4c3b468e08f0",
                         "id": "0958cbc6-6040-430a-848e-aafacbadf4ae",
                         "last_name": "Hirsch",
@@ -12043,7 +12042,6 @@ service:
                           "groups": [
                             "21a54124-397f-494d-985e-3c5b330b8a68",
                           ],
-                          "hire_date": "2020-10-10T00:00:00Z",
                           "home_location": "d2f972d0-2526-434b-9409-4c3b468e08f0",
                           "id": "0958cbc6-6040-430a-848e-aafacbadf4ae",
                           "last_name": "Hirsch",
@@ -12299,7 +12297,6 @@ service:
                       "groups": [
                         "21a54124-397f-494d-985e-3c5b330b8a68",
                       ],
-                      "hire_date": "2020-10-10T00:00:00Z",
                       "home_location": "d2f972d0-2526-434b-9409-4c3b468e08f0",
                       "id": "0958cbc6-6040-430a-848e-aafacbadf4ae",
                       "last_name": "Hirsch",
@@ -15942,7 +15939,6 @@ service:
                   ethnicity: AMERICAN_INDIAN_OR_ALASKA_NATIVE
                   marital_status: SINGLE
                   date_of_birth: '1990-11-10T00:00:00Z'
-                  hire_date: '2020-10-10T00:00:00Z'
                   start_date: '2020-10-11T00:00:00Z'
                   remote_created_at: '2020-10-11T00:00:00Z'
                   employment_status: ACTIVE
@@ -16019,7 +16015,6 @@ service:
                 ethnicity: AMERICAN_INDIAN_OR_ALASKA_NATIVE
                 marital_status: SINGLE
                 date_of_birth: '1990-11-10T00:00:00Z'
-                hire_date: '2020-10-10T00:00:00Z'
                 start_date: '2020-10-11T00:00:00Z'
                 remote_created_at: '2020-10-11T00:00:00Z'
                 employment_status: ACTIVE
@@ -16126,7 +16121,6 @@ service:
               ethnicity: AMERICAN_INDIAN_OR_ALASKA_NATIVE
               marital_status: SINGLE
               date_of_birth: '1990-11-10T00:00:00Z'
-              hire_date: '2020-10-10T00:00:00Z'
               start_date: '2020-10-11T00:00:00Z'
               remote_created_at: '2020-10-11T00:00:00Z'
               employment_status: ACTIVE

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/permit.json
@@ -19493,16 +19493,6 @@ and will return the existing tenant object in the response body.",
                           "last_name": "Doe",
                           "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                           "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                          "roles": [
-                            {
-                              "role": "admin",
-                              "tenant": "stripe-inc",
-                            },
-                            {
-                              "role": "viewer",
-                              "tenant": "othercompany.com",
-                            },
-                          ],
                         },
                       ],
                       "page_count": 1,
@@ -19864,11 +19854,6 @@ service:
                       roles:
                         - viewer
                       status: pending
-                  roles:
-                    - role: admin
-                      tenant: stripe-inc
-                    - role: viewer
-                      tenant: othercompany.com
                   email: jane@coolcompany.com
                   first_name: Jane
                   last_name: Doe
@@ -21128,16 +21113,6 @@ and will return the existing user object in the response body.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -21255,16 +21230,6 @@ and will return the existing user object in the response body.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -21344,16 +21309,6 @@ and will return the existing user object in the response body.",
                           "last_name": "Doe",
                           "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                           "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                          "roles": [
-                            {
-                              "role": "admin",
-                              "tenant": "stripe-inc",
-                            },
-                            {
-                              "role": "viewer",
-                              "tenant": "othercompany.com",
-                            },
-                          ],
                         },
                       ],
                       "page_count": 1,
@@ -21483,16 +21438,6 @@ and will return the existing user object in the response body.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -21643,16 +21588,6 @@ Fields that will be provided will be completely overwritten.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -21796,11 +21731,6 @@ service:
                       roles:
                         - viewer
                       status: pending
-                  roles:
-                    - role: admin
-                      tenant: stripe-inc
-                    - role: viewer
-                      tenant: othercompany.com
                   email: jane@coolcompany.com
                   first_name: Jane
                   last_name: Doe
@@ -21877,11 +21807,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe
@@ -21942,11 +21867,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe
@@ -22021,11 +21941,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe
@@ -22143,11 +22058,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/squidex.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/squidex.json
@@ -20407,7 +20407,6 @@ service:
                   "response": {
                     "body": [
                       {
-                        "contentId": "contentId",
                         "error": {
                           "details": [
                             "details",
@@ -20596,8 +20595,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -20951,8 +20948,6 @@ service:
                           "metadataText": "metadataText",
                           "mimeType": "mimeType",
                           "parentId": "parentId",
-                          "pixelHeight": 1,
-                          "pixelWidth": 1,
                           "slug": "slug",
                           "tags": [
                             "tags",
@@ -21071,8 +21066,6 @@ service:
                           "metadataText": "metadataText",
                           "mimeType": "mimeType",
                           "parentId": "parentId",
-                          "pixelHeight": 1,
-                          "pixelWidth": 1,
                           "slug": "slug",
                           "tags": [
                             "tags",
@@ -21193,8 +21186,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -21373,8 +21364,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -21475,8 +21464,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -21588,8 +21575,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -21829,8 +21814,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -22465,8 +22448,6 @@ service:
                   _meta:
                     isDuplicate: isDuplicate
                   isImage: true
-                  pixelWidth: 1
-                  pixelHeight: 1
     postAsset:
       path: /api/apps/{app}/assets
       method: POST
@@ -22542,8 +22523,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     getAssetsPost:
       path: /api/apps/{app}/assets/query
       method: POST
@@ -22609,8 +22588,6 @@ service:
                   _meta:
                     isDuplicate: isDuplicate
                   isImage: true
-                  pixelWidth: 1
-                  pixelHeight: 1
     getAsset:
       path: /api/apps/{app}/assets/{id}
       method: GET
@@ -22668,8 +22645,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     postUpsertAsset:
       path: /api/apps/{app}/assets/{id}
       method: POST
@@ -22746,8 +22721,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     putAsset:
       path: /api/apps/{app}/assets/{id}
       method: PUT
@@ -22827,8 +22800,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     deleteAsset:
       path: /api/apps/{app}/assets/{id}
       method: DELETE
@@ -22914,7 +22885,6 @@ service:
                   statusCode: 1
                 jobIndex: 1
                 id: id
-                contentId: contentId
     putAssetContent:
       path: /api/apps/{app}/assets/{id}/content
       method: PUT
@@ -22982,8 +22952,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     putAssetParent:
       path: /api/apps/{app}/assets/{id}/parent
       method: PUT
@@ -23051,8 +23019,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
   source:
     openapi: ../openapi.json
 ",
@@ -24029,7 +23995,6 @@ service:
                   "response": {
                     "body": [
                       {
-                        "contentId": "contentId",
                         "error": {
                           "details": [
                             "details",
@@ -25571,7 +25536,6 @@ service:
                   "response": {
                     "body": [
                       {
-                        "contentId": "contentId",
                         "error": {
                           "details": [
                             "details",
@@ -27139,7 +27103,6 @@ service:
                   statusCode: 1
                 jobIndex: 1
                 id: id
-                contentId: contentId
     bulkUpdateContents:
       path: /api/content/{app}/{schema}/bulk
       method: POST
@@ -27213,7 +27176,6 @@ service:
                   statusCode: 1
                 jobIndex: 1
                 id: id
-                contentId: contentId
     putContentStatus:
       path: /api/content/{app}/{schema}/{id}/status
       method: PUT
@@ -29361,7 +29323,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -29434,7 +29395,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -29706,7 +29666,6 @@ service:
                           "createdBy": "createdBy",
                           "id": "id",
                           "isEnabled": true,
-                          "lastExecuted": "2024-01-15T09:30:00Z",
                           "lastModified": "2024-01-15T09:30:00Z",
                           "lastModifiedBy": "lastModifiedBy",
                           "name": "name",
@@ -29789,7 +29748,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -29897,7 +29855,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -30282,7 +30239,6 @@ service:
                     actionType: Algolia
                   numSucceeded: 1000000
                   numFailed: 1000000
-                  lastExecuted: '2024-01-15T09:30:00Z'
               runningRuleId: runningRuleId
     postRule:
       path: /api/apps/{app}/rules
@@ -30346,7 +30302,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     deleteRuleRun:
       path: /api/apps/{app}/rules/run
       method: DELETE
@@ -30435,7 +30390,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     deleteRule:
       path: /api/apps/{app}/rules/{id}
       method: DELETE
@@ -30511,7 +30465,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     disableRule:
       path: /api/apps/{app}/rules/{id}/disable
       method: PUT
@@ -30565,7 +30518,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     triggerRule:
       path: /api/apps/{app}/rules/{id}/trigger
       method: PUT

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/apiture.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/apiture.json
@@ -12726,20 +12726,6 @@
                           },
                           "type": "primitive"
                         },
-                        "createdOn": {
-                          "value": {
-                            "value": "2023-05-18",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "postedOn": {
-                          "value": {
-                            "value": "2023-05-18",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
                         "amount": {
                           "value": {
                             "value": "0.00",
@@ -12822,20 +12808,6 @@
                         "occurredOn": {
                           "value": {
                             "value": "2023-06-18",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "createdOn": {
-                          "value": {
-                            "value": "2023-05-18",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "postedOn": {
-                          "value": {
-                            "value": "2023-05-18",
                             "type": "string"
                           },
                           "type": "primitive"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/assembly.json
@@ -1321,13 +1321,6 @@
                   },
                   "type": "primitive"
                 },
-                "speed_boost": {
-                  "value": {
-                    "value": true,
-                    "type": "boolean"
-                  },
-                  "type": "primitive"
-                },
                 "auto_highlights": {
                   "value": {
                     "value": true,
@@ -2463,13 +2456,6 @@
                   },
                   "type": "primitive"
                 },
-                "speed_boost": {
-                  "value": {
-                    "value": true,
-                    "type": "boolean"
-                  },
-                  "type": "primitive"
-                },
                 "auto_highlights": {
                   "value": {
                     "value": true,
@@ -3602,13 +3588,6 @@
                   "value": {
                     "value": "webhook_auth_header_name",
                     "type": "string"
-                  },
-                  "type": "primitive"
-                },
-                "speed_boost": {
-                  "value": {
-                    "value": true,
-                    "type": "boolean"
                   },
                   "type": "primitive"
                 },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/deepgram.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/deepgram.json
@@ -2040,13 +2040,6 @@
               "properties": {
                 "metadata": {
                   "properties": {
-                    "transaction_key": {
-                      "value": {
-                        "value": "transaction_key",
-                        "type": "string"
-                      },
-                      "type": "primitive"
-                    },
                     "request_id": {
                       "value": {
                         "value": "a847f427-4ad5-4d67-9b95-db801e58251c",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/flexport.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/flexport.json
@@ -36498,13 +36498,6 @@
                                           },
                                           "type": "primitive"
                                         },
-                                        "country_of_origin": {
-                                          "value": {
-                                            "value": "China",
-                                            "type": "string"
-                                          },
-                                          "type": "primitive"
-                                        },
                                         "client_verified": {
                                           "value": {
                                             "value": true,
@@ -37297,13 +37290,6 @@
                                 "product_category": {
                                   "value": {
                                     "value": "Cosmetics",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "country_of_origin": {
-                                  "value": {
-                                    "value": "China",
                                     "type": "string"
                                   },
                                   "type": "primitive"
@@ -38961,13 +38947,6 @@
                               },
                               "type": "primitive"
                             },
-                            "country_of_origin": {
-                              "value": {
-                                "value": "China",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
                             "client_verified": {
                               "value": {
                                 "value": true,
@@ -38996,37 +38975,6 @@
                                     "value": {
                                       "value": {
                                         "value": "blue",
-                                        "type": "string"
-                                      },
-                                      "type": "primitive"
-                                    }
-                                  },
-                                  "type": "object"
-                                }
-                              ],
-                              "type": "array"
-                            },
-                            "hs_codes": {
-                              "value": [
-                                {
-                                  "properties": {
-                                    "_object": {
-                                      "value": {
-                                        "value": "/hs_code",
-                                        "type": "string"
-                                      },
-                                      "type": "primitive"
-                                    },
-                                    "code": {
-                                      "value": {
-                                        "value": "0301:00",
-                                        "type": "string"
-                                      },
-                                      "type": "primitive"
-                                    },
-                                    "country_code": {
-                                      "value": {
-                                        "value": "US",
                                         "type": "string"
                                       },
                                       "type": "primitive"
@@ -39558,13 +39506,6 @@
                       },
                       "type": "primitive"
                     },
-                    "country_of_origin": {
-                      "value": {
-                        "value": "China",
-                        "type": "string"
-                      },
-                      "type": "primitive"
-                    },
                     "client_verified": {
                       "value": {
                         "value": true,
@@ -39593,37 +39534,6 @@
                             "value": {
                               "value": {
                                 "value": "blue",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            }
-                          },
-                          "type": "object"
-                        }
-                      ],
-                      "type": "array"
-                    },
-                    "hs_codes": {
-                      "value": [
-                        {
-                          "properties": {
-                            "_object": {
-                              "value": {
-                                "value": "/hs_code",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
-                            "code": {
-                              "value": {
-                                "value": "0301:00",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
-                            "country_code": {
-                              "value": {
-                                "value": "US",
                                 "type": "string"
                               },
                               "type": "primitive"
@@ -40125,13 +40035,6 @@
                       },
                       "type": "primitive"
                     },
-                    "country_of_origin": {
-                      "value": {
-                        "value": "China",
-                        "type": "string"
-                      },
-                      "type": "primitive"
-                    },
                     "client_verified": {
                       "value": {
                         "value": true,
@@ -40160,37 +40063,6 @@
                             "value": {
                               "value": {
                                 "value": "blue",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            }
-                          },
-                          "type": "object"
-                        }
-                      ],
-                      "type": "array"
-                    },
-                    "hs_codes": {
-                      "value": [
-                        {
-                          "properties": {
-                            "_object": {
-                              "value": {
-                                "value": "/hs_code",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
-                            "code": {
-                              "value": {
-                                "value": "0301:00",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
-                            "country_code": {
-                              "value": {
-                                "value": "US",
                                 "type": "string"
                               },
                               "type": "primitive"
@@ -40715,13 +40587,6 @@
                       },
                       "type": "primitive"
                     },
-                    "country_of_origin": {
-                      "value": {
-                        "value": "China",
-                        "type": "string"
-                      },
-                      "type": "primitive"
-                    },
                     "client_verified": {
                       "value": {
                         "value": true,
@@ -40750,37 +40615,6 @@
                             "value": {
                               "value": {
                                 "value": "blue",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            }
-                          },
-                          "type": "object"
-                        }
-                      ],
-                      "type": "array"
-                    },
-                    "hs_codes": {
-                      "value": [
-                        {
-                          "properties": {
-                            "_object": {
-                              "value": {
-                                "value": "/hs_code",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
-                            "code": {
-                              "value": {
-                                "value": "0301:00",
-                                "type": "string"
-                              },
-                              "type": "primitive"
-                            },
-                            "country_code": {
-                              "value": {
-                                "value": "US",
                                 "type": "string"
                               },
                               "type": "primitive"
@@ -55518,13 +55352,6 @@
                                           },
                                           "type": "primitive"
                                         },
-                                        "country_of_origin": {
-                                          "value": {
-                                            "value": "China",
-                                            "type": "string"
-                                          },
-                                          "type": "primitive"
-                                        },
                                         "client_verified": {
                                           "value": {
                                             "value": true,
@@ -57604,13 +57431,6 @@
                                 "product_category": {
                                   "value": {
                                     "value": "Cosmetics",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "country_of_origin": {
-                                  "value": {
-                                    "value": "China",
                                     "type": "string"
                                   },
                                   "type": "primitive"
@@ -59787,13 +59607,6 @@
                                 "product_category": {
                                   "value": {
                                     "value": "Cosmetics",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "country_of_origin": {
-                                  "value": {
-                                    "value": "China",
                                     "type": "string"
                                   },
                                   "type": "primitive"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/merge.json
@@ -7312,13 +7312,6 @@
                           },
                           "type": "primitive"
                         },
-                        "hire_date": {
-                          "value": {
-                            "value": "2020-10-10T00:00:00Z",
-                            "type": "datetime"
-                          },
-                          "type": "primitive"
-                        },
                         "start_date": {
                           "value": {
                             "value": "2020-10-11T00:00:00Z",
@@ -7805,13 +7798,6 @@
                     "date_of_birth": {
                       "value": {
                         "value": "1990-11-10T00:00:00Z",
-                        "type": "datetime"
-                      },
-                      "type": "primitive"
-                    },
-                    "hire_date": {
-                      "value": {
-                        "value": "2020-10-10T00:00:00Z",
                         "type": "datetime"
                       },
                       "type": "primitive"
@@ -9930,13 +9916,6 @@
                 "date_of_birth": {
                   "value": {
                     "value": "1990-11-10T00:00:00Z",
-                    "type": "datetime"
-                  },
-                  "type": "primitive"
-                },
-                "hire_date": {
-                  "value": {
-                    "value": "2020-10-10T00:00:00Z",
                     "type": "datetime"
                   },
                   "type": "primitive"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/permit.json
@@ -22907,49 +22907,6 @@
                           ],
                           "type": "array"
                         },
-                        "roles": {
-                          "value": [
-                            {
-                              "properties": {
-                                "role": {
-                                  "value": {
-                                    "value": "admin",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "tenant": {
-                                  "value": {
-                                    "value": "stripe-inc",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            {
-                              "properties": {
-                                "role": {
-                                  "value": {
-                                    "value": "viewer",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "tenant": {
-                                  "value": {
-                                    "value": "othercompany.com",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                }
-                              },
-                              "type": "object"
-                            }
-                          ],
-                          "type": "array"
-                        },
                         "email": {
                           "value": {
                             "value": "jane@coolcompany.com",
@@ -23435,49 +23392,6 @@
                   ],
                   "type": "array"
                 },
-                "roles": {
-                  "value": [
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "admin",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "stripe-inc",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "viewer",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "othercompany.com",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  ],
-                  "type": "array"
-                },
                 "email": {
                   "value": {
                     "value": "jane@coolcompany.com",
@@ -23835,49 +23749,6 @@
                         "status": {
                           "value": "pending",
                           "type": "enum"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  ],
-                  "type": "array"
-                },
-                "roles": {
-                  "value": [
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "admin",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "stripe-inc",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "viewer",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "othercompany.com",
-                            "type": "string"
-                          },
-                          "type": "primitive"
                         }
                       },
                       "type": "object"
@@ -24370,49 +24241,6 @@
                         "status": {
                           "value": "pending",
                           "type": "enum"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  ],
-                  "type": "array"
-                },
-                "roles": {
-                  "value": [
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "admin",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "stripe-inc",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "viewer",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "othercompany.com",
-                            "type": "string"
-                          },
-                          "type": "primitive"
                         }
                       },
                       "type": "object"
@@ -24943,49 +24771,6 @@
                         "status": {
                           "value": "pending",
                           "type": "enum"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  ],
-                  "type": "array"
-                },
-                "roles": {
-                  "value": [
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "admin",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "stripe-inc",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "properties": {
-                        "role": {
-                          "value": {
-                            "value": "viewer",
-                            "type": "string"
-                          },
-                          "type": "primitive"
-                        },
-                        "tenant": {
-                          "value": {
-                            "value": "othercompany.com",
-                            "type": "string"
-                          },
-                          "type": "primitive"
                         }
                       },
                       "type": "object"
@@ -25931,49 +25716,6 @@
                                 "status": {
                                   "value": "pending",
                                   "type": "enum"
-                                }
-                              },
-                              "type": "object"
-                            }
-                          ],
-                          "type": "array"
-                        },
-                        "roles": {
-                          "value": [
-                            {
-                              "properties": {
-                                "role": {
-                                  "value": {
-                                    "value": "admin",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "tenant": {
-                                  "value": {
-                                    "value": "stripe-inc",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            {
-                              "properties": {
-                                "role": {
-                                  "value": {
-                                    "value": "viewer",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
-                                },
-                                "tenant": {
-                                  "value": {
-                                    "value": "othercompany.com",
-                                    "type": "string"
-                                  },
-                                  "type": "primitive"
                                 }
                               },
                               "type": "object"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/squidex.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/squidex.json
@@ -30755,13 +30755,6 @@
                             "type": "int64"
                           },
                           "type": "primitive"
-                        },
-                        "lastExecuted": {
-                          "value": {
-                            "value": "2024-01-15T09:30:00Z",
-                            "type": "datetime"
-                          },
-                          "type": "primitive"
                         }
                       },
                       "type": "object"
@@ -31226,13 +31219,6 @@
                   "value": {
                     "value": 1000000,
                     "type": "int64"
-                  },
-                  "type": "primitive"
-                },
-                "lastExecuted": {
-                  "value": {
-                    "value": "2024-01-15T09:30:00Z",
-                    "type": "datetime"
                   },
                   "type": "primitive"
                 }
@@ -31792,13 +31778,6 @@
                   "value": {
                     "value": 1000000,
                     "type": "int64"
-                  },
-                  "type": "primitive"
-                },
-                "lastExecuted": {
-                  "value": {
-                    "value": "2024-01-15T09:30:00Z",
-                    "type": "datetime"
                   },
                   "type": "primitive"
                 }
@@ -32375,13 +32354,6 @@
                     "type": "int64"
                   },
                   "type": "primitive"
-                },
-                "lastExecuted": {
-                  "value": {
-                    "value": "2024-01-15T09:30:00Z",
-                    "type": "datetime"
-                  },
-                  "type": "primitive"
                 }
               },
               "type": "object"
@@ -32770,13 +32742,6 @@
                   "value": {
                     "value": 1000000,
                     "type": "int64"
-                  },
-                  "type": "primitive"
-                },
-                "lastExecuted": {
-                  "value": {
-                    "value": "2024-01-15T09:30:00Z",
-                    "type": "datetime"
                   },
                   "type": "primitive"
                 }
@@ -45647,13 +45612,6 @@
                         "type": "string"
                       },
                       "type": "primitive"
-                    },
-                    "contentId": {
-                      "value": {
-                        "value": "contentId",
-                        "type": "string"
-                      },
-                      "type": "primitive"
                     }
                   },
                   "type": "object"
@@ -45972,13 +45930,6 @@
                     "id": {
                       "value": {
                         "value": "id",
-                        "type": "string"
-                      },
-                      "type": "primitive"
-                    },
-                    "contentId": {
-                      "value": {
-                        "value": "contentId",
                         "type": "string"
                       },
                       "type": "primitive"
@@ -54744,20 +54695,6 @@
                             "type": "boolean"
                           },
                           "type": "primitive"
-                        },
-                        "pixelWidth": {
-                          "value": {
-                            "value": 1,
-                            "type": "int"
-                          },
-                          "type": "primitive"
-                        },
-                        "pixelHeight": {
-                          "value": {
-                            "value": 1,
-                            "type": "int"
-                          },
-                          "type": "primitive"
                         }
                       },
                       "type": "object"
@@ -55288,20 +55225,6 @@
                     "type": "boolean"
                   },
                   "type": "primitive"
-                },
-                "pixelWidth": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
-                },
-                "pixelHeight": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
                 }
               },
               "type": "object"
@@ -55764,20 +55687,6 @@
                             "type": "boolean"
                           },
                           "type": "primitive"
-                        },
-                        "pixelWidth": {
-                          "value": {
-                            "value": 1,
-                            "type": "int"
-                          },
-                          "type": "primitive"
-                        },
-                        "pixelHeight": {
-                          "value": {
-                            "value": 1,
-                            "type": "int"
-                          },
-                          "type": "primitive"
                         }
                       },
                       "type": "object"
@@ -56165,20 +56074,6 @@
                   "value": {
                     "value": true,
                     "type": "boolean"
-                  },
-                  "type": "primitive"
-                },
-                "pixelWidth": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
-                },
-                "pixelHeight": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
                   },
                   "type": "primitive"
                 }
@@ -56710,20 +56605,6 @@
                     "type": "boolean"
                   },
                   "type": "primitive"
-                },
-                "pixelWidth": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
-                },
-                "pixelHeight": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
                 }
               },
               "type": "object"
@@ -57168,20 +57049,6 @@
                   "value": {
                     "value": true,
                     "type": "boolean"
-                  },
-                  "type": "primitive"
-                },
-                "pixelWidth": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
-                },
-                "pixelHeight": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
                   },
                   "type": "primitive"
                 }
@@ -57692,13 +57559,6 @@
                         "type": "string"
                       },
                       "type": "primitive"
-                    },
-                    "contentId": {
-                      "value": {
-                        "value": "contentId",
-                        "type": "string"
-                      },
-                      "type": "primitive"
                     }
                   },
                   "type": "object"
@@ -58188,20 +58048,6 @@
                     "type": "boolean"
                   },
                   "type": "primitive"
-                },
-                "pixelWidth": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
-                },
-                "pixelHeight": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
                 }
               },
               "type": "object"
@@ -58646,20 +58492,6 @@
                   "value": {
                     "value": true,
                     "type": "boolean"
-                  },
-                  "type": "primitive"
-                },
-                "pixelWidth": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
-                  },
-                  "type": "primitive"
-                },
-                "pixelHeight": {
-                  "value": {
-                    "value": 1,
-                    "type": "int"
                   },
                   "type": "primitive"
                 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/apiture.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/apiture.json
@@ -8268,13 +8268,11 @@ The default response lists only recent transactions. Normally, this is transacti
                           "check": {
                             "number": 1,
                           },
-                          "createdOn": "2023-05-18",
                           "description": "description",
                           "id": "d62c0701-0d74",
                           "memo": "memo",
                           "occurredOn": "2023-06-18",
                           "posted": true,
-                          "postedOn": "2023-05-18",
                           "subtype": "check",
                           "type": "balance",
                         },
@@ -8290,7 +8288,6 @@ The default response lists only recent transactions. Normally, this is transacti
                             "imageFront_url": "/accounts/1d16e438-18e0/transactions/88f5bf17-ecc4/images/front/content",
                             "number": 8412,
                           },
-                          "createdOn": "2023-05-18",
                           "description": "description",
                           "id": "88f5bf17-ecc4",
                           "memo": "Paid electric bill",
@@ -8301,7 +8298,6 @@ The default response lists only recent transactions. Normally, this is transacti
                           },
                           "occurredOn": "2023-06-18",
                           "posted": true,
-                          "postedOn": "2023-05-18",
                           "subtype": "check",
                           "type": "debit",
                         },
@@ -8622,8 +8618,6 @@ service:
                   type: balance
                   subtype: check
                   occurredOn: '2023-06-18'
-                  createdOn: '2023-05-18'
-                  postedOn: '2023-05-18'
                   amount: '0.00'
                   posted: true
                   balance: '8509.38'
@@ -8637,8 +8631,6 @@ service:
                   type: debit
                   subtype: check
                   occurredOn: '2023-06-18'
-                  createdOn: '2023-05-18'
-                  postedOn: '2023-05-18'
                   amount: '1276.21'
                   posted: true
                   balance: '8509.38'

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/assembly.json
@@ -4380,7 +4380,6 @@ docs: Real-time transcription
                       "speaker_labels": true,
                       "speakers_expected": 1,
                       "speech_threshold": 1.1,
-                      "speed_boost": true,
                       "status": "queued",
                       "summarization": true,
                       "summary": "summary",
@@ -4604,7 +4603,6 @@ docs: Real-time transcription
                       "speaker_labels": true,
                       "speakers_expected": 1,
                       "speech_threshold": 1.1,
-                      "speed_boost": true,
                       "status": "queued",
                       "summarization": true,
                       "summary": "summary",
@@ -4816,7 +4814,6 @@ docs: Real-time transcription
                       "speaker_labels": true,
                       "speakers_expected": 1,
                       "speech_threshold": 1.1,
-                      "speed_boost": true,
                       "status": "queued",
                       "summarization": true,
                       "summary": "summary",
@@ -5404,7 +5401,6 @@ service:
               webhook_status_code: 1
               webhook_auth: true
               webhook_auth_header_name: webhook_auth_header_name
-              speed_boost: true
               auto_highlights: true
               auto_highlights_result:
                 results:
@@ -5557,7 +5553,6 @@ service:
               webhook_status_code: 1
               webhook_auth: true
               webhook_auth_header_name: webhook_auth_header_name
-              speed_boost: true
               auto_highlights: true
               auto_highlights_result:
                 results:
@@ -5708,7 +5703,6 @@ service:
               webhook_status_code: 1
               webhook_auth: true
               webhook_auth_header_name: webhook_auth_header_name
-              speed_boost: true
               auto_highlights: true
               auto_highlights_result:
                 results:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/belvo.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/belvo.json
@@ -21689,11 +21689,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -21711,28 +21708,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -21850,7 +21839,6 @@ client.connect()
                         "collected_at": "2022-02-09T08:45:50Z",
                         "credit_limit": 15600,
                         "cutting_date": "2021-04-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
                         "minimum_payment": 690,
                         "next_payment_date": "2021-03-31",
@@ -21870,28 +21858,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -22009,11 +21989,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -22031,16 +22008,12 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "ER8072930097",
                         "contract_start_date": "2018-01-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
@@ -22048,12 +22021,8 @@ client.connect()
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "SFH",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 41,
                         "number_of_installments_total": 50,
                         "outstanding_balance": 164000,
@@ -22171,11 +22140,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -22229,28 +22195,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -22368,11 +22326,8 @@ client.connect()
                         "collected_at": "2019-09-27T13:01:41Z",
                         "credit_limit": 192000,
                         "cutting_date": "2019-12-11",
-                        "end_date": "end_date",
                         "interest_rate": 4,
-                        "last_payment_date": "last_payment_date",
                         "minimum_payment": 2400.3,
-                        "monthly_payment": 1.1,
                         "next_payment_date": "2019-12-13",
                         "no_interest_payment": 2690.83,
                       },
@@ -22390,28 +22345,20 @@ client.connect()
                         "contract_end_date": "2027-10-01",
                         "contract_number": "890ASLDJF87SD00",
                         "contract_start_date": "2020-03-01",
-                        "credit_limit": 1.1,
-                        "cutting_date": "cutting_date",
-                        "cutting_day": "cutting_day",
                         "fees": [
                           {
                             "type": "OPERATION_FEE",
                             "value": 5.6,
                           },
                         ],
-                        "interest_rate": 1.1,
                         "interest_rates": [
                           {
                             "name": "jurosEfetivo",
                             "value": 7.85,
                           },
                         ],
-                        "last_payment_date": "last_payment_date",
-                        "last_period_balance": 1.1,
-                        "limit_day": "limit_day",
                         "loan_type": "Consignado",
                         "monthly_payment": 1000,
-                        "no_interest_payment": 1.1,
                         "number_of_installments_outstanding": 48,
                         "number_of_installments_total": 60,
                         "outstanding_balance": 182000,
@@ -22600,7 +22547,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -22623,7 +22569,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -22980,11 +22925,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -23002,28 +22944,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -23161,7 +23095,6 @@ client.connect()
                           "collected_at": "2022-02-09T08:45:50Z",
                           "credit_limit": 15600,
                           "cutting_date": "2021-04-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
                           "minimum_payment": 690,
                           "next_payment_date": "2021-03-31",
@@ -23181,28 +23114,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -23340,11 +23265,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -23362,16 +23284,12 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "ER8072930097",
                           "contract_start_date": "2018-01-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
@@ -23379,12 +23297,8 @@ client.connect()
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "SFH",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 41,
                           "number_of_installments_total": 50,
                           "outstanding_balance": 164000,
@@ -23522,11 +23436,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -23580,28 +23491,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -23739,11 +23642,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -23761,28 +23661,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -23965,11 +23857,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -23987,28 +23876,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -24137,7 +24018,6 @@ client.connect()
                           "collected_at": "2022-02-09T08:45:50Z",
                           "credit_limit": 15600,
                           "cutting_date": "2021-04-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
                           "minimum_payment": 690,
                           "next_payment_date": "2021-03-31",
@@ -24157,28 +24037,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -24307,11 +24179,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -24329,16 +24198,12 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "ER8072930097",
                           "contract_start_date": "2018-01-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
@@ -24346,12 +24211,8 @@ client.connect()
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "SFH",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 41,
                           "number_of_installments_total": 50,
                           "outstanding_balance": 164000,
@@ -24480,11 +24341,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -24538,28 +24396,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -24688,11 +24538,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -24710,28 +24557,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -25100,8 +24939,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
           code-samples:
             - language: cURL
               code: |
@@ -25255,9 +25092,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -25278,14 +25112,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -25397,7 +25223,6 @@ service:
                   minimum_payment: 690
                   no_interest_payment: 11550.15
                   interest_rate: 4
-                  end_date: end_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -25418,14 +25243,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -25537,9 +25354,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -25561,14 +25375,6 @@ service:
                   contract_start_date: '2018-01-01'
                   contract_end_date: '2027-10-01'
                   contract_number: ER8072930097
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -25680,9 +25486,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -25703,14 +25506,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2022-02-09T08:45:50Z'
                     name: CICLO DE VIDA 2040 I
@@ -25843,9 +25638,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -25866,14 +25658,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -26040,9 +25824,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -26063,14 +25844,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -26191,7 +25964,6 @@ service:
                   minimum_payment: 690
                   no_interest_payment: 11550.15
                   interest_rate: 4
-                  end_date: end_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -26212,14 +25984,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -26340,9 +26104,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -26364,14 +26125,6 @@ service:
                   contract_start_date: '2018-01-01'
                   contract_end_date: '2027-10-01'
                   contract_number: ER8072930097
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -26492,9 +26245,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -26515,14 +26265,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2022-02-09T08:45:50Z'
                     name: CICLO DE VIDA 2040 I
@@ -26664,9 +26406,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -26687,14 +26426,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37
@@ -26866,9 +26597,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -26889,14 +26617,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -26999,7 +26719,6 @@ service:
                 minimum_payment: 690
                 no_interest_payment: 11550.15
                 interest_rate: 4
-                end_date: end_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -27020,14 +26739,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -27130,9 +26841,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -27154,14 +26862,6 @@ service:
                 contract_start_date: '2018-01-01'
                 contract_end_date: '2027-10-01'
                 contract_number: ER8072930097
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -27264,9 +26964,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -27287,14 +26984,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               funds_data:
                 - collected_at: '2022-02-09T08:45:50Z'
                   name: CICLO DE VIDA 2040 I
@@ -27418,9 +27107,6 @@ service:
                 minimum_payment: 2400.3
                 no_interest_payment: 2690.83
                 interest_rate: 4
-                end_date: end_date
-                monthly_payment: 1.1
-                last_payment_date: last_payment_date
               loan_data:
                 collected_at: '2022-02-09T08:45:50Z'
                 contract_amount: 202000
@@ -27441,14 +27127,6 @@ service:
                 contract_start_date: '2020-03-01'
                 contract_end_date: '2027-10-01'
                 contract_number: 890ASLDJF87SD00
-                credit_limit: 1.1
-                last_period_balance: 1.1
-                interest_rate: 1.1
-                limit_day: limit_day
-                cutting_day: cutting_day
-                cutting_date: cutting_date
-                last_payment_date: last_payment_date
-                no_interest_payment: 1.1
               receivables_data:
                 current: 2193.83
                 available: 800.37
@@ -28048,11 +27726,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -28067,7 +27742,6 @@ client.connect()
                           "name": "erebor_br_retail",
                           "type": "bank",
                         },
-                        "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                         "last_accessed_at": "2021-03-09T10:28:40Z",
                         "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                         "loan_data": {
@@ -28076,28 +27750,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -28118,8 +27784,6 @@ client.connect()
                         "type": "Cuentas de efectivo",
                       },
                       "balance": 4.25,
-                      "collected_at": "2022-04-06T23:30:51Z",
-                      "current_balance": 4.25,
                       "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                       "value_date": "2022-04-04",
                     },
@@ -28293,7 +27957,6 @@ client.connect()
                               "name": "erebor_br_retail",
                               "type": "bank",
                             },
-                            "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                             "last_accessed_at": "2021-03-09T10:28:40Z",
                             "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                             "loan_data": {
@@ -28310,8 +27973,6 @@ client.connect()
                             "type": "Cuentas de efectivo",
                           },
                           "balance": 4.25,
-                          "collected_at": "2022-04-06T23:30:51Z",
-                          "current_balance": 4.25,
                           "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                           "value_date": "2022-04-04",
                         },
@@ -28622,7 +28283,6 @@ client.connect()
                             "name": "erebor_br_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                           "loan_data": {
@@ -28645,8 +28305,6 @@ client.connect()
                           "type": "Cuentas de efectivo",
                         },
                         "balance": 4.25,
-                        "collected_at": "2022-04-06T23:30:51Z",
-                        "current_balance": 4.25,
                         "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                         "value_date": "2022-04-04",
                       },
@@ -28827,7 +28485,6 @@ client.connect()
                             "name": "erebor_br_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                           "loan_data": {
@@ -28850,8 +28507,6 @@ client.connect()
                           "type": "Cuentas de efectivo",
                         },
                         "balance": 4.25,
-                        "collected_at": "2022-04-06T23:30:51Z",
-                        "current_balance": 4.25,
                         "id": "b834e69b-1aa4-465d-969c-07c886a4fbed",
                         "value_date": "2022-04-04",
                       },
@@ -29180,11 +28835,8 @@ service:
                       outstanding_balance: 182000
                       monthly_payment: 1000
                       contract_end_date: '2027-10-01'
-                    internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
                   value_date: '2022-04-04'
                   balance: 4.25
-                  current_balance: 4.25
-                  collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -29389,11 +29041,8 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
                 value_date: '2022-04-04'
                 balance: 4.25
-                current_balance: 4.25
-                collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -29565,11 +29214,8 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
                 value_date: '2022-04-04'
                 balance: 4.25
-                current_balance: 4.25
-                collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -29723,9 +29369,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -29746,14 +29389,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2020-04-23T21:32:55Z'
                 receivables_data:
@@ -29761,11 +29396,8 @@ service:
                   available: 800.37
                   anticipated: 1393.46
                   collected_at: '2022-02-09T08:45:50Z'
-                internal_identification: 9fa5fab9-e2b7-4bd7-8413-71ed9bb94b4c
               value_date: '2022-04-04'
               balance: 4.25
-              current_balance: 4.25
-              collected_at: '2022-04-06T23:30:51Z'
           code-samples:
             - language: cURL
               code: |
@@ -37744,7 +37376,6 @@ client.connect()
                       "invoice_type": "Ingreso",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                       "payment_method": "PUE",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "04",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -37784,11 +37415,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "ACNE SA DE CV",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "Roberto Martinez Diaz",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -37930,7 +37559,6 @@ client.connect()
                       "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                       "invoice_type": "Pago",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "99",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -37970,11 +37598,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "ACNE SA DE CV",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "Roberto Martinez Diaz",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -38117,7 +37743,6 @@ client.connect()
                       "invoice_type": "Nómina",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                       "payment_method": "PUE",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "99",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -38157,11 +37782,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "Roberto Martinez Diaz",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "ACNE SA DE CV",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -38304,7 +37927,6 @@ client.connect()
                       "invoice_type": "Egreso",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                       "payment_method": "PUE",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "04",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -38344,11 +37966,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "ACNE SA DE CV",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "Roberto Martinez Diaz",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -38490,7 +38110,6 @@ client.connect()
                       "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                       "invoice_type": "Traslado",
                       "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                      "payment_method_description": "payment_method_description",
                       "payment_type": "99",
                       "payment_type_description": "payment_type_description",
                       "payments": [
@@ -38530,11 +38149,9 @@ client.connect()
                         "version": "1.2",
                       },
                       "place_of_issue": "11000",
-                      "receiver_blacklist_status": "receiver_blacklist_status",
                       "receiver_id": "MNMK3203409H1",
                       "receiver_name": "CARGOS S.A. DE C.V.",
                       "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                      "sender_blacklist_status": "sender_blacklist_status",
                       "sender_id": "GHTF980303F7",
                       "sender_name": "ACNE SA DE CV",
                       "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -38747,7 +38364,6 @@ client.connect()
                           "invoice_type": "Ingreso",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                           "payment_method": "PUE",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "04",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -38785,11 +38401,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "ACNE SA DE CV",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "Roberto Martinez Diaz",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -38963,7 +38577,6 @@ client.connect()
                           "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                           "invoice_type": "Pago",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "99",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -39002,11 +38615,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "ACNE SA DE CV",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "Roberto Martinez Diaz",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -39181,7 +38792,6 @@ client.connect()
                           "invoice_type": "Nómina",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                           "payment_method": "PUE",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "99",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -39220,11 +38830,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "Roberto Martinez Diaz",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "ACNE SA DE CV",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -39399,7 +39007,6 @@ client.connect()
                           "invoice_type": "Egreso",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                           "payment_method": "PUE",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "04",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -39437,11 +39044,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "ACNE SA DE CV",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "Roberto Martinez Diaz",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -39615,7 +39220,6 @@ client.connect()
                           "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                           "invoice_type": "Traslado",
                           "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                          "payment_method_description": "payment_method_description",
                           "payment_type": "99",
                           "payment_type_description": "payment_type_description",
                           "payments": [
@@ -39653,11 +39257,9 @@ client.connect()
                             "version": "1.2",
                           },
                           "place_of_issue": "11000",
-                          "receiver_blacklist_status": "receiver_blacklist_status",
                           "receiver_id": "MNMK3203409H1",
                           "receiver_name": "CARGOS S.A. DE C.V.",
                           "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                          "sender_blacklist_status": "sender_blacklist_status",
                           "sender_id": "GHTF980303F7",
                           "sender_name": "ACNE SA DE CV",
                           "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -39984,7 +39586,6 @@ client.connect()
                         "invoice_type": "Egreso",
                         "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -40023,11 +39624,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "01165",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "BBB222222BB22",
                         "receiver_name": "BELVO CORP",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "AAA111111AA11",
                         "sender_name": "ACME CORP",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -40230,7 +39829,6 @@ client.connect()
                         "invoice_type": "Ingreso",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "04",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -40269,11 +39867,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "ACNE SA DE CV",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "Roberto Martinez Diaz",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -40434,7 +40030,6 @@ client.connect()
                         "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                         "invoice_type": "Pago",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -40474,11 +40069,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "ACNE SA DE CV",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "Roberto Martinez Diaz",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -40640,7 +40233,6 @@ client.connect()
                         "invoice_type": "Nómina",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -40679,11 +40271,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "Roberto Martinez Diaz",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "ACNE SA DE CV",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -40845,7 +40435,6 @@ client.connect()
                         "invoice_type": "Egreso",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
                         "payment_method": "PUE",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "04",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -40884,11 +40473,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "ACNE SA DE CV",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "Roberto Martinez Diaz",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -41049,7 +40636,6 @@ client.connect()
                         "invoice_identification": "862B9918-3K6H-4E0B-NAI9-2BE2D833B840",
                         "invoice_type": "Traslado",
                         "link": "1bd948f7-245d-4313-b604-34d1044cb908",
-                        "payment_method_description": "payment_method_description",
                         "payment_type": "99",
                         "payment_type_description": "payment_type_description",
                         "payments": [
@@ -41088,11 +40674,9 @@ client.connect()
                           "version": "1.2",
                         },
                         "place_of_issue": "11000",
-                        "receiver_blacklist_status": "receiver_blacklist_status",
                         "receiver_id": "MNMK3203409H1",
                         "receiver_name": "CARGOS S.A. DE C.V.",
                         "receiver_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
-                        "sender_blacklist_status": "sender_blacklist_status",
                         "sender_id": "GHTF980303F7",
                         "sender_name": "ACNE SA DE CV",
                         "sender_tax_fraud_status": "NO_TAX_FRAUD_STATUS",
@@ -41490,7 +41074,6 @@ service:
                   payment_type: '04'
                   payment_type_description: payment_type_description
                   payment_method: PUE
-                  payment_method_description: payment_method_description
                   usage: G03
                   version: '3.3'
                   place_of_issue: '11000'
@@ -41548,8 +41131,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -41677,7 +41258,6 @@ service:
                   certification_authority: FGV330542BG6
                   payment_type: '99'
                   payment_type_description: payment_type_description
-                  payment_method_description: payment_method_description
                   usage: P01
                   version: '3.3'
                   place_of_issue: '11000'
@@ -41736,8 +41316,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -41866,7 +41444,6 @@ service:
                   payment_type: '99'
                   payment_type_description: payment_type_description
                   payment_method: PUE
-                  payment_method_description: payment_method_description
                   usage: P01
                   version: '3.3'
                   place_of_issue: '11000'
@@ -41925,8 +41502,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -42055,7 +41630,6 @@ service:
                   payment_type: '04'
                   payment_type_description: payment_type_description
                   payment_method: PUE
-                  payment_method_description: payment_method_description
                   usage: G03
                   version: '3.3'
                   place_of_issue: '11000'
@@ -42113,8 +41687,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -42242,7 +41814,6 @@ service:
                   certification_authority: FGV330542BG6
                   payment_type: '99'
                   payment_type_description: payment_type_description
-                  payment_method_description: payment_method_description
                   usage: G03
                   version: '3.3'
                   place_of_issue: '11000'
@@ -42300,8 +41871,6 @@ service:
                   warnings:
                     code: warning_code
                     message: warning message
-                  sender_blacklist_status: sender_blacklist_status
-                  receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -42491,7 +42060,6 @@ service:
                 payment_type: '04'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: G03
                 version: '3.3'
                 place_of_issue: '11000'
@@ -42550,8 +42118,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -42663,7 +42229,6 @@ service:
                 certification_authority: FGV330542BG6
                 payment_type: '99'
                 payment_type_description: payment_type_description
-                payment_method_description: payment_method_description
                 usage: P01
                 version: '3.3'
                 place_of_issue: '11000'
@@ -42723,8 +42288,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -42837,7 +42400,6 @@ service:
                 payment_type: '99'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: P01
                 version: '3.3'
                 place_of_issue: '11000'
@@ -42896,8 +42458,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -43010,7 +42570,6 @@ service:
                 payment_type: '04'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: G03
                 version: '3.3'
                 place_of_issue: '11000'
@@ -43069,8 +42628,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -43182,7 +42739,6 @@ service:
                 certification_authority: FGV330542BG6
                 payment_type: '99'
                 payment_type_description: payment_type_description
-                payment_method_description: payment_method_description
                 usage: G03
                 version: '3.3'
                 place_of_issue: '11000'
@@ -43241,8 +42797,6 @@ service:
                 warnings:
                   code: warning_code
                   message: warning message
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -43393,7 +42947,6 @@ service:
                 payment_type: '99'
                 payment_type_description: payment_type_description
                 payment_method: PUE
-                payment_method_description: payment_method_description
                 usage: P01
                 version: '3.3'
                 place_of_issue: '01165'
@@ -43451,8 +43004,6 @@ service:
                     this invoice might be missing data. Please check
                     https://tinyurl.com/yydzhy5d for more information on this
                     error.
-                sender_blacklist_status: sender_blacklist_status
-                receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -43598,7 +43149,6 @@ service:
               payment_type: '04'
               payment_type_description: payment_type_description
               payment_method: PUE
-              payment_method_description: payment_method_description
               usage: G03
               version: '3.3'
               place_of_issue: '11000'
@@ -43659,8 +43209,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -43754,7 +43302,6 @@ service:
               certification_authority: FGV330542BG6
               payment_type: '99'
               payment_type_description: payment_type_description
-              payment_method_description: payment_method_description
               usage: P01
               version: '3.3'
               place_of_issue: '11000'
@@ -43815,8 +43362,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -43911,7 +43456,6 @@ service:
               payment_type: '99'
               payment_type_description: payment_type_description
               payment_method: PUE
-              payment_method_description: payment_method_description
               usage: P01
               version: '3.3'
               place_of_issue: '11000'
@@ -43972,8 +43516,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -44068,7 +43610,6 @@ service:
               payment_type: '04'
               payment_type_description: payment_type_description
               payment_method: PUE
-              payment_method_description: payment_method_description
               usage: G03
               version: '3.3'
               place_of_issue: '11000'
@@ -44129,8 +43670,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -44224,7 +43763,6 @@ service:
               certification_authority: FGV330542BG6
               payment_type: '99'
               payment_type_description: payment_type_description
-              payment_method_description: payment_method_description
               usage: G03
               version: '3.3'
               place_of_issue: '11000'
@@ -44285,8 +43823,6 @@ service:
               warnings:
                 code: warning_code
                 message: warning message
-              sender_blacklist_status: sender_blacklist_status
-              receiver_blacklist_status: receiver_blacklist_status
           code-samples:
             - language: cURL
               code: |
@@ -49208,47 +48744,6 @@ A payment intent captures all payment information (such as the amount to be char
                         "open_finance",
                       ],
                       "amount": "350000.00",
-                      "charges": [
-                        {
-                          "amount": "100.12",
-                          "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                          "created_at": "2022-02-09T08:45:50Z",
-                          "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "currency": "BRL",
-                          "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                          "description": "Training shoes",
-                          "failure_code": "failure_code",
-                          "failure_message": "failure_message",
-                          "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "metadata": {
-                            "internal_reference_id": "GGq73487w2",
-                          },
-                          "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                          "payment_method_details": {},
-                          "payment_method_information": {},
-                          "payment_method_type": "open_finance",
-                          "provider": "belvo",
-                          "status": "PENDING",
-                          "transactions": [
-                            {
-                              "amount": "1020.00",
-                              "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "currency": "BRL",
-                              "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                              "description": "Training shoes",
-                              "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                              "payer": {
-                                "key": "value",
-                              },
-                              "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                              "transaction_type": "INFLOW",
-                            },
-                          ],
-                          "updated_at": "2022-02-09T08:45:50Z",
-                        },
-                      ],
                       "created_at": "2022-02-09T08:45:50Z",
                       "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                       "currency": "BRL",
@@ -49396,47 +48891,6 @@ A payment intent captures all payment information (such as the amount to be char
                         "open_finance",
                       ],
                       "amount": "350000.00",
-                      "charges": [
-                        {
-                          "amount": "100.12",
-                          "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                          "created_at": "2022-02-09T08:45:50Z",
-                          "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "currency": "BRL",
-                          "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                          "description": "Training shoes",
-                          "failure_code": "failure_code",
-                          "failure_message": "failure_message",
-                          "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "metadata": {
-                            "internal_reference_id": "GGq73487w2",
-                          },
-                          "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                          "payment_method_details": {},
-                          "payment_method_information": {},
-                          "payment_method_type": "open_finance",
-                          "provider": "belvo",
-                          "status": "PENDING",
-                          "transactions": [
-                            {
-                              "amount": "1020.00",
-                              "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "currency": "BRL",
-                              "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                              "description": "Training shoes",
-                              "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                              "payer": {
-                                "key": "value",
-                              },
-                              "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                              "transaction_type": "INFLOW",
-                            },
-                          ],
-                          "updated_at": "2022-02-09T08:45:50Z",
-                        },
-                      ],
                       "created_at": "2022-02-09T08:45:50Z",
                       "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                       "currency": "BRL",
@@ -49564,43 +49018,6 @@ A payment intent captures all payment information (such as the amount to be char
                             "open_finance",
                           ],
                           "amount": "350000.00",
-                          "charges": [
-                            {
-                              "amount": "100.12",
-                              "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                              "description": "Training shoes",
-                              "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "metadata": {
-                                "internal_reference_id": "GGq73487w2",
-                              },
-                              "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                              "payment_method_details": {},
-                              "payment_method_information": {},
-                              "provider": "belvo",
-                              "status": "PENDING",
-                              "transactions": [
-                                {
-                                  "amount": "1020.00",
-                                  "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                                  "created_at": "2022-02-09T08:45:50Z",
-                                  "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                                  "currency": "BRL",
-                                  "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                                  "description": "Training shoes",
-                                  "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                                  "payer": {
-                                    "key": "value",
-                                  },
-                                  "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                                  "transaction_type": "INFLOW",
-                                },
-                              ],
-                              "updated_at": "2022-02-09T08:45:50Z",
-                            },
-                          ],
                           "created_at": "2022-02-09T08:45:50Z",
                           "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                           "currency": "BRL",
@@ -49759,47 +49176,6 @@ During the payment intent flow, you need to fill in the payment intent with requ
                         "open_finance",
                       ],
                       "amount": "350000.00",
-                      "charges": [
-                        {
-                          "amount": "100.12",
-                          "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                          "created_at": "2022-02-09T08:45:50Z",
-                          "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "currency": "BRL",
-                          "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                          "description": "Training shoes",
-                          "failure_code": "failure_code",
-                          "failure_message": "failure_message",
-                          "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                          "metadata": {
-                            "internal_reference_id": "GGq73487w2",
-                          },
-                          "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                          "payment_method_details": {},
-                          "payment_method_information": {},
-                          "payment_method_type": "open_finance",
-                          "provider": "belvo",
-                          "status": "PENDING",
-                          "transactions": [
-                            {
-                              "amount": "1020.00",
-                              "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                              "created_at": "2022-02-09T08:45:50Z",
-                              "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                              "currency": "BRL",
-                              "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                              "description": "Training shoes",
-                              "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                              "payer": {
-                                "key": "value",
-                              },
-                              "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                              "transaction_type": "INFLOW",
-                            },
-                          ],
-                          "updated_at": "2022-02-09T08:45:50Z",
-                        },
-                      ],
                       "created_at": "2022-02-09T08:45:50Z",
                       "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                       "currency": "BRL",
@@ -50084,35 +49460,6 @@ service:
                       callback_url: https://www.acmecorp.com/checkout/3487321
                       belvo_flow: true
                   payment_method_information: {}
-                  charges:
-                    - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                      status: PENDING
-                      amount: '100.12'
-                      description: Training shoes
-                      metadata:
-                        internal_reference_id: GGq73487w2
-                      beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                      provider: belvo
-                      payment_method_details: {}
-                      payment_method_information: {}
-                      payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                      transactions:
-                        - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                          created_at: '2022-02-09T08:45:50Z'
-                          created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                          amount: '1020.00'
-                          currency: BRL
-                          description: Training shoes
-                          transaction_type: INFLOW
-                          beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                          payer:
-                            key: value
-                          payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                          customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                      updated_at: '2022-02-09T08:45:50Z'
                   provider: belvo
                   selected_payment_method_type: open_finance
                   status: REQUIRES_PAYMENT_METHOD
@@ -50246,39 +49593,6 @@ service:
                   redirect_url: https://wakandanational.com/
                   bank_payment_id: '456213985641233659874512459842'
                   end_to_end_id: '2007300520'
-              charges:
-                - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  created_at: '2022-02-09T08:45:50Z'
-                  created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                  failure_code: failure_code
-                  failure_message: failure_message
-                  status: PENDING
-                  amount: '100.12'
-                  currency: BRL
-                  description: Training shoes
-                  metadata:
-                    internal_reference_id: GGq73487w2
-                  beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                  provider: belvo
-                  payment_method_type: open_finance
-                  payment_method_details: {}
-                  payment_method_information: {}
-                  payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                  transactions:
-                    - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      amount: '1020.00'
-                      currency: BRL
-                      description: Training shoes
-                      transaction_type: INFLOW
-                      beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                      payer:
-                        key: value
-                      payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                      customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                  updated_at: '2022-02-09T08:45:50Z'
               provider: belvo
               selected_payment_method_type: open_finance
               status: REQUIRES_PAYMENT_METHOD
@@ -50359,39 +49673,6 @@ service:
                   redirect_url: https://wakandanational.com/
                   bank_payment_id: '456213985641233659874512459842'
                   end_to_end_id: '2007300520'
-              charges:
-                - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  created_at: '2022-02-09T08:45:50Z'
-                  created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                  failure_code: failure_code
-                  failure_message: failure_message
-                  status: PENDING
-                  amount: '100.12'
-                  currency: BRL
-                  description: Training shoes
-                  metadata:
-                    internal_reference_id: GGq73487w2
-                  beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                  provider: belvo
-                  payment_method_type: open_finance
-                  payment_method_details: {}
-                  payment_method_information: {}
-                  payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                  transactions:
-                    - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      amount: '1020.00'
-                      currency: BRL
-                      description: Training shoes
-                      transaction_type: INFLOW
-                      beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                      payer:
-                        key: value
-                      payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                      customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                  updated_at: '2022-02-09T08:45:50Z'
               provider: belvo
               selected_payment_method_type: open_finance
               status: REQUIRES_PAYMENT_METHOD
@@ -50502,39 +49783,6 @@ service:
                   redirect_url: https://wakandanational.com/
                   bank_payment_id: '456213985641233659874512459842'
                   end_to_end_id: '2007300520'
-              charges:
-                - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  created_at: '2022-02-09T08:45:50Z'
-                  created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                  customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                  failure_code: failure_code
-                  failure_message: failure_message
-                  status: PENDING
-                  amount: '100.12'
-                  currency: BRL
-                  description: Training shoes
-                  metadata:
-                    internal_reference_id: GGq73487w2
-                  beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                  provider: belvo
-                  payment_method_type: open_finance
-                  payment_method_details: {}
-                  payment_method_information: {}
-                  payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                  transactions:
-                    - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                      created_at: '2022-02-09T08:45:50Z'
-                      created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                      amount: '1020.00'
-                      currency: BRL
-                      description: Training shoes
-                      transaction_type: INFLOW
-                      beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                      payer:
-                        key: value
-                      payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                      customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                  updated_at: '2022-02-09T08:45:50Z'
               provider: belvo
               selected_payment_method_type: open_finance
               status: REQUIRES_PAYMENT_METHOD
@@ -50629,43 +49877,6 @@ types:
                           "open_finance",
                         ],
                         "amount": "1234.12",
-                        "charges": [
-                          {
-                            "amount": "100.12",
-                            "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                            "created_at": "2022-02-09T08:45:50Z",
-                            "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                            "description": "Training shoes",
-                            "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "metadata": {
-                              "internal_reference_id": "GGq73487w2",
-                            },
-                            "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                            "payment_method_details": {},
-                            "payment_method_information": {},
-                            "provider": "belvo",
-                            "status": "PENDING",
-                            "transactions": [
-                              {
-                                "amount": "1020.00",
-                                "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                                "created_at": "2022-02-09T08:45:50Z",
-                                "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                                "currency": "BRL",
-                                "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                                "description": "Training shoes",
-                                "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                                "payer": {
-                                  "key": "value",
-                                },
-                                "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                                "transaction_type": "INFLOW",
-                              },
-                            ],
-                            "updated_at": "2022-02-09T08:45:50Z",
-                          },
-                        ],
                         "created_at": "2022-02-09T08:45:50Z",
                         "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                         "currency": "BRL",
@@ -50751,43 +49962,6 @@ types:
                           "open_finance",
                         ],
                         "amount": "1234.12",
-                        "charges": [
-                          {
-                            "amount": "100.12",
-                            "beneficiary": "58524ccc-89ac-4ab6-b62b-c3da3f19a722",
-                            "created_at": "2022-02-09T08:45:50Z",
-                            "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "customer": "531aa631-70a0-4eeb-ab97-51dea3e90c89",
-                            "description": "Training shoes",
-                            "id": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                            "metadata": {
-                              "internal_reference_id": "GGq73487w2",
-                            },
-                            "payment_intent": "50c04229-7b1d-4a53-951c-8ad53e10c6ca",
-                            "payment_method_details": {},
-                            "payment_method_information": {},
-                            "provider": "belvo",
-                            "status": "PENDING",
-                            "transactions": [
-                              {
-                                "amount": "1020.00",
-                                "beneficiary": "a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc",
-                                "created_at": "2022-02-09T08:45:50Z",
-                                "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
-                                "currency": "BRL",
-                                "customer": "9eebd63b-3339-44a9-8a5a-72bb6cb2f310",
-                                "description": "Training shoes",
-                                "id": "fd0f3303-cafb-47ea-9753-21155cb144ab",
-                                "payer": {
-                                  "key": "value",
-                                },
-                                "payment_intent": "004a28bb-fac2-4172-884b-5b6ea15314ad",
-                                "transaction_type": "INFLOW",
-                              },
-                            ],
-                            "updated_at": "2022-02-09T08:45:50Z",
-                          },
-                        ],
                         "created_at": "2022-02-09T08:45:50Z",
                         "created_by": "1c83ead8-6665-429c-a17a-ddc76cb3a95e",
                         "currency": "BRL",
@@ -51282,35 +50456,6 @@ service:
                     payer_institution: 600f1b4a-1ef9-4f89-b341-1a35f0c32cc0
                     callback_url: https://www.acmecorp.com/checkout/3487321
                 payment_method_information: {}
-                charges:
-                  - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    created_at: '2022-02-09T08:45:50Z'
-                    created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                    status: PENDING
-                    amount: '100.12'
-                    description: Training shoes
-                    metadata:
-                      internal_reference_id: GGq73487w2
-                    beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                    provider: belvo
-                    payment_method_details: {}
-                    payment_method_information: {}
-                    payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                    transactions:
-                      - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                        created_at: '2022-02-09T08:45:50Z'
-                        created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                        amount: '1020.00'
-                        currency: BRL
-                        description: Training shoes
-                        transaction_type: INFLOW
-                        beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                        payer:
-                          key: value
-                        payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                        customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                    updated_at: '2022-02-09T08:45:50Z'
                 provider: belvo
                 selected_payment_method_type: open_finance
                 status: REQUIRES_PAYMENT_METHOD
@@ -51385,35 +50530,6 @@ service:
                     payer_institution: 600f1b4a-1ef9-4f89-b341-1a35f0c32cc0
                     callback_url: https://www.acmecorp.com/checkout/3487321
                 payment_method_information: {}
-                charges:
-                  - id: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    created_at: '2022-02-09T08:45:50Z'
-                    created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                    customer: 531aa631-70a0-4eeb-ab97-51dea3e90c89
-                    status: PENDING
-                    amount: '100.12'
-                    description: Training shoes
-                    metadata:
-                      internal_reference_id: GGq73487w2
-                    beneficiary: 58524ccc-89ac-4ab6-b62b-c3da3f19a722
-                    provider: belvo
-                    payment_method_details: {}
-                    payment_method_information: {}
-                    payment_intent: 50c04229-7b1d-4a53-951c-8ad53e10c6ca
-                    transactions:
-                      - id: fd0f3303-cafb-47ea-9753-21155cb144ab
-                        created_at: '2022-02-09T08:45:50Z'
-                        created_by: 1c83ead8-6665-429c-a17a-ddc76cb3a95e
-                        amount: '1020.00'
-                        currency: BRL
-                        description: Training shoes
-                        transaction_type: INFLOW
-                        beneficiary: a80d5a9d-20ae-479a-8dd7-ff3443bcbbfc
-                        payer:
-                          key: value
-                        payment_intent: 004a28bb-fac2-4172-884b-5b6ea15314ad
-                        customer: 9eebd63b-3339-44a9-8a5a-72bb6cb2f310
-                    updated_at: '2022-02-09T08:45:50Z'
                 provider: belvo
                 selected_payment_method_type: open_finance
                 status: REQUIRES_PAYMENT_METHOD
@@ -53330,7 +52446,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -53353,7 +52468,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -53755,7 +52869,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -53778,7 +52891,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -53943,7 +53055,6 @@ client.connect()
                             "current": 5874.13,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "bank_product_id",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2019-09-27T13:01:41Z",
                           "created_at": "2022-02-09T08:45:50Z",
@@ -53966,7 +53077,6 @@ client.connect()
                           "institution": {
                             "name": "erebor_mx_retail",
                           },
-                          "internal_identification": "internal_identification",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -54433,8 +53543,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
                 name: Netflix
                 transactions:
                   - amount: 2145.45
@@ -54596,8 +53704,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
                 name: Netflix
                 transactions:
                   - amount: 2145.45
@@ -54763,8 +53869,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: bank_product_id
-                  internal_identification: internal_identification
                 name: Netflix
                 transactions:
                   - amount: 2145.45
@@ -72674,7 +71778,6 @@ client.connect()
                           "current": 0,
                         },
                         "balance_type": "ASSET",
-                        "bank_product_id": "46",
                         "category": "CHECKING_ACCOUNT",
                         "collected_at": "2022-02-09T08:45:50Z",
                         "created_at": "2022-02-09T08:46:20Z",
@@ -72682,11 +71785,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -72701,7 +71801,6 @@ client.connect()
                           "name": "erebor_mx_retail",
                           "type": "bank",
                         },
-                        "internal_identification": "996685090015",
                         "last_accessed_at": "2021-03-09T10:28:40Z",
                         "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                         "loan_data": {
@@ -72710,28 +71809,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -72879,11 +71970,8 @@ client.connect()
                           "collected_at": "2019-09-27T13:01:41Z",
                           "credit_limit": 192000,
                           "cutting_date": "2019-12-11",
-                          "end_date": "end_date",
                           "interest_rate": 4,
-                          "last_payment_date": "last_payment_date",
                           "minimum_payment": 2400.3,
-                          "monthly_payment": 1.1,
                           "next_payment_date": "2019-12-13",
                           "no_interest_payment": 2690.83,
                         },
@@ -72898,7 +71986,6 @@ client.connect()
                           "name": "erebor_mx_retail",
                           "type": "bank",
                         },
-                        "internal_identification": "996685090015",
                         "last_accessed_at": "2021-03-09T10:28:40Z",
                         "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                         "loan_data": {
@@ -72907,28 +71994,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -73095,28 +72174,20 @@ client.connect()
                           "contract_end_date": "2027-10-01",
                           "contract_number": "890ASLDJF87SD00",
                           "contract_start_date": "2020-03-01",
-                          "credit_limit": 1.1,
-                          "cutting_date": "cutting_date",
-                          "cutting_day": "cutting_day",
                           "fees": [
                             {
                               "type": "OPERATION_FEE",
                               "value": 5.6,
                             },
                           ],
-                          "interest_rate": 1.1,
                           "interest_rates": [
                             {
                               "name": "jurosEfetivo",
                               "value": 7.85,
                             },
                           ],
-                          "last_payment_date": "last_payment_date",
-                          "last_period_balance": 1.1,
-                          "limit_day": "limit_day",
                           "loan_type": "Consignado",
                           "monthly_payment": 1000,
-                          "no_interest_payment": 1.1,
                           "number_of_installments_outstanding": 48,
                           "number_of_installments_total": 60,
                           "outstanding_balance": 182000,
@@ -73356,7 +72427,6 @@ client.connect()
                               "current": 0,
                             },
                             "balance_type": "ASSET",
-                            "bank_product_id": "46",
                             "category": "CHECKING_ACCOUNT",
                             "collected_at": "2022-02-09T08:45:50Z",
                             "created_at": "2022-02-09T08:46:20Z",
@@ -73366,7 +72436,6 @@ client.connect()
                               "name": "erebor_mx_retail",
                               "type": "bank",
                             },
-                            "internal_identification": "996685090015",
                             "last_accessed_at": "2021-03-09T10:28:40Z",
                             "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                             "loan_data": {
@@ -73566,7 +72635,6 @@ client.connect()
                               "name": "erebor_mx_retail",
                               "type": "bank",
                             },
-                            "internal_identification": "996685090015",
                             "last_accessed_at": "2021-03-09T10:28:40Z",
                             "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                             "loan_data": {
@@ -74221,7 +73289,6 @@ client.connect()
                             "current": 0,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "46",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2022-02-09T08:45:50Z",
                           "created_at": "2022-02-09T08:46:20Z",
@@ -74245,7 +73312,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -74431,7 +73497,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -74822,7 +73887,6 @@ client.connect()
                             "current": 0,
                           },
                           "balance_type": "ASSET",
-                          "bank_product_id": "46",
                           "category": "CHECKING_ACCOUNT",
                           "collected_at": "2022-02-09T08:45:50Z",
                           "created_at": "2022-02-09T08:46:20Z",
@@ -74846,7 +73910,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -75037,7 +74100,6 @@ client.connect()
                             "name": "erebor_mx_retail",
                             "type": "bank",
                           },
-                          "internal_identification": "996685090015",
                           "last_accessed_at": "2021-03-09T10:28:40Z",
                           "link": "30cb4806-6e00-48a4-91c9-ca55968576c8",
                           "loan_data": {
@@ -75885,8 +74947,6 @@ service:
                       outstanding_balance: 182000
                       monthly_payment: 1000
                       contract_end_date: '2027-10-01'
-                    bank_product_id: '46'
-                    internal_identification: '996685090015'
                   collected_at: '2022-07-20T22:09:33Z'
                   created_at: '2022-07-20T22:09:35Z'
                   value_date: '2022-07-11'
@@ -76064,7 +75124,6 @@ service:
                       outstanding_balance: 182000
                       monthly_payment: 1000
                       contract_end_date: '2027-10-01'
-                    internal_identification: '996685090015'
                   collected_at: '2022-07-20T22:09:33Z'
                   created_at: '2022-07-20T22:09:35Z'
                   value_date: '2022-07-11'
@@ -76441,8 +75500,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: '46'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -76603,7 +75660,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -77111,8 +76167,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  bank_product_id: '46'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -77268,7 +76322,6 @@ service:
                     available: 800.37
                     anticipated: 1393.46
                     collected_at: '2022-02-09T08:45:50Z'
-                  internal_identification: '996685090015'
                 collected_at: '2022-07-20T22:09:33Z'
                 created_at: '2022-07-20T22:09:35Z'
                 value_date: '2022-07-11'
@@ -77600,9 +76653,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -77623,14 +76673,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2020-04-23T21:32:55Z'
                 receivables_data:
@@ -77638,8 +76680,6 @@ service:
                   available: 800.37
                   anticipated: 1393.46
                   collected_at: '2022-02-09T08:45:50Z'
-                bank_product_id: '46'
-                internal_identification: '996685090015'
               collected_at: '2022-07-20T22:09:33Z'
               created_at: '2022-07-20T22:09:35Z'
               value_date: '2022-07-11'
@@ -77764,9 +76804,6 @@ service:
                   minimum_payment: 2400.3
                   no_interest_payment: 2690.83
                   interest_rate: 4
-                  end_date: end_date
-                  monthly_payment: 1.1
-                  last_payment_date: last_payment_date
                 loan_data:
                   collected_at: '2022-02-09T08:45:50Z'
                   contract_amount: 202000
@@ -77787,14 +76824,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 funds_data:
                   - collected_at: '2020-04-23T21:32:55Z'
                 receivables_data:
@@ -77802,7 +76831,6 @@ service:
                   available: 800.37
                   anticipated: 1393.46
                   collected_at: '2022-02-09T08:45:50Z'
-                internal_identification: '996685090015'
               collected_at: '2022-07-20T22:09:33Z'
               created_at: '2022-07-20T22:09:35Z'
               value_date: '2022-07-11'
@@ -77947,14 +76975,6 @@ service:
                   contract_start_date: '2020-03-01'
                   contract_end_date: '2027-10-01'
                   contract_number: 890ASLDJF87SD00
-                  credit_limit: 1.1
-                  last_period_balance: 1.1
-                  interest_rate: 1.1
-                  limit_day: limit_day
-                  cutting_day: cutting_day
-                  cutting_date: cutting_date
-                  last_payment_date: last_payment_date
-                  no_interest_payment: 1.1
                 receivables_data:
                   current: 2193.83
                   available: 800.37

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/deepgram.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/deepgram.json
@@ -10430,7 +10430,6 @@ channel:
                           "model_uuid": "80ab3179-d113-4254-bd6b-4a2f96498695",
                           "output_tokens": 7,
                         },
-                        "transaction_key": "transaction_key",
                       },
                       "results": {
                         "channels": [
@@ -11395,7 +11394,6 @@ service:
           response:
             body:
               metadata:
-                transaction_key: transaction_key
                 request_id: a847f427-4ad5-4d67-9b95-db801e58251c
                 sha256: >-
                   154e291ecfa8be6ab8343560bcc109008fa7853eb5372533e8efdefc9b504c33

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/flexport.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/flexport.json
@@ -15916,7 +15916,6 @@ docs: Endpoints relating to Contact objects
                                 "product": {
                                   "_object": "/product",
                                   "client_verified": true,
-                                  "country_of_origin": "China",
                                   "description": "The best 12V AC Adapter on the market",
                                   "id": 84291,
                                   "name": "AC Adapter 12V",
@@ -16059,7 +16058,6 @@ docs: Endpoints relating to Contact objects
                             "product": {
                               "_object": "/product",
                               "client_verified": true,
-                              "country_of_origin": "China",
                               "description": "The best 12V AC Adapter on the market",
                               "id": 84291,
                               "name": "AC Adapter 12V",
@@ -16313,7 +16311,6 @@ service:
                           sku: WDVCDFD-RM00472
                           description: The best 12V AC Adapter on the market
                           product_category: Cosmetics
-                          country_of_origin: China
                           client_verified: true
     show:
       path: /ocean/shipment_containers/{id}
@@ -16396,7 +16393,6 @@ service:
                       sku: WDVCDFD-RM00472
                       description: The best 12V AC Adapter on the market
                       product_category: Cosmetics
-                      country_of_origin: China
                       client_verified: true
   source:
     openapi: ../openapi.yml
@@ -20658,15 +20654,7 @@ docs: Endpoints relating to Ports objects
                           },
                         ],
                         "client_verified": true,
-                        "country_of_origin": "China",
                         "description": "The best 12V AC Adapter on the market",
-                        "hs_codes": [
-                          {
-                            "_object": "/hs_code",
-                            "code": "0301:00",
-                            "country_code": "US",
-                          },
-                        ],
                         "id": 84291,
                         "name": "AC Adapter 12V",
                         "product_category": "Cosmetics",
@@ -20774,15 +20762,7 @@ docs: Endpoints relating to Ports objects
                               },
                             ],
                             "client_verified": true,
-                            "country_of_origin": "China",
                             "description": "The best 12V AC Adapter on the market",
-                            "hs_codes": [
-                              {
-                                "_object": "/hs_code",
-                                "code": "0301:00",
-                                "country_code": "US",
-                              },
-                            ],
                             "id": 84291,
                             "name": "AC Adapter 12V",
                             "product_category": "Cosmetics",
@@ -20863,15 +20843,7 @@ docs: Endpoints relating to Ports objects
                           },
                         ],
                         "client_verified": true,
-                        "country_of_origin": "China",
                         "description": "The best 12V AC Adapter on the market",
-                        "hs_codes": [
-                          {
-                            "_object": "/hs_code",
-                            "code": "0301:00",
-                            "country_code": "US",
-                          },
-                        ],
                         "id": 84291,
                         "name": "AC Adapter 12V",
                         "product_category": "Cosmetics",
@@ -20938,15 +20910,7 @@ docs: Endpoints relating to Ports objects
                           },
                         ],
                         "client_verified": true,
-                        "country_of_origin": "China",
                         "description": "The best 12V AC Adapter on the market",
-                        "hs_codes": [
-                          {
-                            "_object": "/hs_code",
-                            "code": "0301:00",
-                            "country_code": "US",
-                          },
-                        ],
                         "id": 84291,
                         "name": "AC Adapter 12V",
                         "product_category": "Cosmetics",
@@ -21205,16 +21169,11 @@ service:
                     description: The best 12V AC Adapter on the market
                     archived_at: '2019-01-18T22:08:38Z'
                     product_category: Cosmetics
-                    country_of_origin: China
                     client_verified: true
                     product_properties:
                       - _object: /product/property
                         type: color
                         value: blue
-                    hs_codes:
-                      - _object: /hs_code
-                        code: '0301:00'
-                        country_code: US
                     classifications:
                       - _object: /product/classification
                         codes:
@@ -21294,16 +21253,11 @@ service:
                 description: The best 12V AC Adapter on the market
                 archived_at: '2019-01-18T22:08:38Z'
                 product_category: Cosmetics
-                country_of_origin: China
                 client_verified: true
                 product_properties:
                   - _object: /product/property
                     type: color
                     value: blue
-                hs_codes:
-                  - _object: /hs_code
-                    code: '0301:00'
-                    country_code: US
                 classifications:
                   - _object: /product/classification
                     codes:
@@ -21344,16 +21298,11 @@ service:
                 description: The best 12V AC Adapter on the market
                 archived_at: '2019-01-18T22:08:38Z'
                 product_category: Cosmetics
-                country_of_origin: China
                 client_verified: true
                 product_properties:
                   - _object: /product/property
                     type: color
                     value: blue
-                hs_codes:
-                  - _object: /hs_code
-                    code: '0301:00'
-                    country_code: US
                 classifications:
                   - _object: /product/classification
                     codes:
@@ -21434,16 +21383,11 @@ service:
                 description: The best 12V AC Adapter on the market
                 archived_at: '2019-01-18T22:08:38Z'
                 product_category: Cosmetics
-                country_of_origin: China
                 client_verified: true
                 product_properties:
                   - _object: /product/property
                     type: color
                     value: blue
-                hs_codes:
-                  - _object: /hs_code
-                    code: '0301:00'
-                    country_code: US
                 classifications:
                   - _object: /product/classification
                     codes:
@@ -24274,7 +24218,6 @@ docs: >-
                                 "product": {
                                   "_object": "/product",
                                   "client_verified": true,
-                                  "country_of_origin": "China",
                                   "description": "The best 12V AC Adapter on the market",
                                   "id": 84291,
                                   "name": "AC Adapter 12V",
@@ -24790,7 +24733,6 @@ docs: >-
                             "product": {
                               "_object": "/product",
                               "client_verified": true,
-                              "country_of_origin": "China",
                               "description": "The best 12V AC Adapter on the market",
                               "id": 84291,
                               "name": "AC Adapter 12V",
@@ -25106,7 +25048,6 @@ docs: >-
                             "product": {
                               "_object": "/product",
                               "client_verified": true,
-                              "country_of_origin": "China",
                               "description": "The best 12V AC Adapter on the market",
                               "id": 84291,
                               "name": "AC Adapter 12V",
@@ -25840,7 +25781,6 @@ service:
                           sku: WDVCDFD-RM00472
                           description: The best 12V AC Adapter on the market
                           product_category: Cosmetics
-                          country_of_origin: China
                           client_verified: true
                     legs:
                       _object: /api/refs/collection
@@ -26084,7 +26024,6 @@ service:
                       sku: WDVCDFD-RM00472
                       description: The best 12V AC Adapter on the market
                       product_category: Cosmetics
-                      country_of_origin: China
                       client_verified: true
                 legs:
                   _object: /api/refs/collection
@@ -26348,7 +26287,6 @@ service:
                       sku: WDVCDFD-RM00472
                       description: The best 12V AC Adapter on the market
                       product_category: Cosmetics
-                      country_of_origin: China
                       client_verified: true
                 legs:
                   _object: /api/refs/collection

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/merge.json
@@ -11884,7 +11884,6 @@ service:
                         "groups": [
                           "21a54124-397f-494d-985e-3c5b330b8a68",
                         ],
-                        "hire_date": "2020-10-10T00:00:00Z",
                         "home_location": "d2f972d0-2526-434b-9409-4c3b468e08f0",
                         "id": "0958cbc6-6040-430a-848e-aafacbadf4ae",
                         "last_name": "Hirsch",
@@ -12043,7 +12042,6 @@ service:
                           "groups": [
                             "21a54124-397f-494d-985e-3c5b330b8a68",
                           ],
-                          "hire_date": "2020-10-10T00:00:00Z",
                           "home_location": "d2f972d0-2526-434b-9409-4c3b468e08f0",
                           "id": "0958cbc6-6040-430a-848e-aafacbadf4ae",
                           "last_name": "Hirsch",
@@ -12299,7 +12297,6 @@ service:
                       "groups": [
                         "21a54124-397f-494d-985e-3c5b330b8a68",
                       ],
-                      "hire_date": "2020-10-10T00:00:00Z",
                       "home_location": "d2f972d0-2526-434b-9409-4c3b468e08f0",
                       "id": "0958cbc6-6040-430a-848e-aafacbadf4ae",
                       "last_name": "Hirsch",
@@ -15942,7 +15939,6 @@ service:
                   ethnicity: AMERICAN_INDIAN_OR_ALASKA_NATIVE
                   marital_status: SINGLE
                   date_of_birth: '1990-11-10T00:00:00Z'
-                  hire_date: '2020-10-10T00:00:00Z'
                   start_date: '2020-10-11T00:00:00Z'
                   remote_created_at: '2020-10-11T00:00:00Z'
                   employment_status: ACTIVE
@@ -16019,7 +16015,6 @@ service:
                 ethnicity: AMERICAN_INDIAN_OR_ALASKA_NATIVE
                 marital_status: SINGLE
                 date_of_birth: '1990-11-10T00:00:00Z'
-                hire_date: '2020-10-10T00:00:00Z'
                 start_date: '2020-10-11T00:00:00Z'
                 remote_created_at: '2020-10-11T00:00:00Z'
                 employment_status: ACTIVE
@@ -16126,7 +16121,6 @@ service:
               ethnicity: AMERICAN_INDIAN_OR_ALASKA_NATIVE
               marital_status: SINGLE
               date_of_birth: '1990-11-10T00:00:00Z'
-              hire_date: '2020-10-10T00:00:00Z'
               start_date: '2020-10-11T00:00:00Z'
               remote_created_at: '2020-10-11T00:00:00Z'
               employment_status: ACTIVE

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/permit.json
@@ -17675,16 +17675,6 @@ and will return the existing tenant object in the response body.",
                           "last_name": "Doe",
                           "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                           "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                          "roles": [
-                            {
-                              "role": "admin",
-                              "tenant": "stripe-inc",
-                            },
-                            {
-                              "role": "viewer",
-                              "tenant": "othercompany.com",
-                            },
-                          ],
                         },
                       ],
                       "page_count": 1,
@@ -18046,11 +18036,6 @@ service:
                       roles:
                         - viewer
                       status: pending
-                  roles:
-                    - role: admin
-                      tenant: stripe-inc
-                    - role: viewer
-                      tenant: othercompany.com
                   email: jane@coolcompany.com
                   first_name: Jane
                   last_name: Doe
@@ -19310,16 +19295,6 @@ and will return the existing user object in the response body.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -19437,16 +19412,6 @@ and will return the existing user object in the response body.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -19526,16 +19491,6 @@ and will return the existing user object in the response body.",
                           "last_name": "Doe",
                           "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                           "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                          "roles": [
-                            {
-                              "role": "admin",
-                              "tenant": "stripe-inc",
-                            },
-                            {
-                              "role": "viewer",
-                              "tenant": "othercompany.com",
-                            },
-                          ],
                         },
                       ],
                       "page_count": 1,
@@ -19665,16 +19620,6 @@ and will return the existing user object in the response body.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -19825,16 +19770,6 @@ Fields that will be provided will be completely overwritten.",
                       "last_name": "Doe",
                       "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
                       "project_id": "405d8375-3514-403b-8c43-83ae74cfe0e9",
-                      "roles": [
-                        {
-                          "role": "admin",
-                          "tenant": "stripe-inc",
-                        },
-                        {
-                          "role": "viewer",
-                          "tenant": "othercompany.com",
-                        },
-                      ],
                     },
                   },
                 },
@@ -19978,11 +19913,6 @@ service:
                       roles:
                         - viewer
                       status: pending
-                  roles:
-                    - role: admin
-                      tenant: stripe-inc
-                    - role: viewer
-                      tenant: othercompany.com
                   email: jane@coolcompany.com
                   first_name: Jane
                   last_name: Doe
@@ -20059,11 +19989,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe
@@ -20124,11 +20049,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe
@@ -20203,11 +20123,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe
@@ -20325,11 +20240,6 @@ service:
                   roles:
                     - viewer
                   status: pending
-              roles:
-                - role: admin
-                  tenant: stripe-inc
-                - role: viewer
-                  tenant: othercompany.com
               email: jane@coolcompany.com
               first_name: Jane
               last_name: Doe

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/squidex.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/squidex.json
@@ -12038,7 +12038,6 @@ service:
                   "response": {
                     "body": [
                       {
-                        "contentId": "contentId",
                         "error": {
                           "details": [
                             "details",
@@ -12227,8 +12226,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -12582,8 +12579,6 @@ service:
                           "metadataText": "metadataText",
                           "mimeType": "mimeType",
                           "parentId": "parentId",
-                          "pixelHeight": 1,
-                          "pixelWidth": 1,
                           "slug": "slug",
                           "tags": [
                             "tags",
@@ -12702,8 +12697,6 @@ service:
                           "metadataText": "metadataText",
                           "mimeType": "mimeType",
                           "parentId": "parentId",
-                          "pixelHeight": 1,
-                          "pixelWidth": 1,
                           "slug": "slug",
                           "tags": [
                             "tags",
@@ -12824,8 +12817,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -13004,8 +12995,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -13106,8 +13095,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -13219,8 +13206,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -13460,8 +13445,6 @@ service:
                       "metadataText": "metadataText",
                       "mimeType": "mimeType",
                       "parentId": "parentId",
-                      "pixelHeight": 1,
-                      "pixelWidth": 1,
                       "slug": "slug",
                       "tags": [
                         "tags",
@@ -14096,8 +14079,6 @@ service:
                   _meta:
                     isDuplicate: isDuplicate
                   isImage: true
-                  pixelWidth: 1
-                  pixelHeight: 1
     postAsset:
       path: /api/apps/{app}/assets
       method: POST
@@ -14173,8 +14154,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     getAssetsPost:
       path: /api/apps/{app}/assets/query
       method: POST
@@ -14240,8 +14219,6 @@ service:
                   _meta:
                     isDuplicate: isDuplicate
                   isImage: true
-                  pixelWidth: 1
-                  pixelHeight: 1
     getAsset:
       path: /api/apps/{app}/assets/{id}
       method: GET
@@ -14299,8 +14276,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     postUpsertAsset:
       path: /api/apps/{app}/assets/{id}
       method: POST
@@ -14377,8 +14352,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     putAsset:
       path: /api/apps/{app}/assets/{id}
       method: PUT
@@ -14458,8 +14431,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     deleteAsset:
       path: /api/apps/{app}/assets/{id}
       method: DELETE
@@ -14545,7 +14516,6 @@ service:
                   statusCode: 1
                 jobIndex: 1
                 id: id
-                contentId: contentId
     putAssetContent:
       path: /api/apps/{app}/assets/{id}/content
       method: PUT
@@ -14613,8 +14583,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
     putAssetParent:
       path: /api/apps/{app}/assets/{id}/parent
       method: PUT
@@ -14682,8 +14650,6 @@ service:
               _meta:
                 isDuplicate: isDuplicate
               isImage: true
-              pixelWidth: 1
-              pixelHeight: 1
   source:
     openapi: ../openapi.json
 ",
@@ -15660,7 +15626,6 @@ service:
                   "response": {
                     "body": [
                       {
-                        "contentId": "contentId",
                         "error": {
                           "details": [
                             "details",
@@ -17202,7 +17167,6 @@ service:
                   "response": {
                     "body": [
                       {
-                        "contentId": "contentId",
                         "error": {
                           "details": [
                             "details",
@@ -18770,7 +18734,6 @@ service:
                   statusCode: 1
                 jobIndex: 1
                 id: id
-                contentId: contentId
     bulkUpdateContents:
       path: /api/content/{app}/{schema}/bulk
       method: POST
@@ -18844,7 +18807,6 @@ service:
                   statusCode: 1
                 jobIndex: 1
                 id: id
-                contentId: contentId
     putContentStatus:
       path: /api/content/{app}/{schema}/{id}/status
       method: PUT
@@ -20992,7 +20954,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -21065,7 +21026,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -21337,7 +21297,6 @@ service:
                           "createdBy": "createdBy",
                           "id": "id",
                           "isEnabled": true,
-                          "lastExecuted": "2024-01-15T09:30:00Z",
                           "lastModified": "2024-01-15T09:30:00Z",
                           "lastModifiedBy": "lastModifiedBy",
                           "name": "name",
@@ -21420,7 +21379,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -21528,7 +21486,6 @@ service:
                       "createdBy": "createdBy",
                       "id": "id",
                       "isEnabled": true,
-                      "lastExecuted": "2024-01-15T09:30:00Z",
                       "lastModified": "2024-01-15T09:30:00Z",
                       "lastModifiedBy": "lastModifiedBy",
                       "name": "name",
@@ -21913,7 +21870,6 @@ service:
                     actionType: Algolia
                   numSucceeded: 1000000
                   numFailed: 1000000
-                  lastExecuted: '2024-01-15T09:30:00Z'
               runningRuleId: runningRuleId
     postRule:
       path: /api/apps/{app}/rules
@@ -21977,7 +21933,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     deleteRuleRun:
       path: /api/apps/{app}/rules/run
       method: DELETE
@@ -22066,7 +22021,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     deleteRule:
       path: /api/apps/{app}/rules/{id}
       method: DELETE
@@ -22142,7 +22096,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     disableRule:
       path: /api/apps/{app}/rules/{id}/disable
       method: PUT
@@ -22196,7 +22149,6 @@ service:
                 actionType: Algolia
               numSucceeded: 1000000
               numFailed: 1000000
-              lastExecuted: '2024-01-15T09:30:00Z'
     triggerRule:
       path: /api/apps/{app}/rules/{id}/trigger
       method: PUT

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fixed ExampleTypeFactory to ignore generating parameters in example when that parameter is both optional and deprecated
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-21"
+  version: 0.64.15
+
+- changelogEntry:
+    - summary: |
         Separate nullable and optional property handling in IR conversion.
       type: fix
   irVersion: 58


### PR DESCRIPTION
## Description
Updated issue with ExampleTypeFactory in response to this issue raised by Eleven Labs: 

https://github.com/elevenlabs/elevenlabs-docs/pull/1243/files

The issue was that a parameter was deprecated and optional, but our example generation doesn't filter for that. There are edge cases where params are deprecated and required, so the check for both properties was necessary for now. 

## Changes Made
- Updated `ExampleTypeFactory.buildExampleHelper` to filter out properties that are optional and deprecated 


## Testing
<!-- Describe how you tested these changes -->
✅ Unit tests updated
✅ Local testing passed

