### PR TITLE
fix(cli): change global header examples to use wireValue instead of name

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/AbstractOperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/AbstractOperationConverter.ts
@@ -137,11 +137,17 @@ export abstract class AbstractOperationConverter extends AbstractConverter<
                             }
                         }
 
-                        if (
-                            !HEADERS_TO_SKIP.has(headerName.toLowerCase()) &&
-                            !duplicateHeader &&
-                            !this.context.globalHeaderNames?.includes(headerWireValue)
-                        ) {
+                        const globalHeaderNames = this.context.globalHeaderNames;
+                        if (globalHeaderNames != null) {
+                            for (const globalHeaderName of globalHeaderNames) {
+                                if (globalHeaderName.toLowerCase() === headerWireValue.toLowerCase()) {
+                                    duplicateHeader = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!HEADERS_TO_SKIP.has(headerName.toLowerCase()) && !duplicateHeader) {
                             headers.push(convertedParameter.parameter);
                         }
                         break;

--- a/packages/cli/api-importers/v2-importer-tests/src/__test__/__snapshots__/v3-docs/x-fern-global-headers.json
+++ b/packages/cli/api-importers/v2-importer-tests/src/__test__/__snapshots__/v3-docs/x-fern-global-headers.json
@@ -677,8 +677,8 @@
                   "headers": {
                     "x-api-key": "x-api-key",
                     "my-api-version": "my-api-version",
-                    "": "another_header",
-                    "Square-Version": "version"
+                    "another_header": "another_header",
+                    "version": "version"
                   },
                   "requestBody": {
                     "stream": true
@@ -1033,8 +1033,8 @@
                   "headers": {
                     "x-api-key": "x-api-key",
                     "my-api-version": "my-api-version",
-                    "": "another_header",
-                    "Square-Version": "version"
+                    "another_header": "another_header",
+                    "version": "version"
                   },
                   "requestBody": {
                     "stream": false

--- a/packages/cli/api-importers/v2-importer-tests/src/__test__/__snapshots__/v3-sdks/x-fern-global-headers.json
+++ b/packages/cli/api-importers/v2-importer-tests/src/__test__/__snapshots__/v3-sdks/x-fern-global-headers.json
@@ -1055,8 +1055,8 @@
                   "headers": {
                     "x-api-key": "x-api-key",
                     "my-api-version": "my-api-version",
-                    "": "another_header",
-                    "Square-Version": "version"
+                    "another_header": "another_header",
+                    "version": "version"
                   },
                   "requestBody": {
                     "stream": true
@@ -1787,8 +1787,8 @@
                   "headers": {
                     "x-api-key": "x-api-key",
                     "my-api-version": "my-api-version",
-                    "": "another_header",
-                    "Square-Version": "version"
+                    "another_header": "another_header",
+                    "version": "version"
                   },
                   "requestBody": {
                     "stream": false

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Update v2Examples to use the wire value for headers.
+      type: feat
+  irVersion: 58
+  createdAt: "2025-06-24"
+  version: 0.64.17
+
+- changelogEntry:
+    - summary: |
         Add `fern export` command to export API to an OpenAPI spec.
       type: feat
   irVersion: 58

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - changelogEntry:
     - summary: |
         Update v2Examples to use the wire value for headers.
-      type: feat
+      type: fix
   irVersion: 58
   createdAt: "2025-06-24"
   version: 0.64.17

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/oas-ir-fdr/x-fern-global-headers.json
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/oas-ir-fdr/x-fern-global-headers.json
@@ -182,8 +182,8 @@
               "headers": {
                 "x-api-key": "x-api-key",
                 "my-api-version": "my-api-version",
-                "": "another_header",
-                "Square-Version": "version"
+                "another_header": "another_header",
+                "version": "version"
               },
               "requestBody": {
                 "stream": true
@@ -304,8 +304,8 @@
               "headers": {
                 "x-api-key": "x-api-key",
                 "my-api-version": "my-api-version",
-                "": "another_header",
-                "Square-Version": "version"
+                "another_header": "another_header",
+                "version": "version"
               },
               "requestBody": {
                 "stream": false

--- a/packages/commons/ir-utils/src/examples/v2/getParameterExamples.ts
+++ b/packages/commons/ir-utils/src/examples/v2/getParameterExamples.ts
@@ -59,7 +59,7 @@ export function getParameterExamples({
         const { userExample, autoExample } = getFirstExamples(parameter.v2Examples);
 
         if (userExample !== undefined) {
-            result.headers[parameter.name.name.originalName] = userExample;
+            result.headers[parameter.name.wireValue] = userExample;
         } else if (autoExample !== undefined) {
             if (
                 skipOptionalRequestProperties &&
@@ -68,7 +68,7 @@ export function getParameterExamples({
                 continue;
             }
 
-            result.headers[parameter.name.name.originalName] = autoExample;
+            result.headers[parameter.name.wireValue] = autoExample;
         }
     }
 


### PR DESCRIPTION
## Description
-  change global header examples to use wireValue instead of name

## Testing
- [x] Unit tests added/updated
- [X] Manual testing completed

