### PR TITLE
chore(python): bump pydantic core dependency to >=2.18.2

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.23.1
+  changelogEntry:
+    - summary: |
+        Bump pydantic-core dependency to >=2.18.2 to ensure compatibility with newer pydantic versions and improve performance.
+      type: chore
+  createdAt: '2025-06-24'
+  irVersion: 58
+
 - version: 4.23.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/external_dependencies/pydantic.py
+++ b/generators/python/src/fern_python/external_dependencies/pydantic.py
@@ -2,7 +2,7 @@ import enum
 
 from fern_python.codegen import AST
 
-PYDANTIC_CORE_DEPENDENCY = AST.Dependency(name="pydantic-core", version="^2.18.2")
+PYDANTIC_CORE_DEPENDENCY = AST.Dependency(name="pydantic-core", version=">=2.18.2")
 PYDANTIC_DEPENDENCY = AST.Dependency(name="pydantic", version=">= 1.9.2")
 PYDANTIC_V1_DEPENDENCY = AST.Dependency(name="pydantic", version=">= 1.9.2,<= 1.10.14")
 PYDANTIC_V2_DEPENDENCY = AST.Dependency(name="pydantic", version=">= 2.0.0")

--- a/seed/python-sdk/imdb/poetry.lock
+++ b/seed/python-sdk/imdb/poetry.lock
@@ -547,4 +547,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9c462a453d491f6c13e77f216c114935f5785c9e0c2288839fb0862ea2551003"
+content-hash = "8551b871abee465e23fb0966d51f2c155fd257b55bdcb0c02d095de19f92f358"

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -37,7 +37,7 @@ Repository = 'https://github.com/imdb/fern'
 python = "^3.8"
 httpx = ">=0.21.2"
 pydantic = ">= 1.9.2"
-pydantic-core = "^2.18.2"
+pydantic-core = ">=2.18.2"
 typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/seed/python-sdk/imdb/requirements.txt
+++ b/seed/python-sdk/imdb/requirements.txt
@@ -1,4 +1,4 @@
 httpx>=0.21.2
 pydantic>= 1.9.2
-pydantic-core==2.18.2
+pydantic-core>=2.18.2
 typing_extensions>= 4.0.0


### PR DESCRIPTION
## Description
Bumps the pydantic core version to `>=2.18.2`

## Changes Made
- Allows for use with the latest version of pydantic

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed

