### PR TITLE
chore(cli): pin windows to legacy

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-24.mdx
+++ b/fern/pages/changelogs/cli/2025-06-24.mdx
@@ -1,4 +1,4 @@
 ## 0.64.19
-**`(feat):`** Pin Windows to legacy preview mode.
+**`(fix):`** Pin Windows to legacy preview mode.
 
 

--- a/fern/pages/changelogs/cli/2025-06-24.mdx
+++ b/fern/pages/changelogs/cli/2025-06-24.mdx
@@ -1,4 +1,4 @@
-## 0.64.17
+## 0.64.19
 **`(feat):`** Pin Windows to legacy preview mode.
 
 

--- a/fern/pages/changelogs/cli/2025-06-24.mdx
+++ b/fern/pages/changelogs/cli/2025-06-24.mdx
@@ -1,0 +1,4 @@
+## 0.64.17
+**`(feat):`** Pin Windows to legacy preview mode.
+
+

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1246,7 +1246,7 @@ function addDocsPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
                 bundlePath,
                 brokenLinks: argv.brokenLinks,
                 appPreview: argv.beta,
-                legacyPreview: argv.legacy,
+                legacyPreview: argv.legacy || process.platform === "win32",
                 backendPort
             });
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Pin Windows to legacy preview mode.
+      type: feat
+  irVersion: 58
+  createdAt: "2025-06-24"
+  version: 0.64.17
+
+- changelogEntry:
+    - summary: |
         Add `fern export` command to export API to an OpenAPI spec.
       type: feat
   irVersion: 58


### PR DESCRIPTION
while we work on fixing local dev for windows users, we will pin them to the legacy dev environment 
