### PR TITLE
chore(internal): add missing flag to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Below are some examples of using the command.
 - For a single generator: `pnpm seed test --generator python-sdk`
 - For a single generator and test definition: `pnpm seed test --generator python-sdk --fixture file-download`
 - For a single generator, test definition, and skipping scripts: `pnpm seed test --generator python-sdk --fixture file-download --skip-scripts`
-- For running the generator locally (not on docker): `pnpm seed test --generator python-sdk`
+- For running the generator locally (not on docker): `pnpm seed test --generator python-sdk --local`
 
 ### Running seed against a custom fern definition
 


### PR DESCRIPTION
I think the `--local` flag is missing in the shown example