### PR TITLE
fix(internal): ignore .preview dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ seed/python-sdk/**/output.prof
 
 # Cursor
 .cursor
+
+# Preview
+.preview/

--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ seed/python-sdk/**/output.prof
 .cursor
 
 # Preview
-.preview/
+**/.preview/


### PR DESCRIPTION
## Description
Sometimes stuff gets checked in from the .preview directory. We don't want that.

## Changes Made
- Added `.preview/` to the git ignore file

## Testing
Just a gitignore update
