### PR TITLE
fix(ci): Throw error (rather than only logging it) if we get a parsing error

### DIFF
--- a/packages/seed/src/utils/convertVersionsFileToReleases.ts
+++ b/packages/seed/src/utils/convertVersionsFileToReleases.ts
@@ -28,9 +28,9 @@ export async function parseGeneratorReleasesFile({
                 });
                 await action(release);
             } catch (e) {
-                context.logger.error(
-                    `Failed to parse and run action on release ${JSON.stringify(entry)}: ${(e as Error)?.message}`
-                );
+                const errorMessage = `Failed to parse and run action on release ${JSON.stringify(entry)}: ${(e as Error)?.message}`;
+                context.logger.error(errorMessage);
+                throw new Error(errorMessage); // Throw to fail CI
             }
         }
     }
@@ -53,9 +53,9 @@ export async function parseCliReleasesFile({
                 const release = serializers.generators.CliReleaseRequest.parseOrThrow(entry);
                 await action(release);
             } catch (e) {
-                context.logger.error(
-                    `Failed to parse and run action on release ${JSON.stringify(entry)}: ${(e as Error)?.message}`
-                );
+                const errorMessage = `Failed to parse and run action on release ${JSON.stringify(entry)}: ${(e as Error)?.message}`;
+                context.logger.error(errorMessage);
+                throw new Error(errorMessage); // Throw to fail CI
             }
         }
     }

--- a/packages/seed/src/utils/convertVersionsFileToReleases.ts
+++ b/packages/seed/src/utils/convertVersionsFileToReleases.ts
@@ -28,7 +28,7 @@ export async function parseGeneratorReleasesFile({
                 });
                 await action(release);
             } catch (e) {
-                const errorMessage = `Failed to parse and run action on release ${JSON.stringify(entry)}: ${(e as Error)?.message}`;
+                const errorMessage = `Failed to parse and run action on release ${JSON.stringify(entry, undefined, 2)}: ${(e as Error)?.message}`;
                 context.logger.error(errorMessage);
                 throw new Error(errorMessage); // Throw to fail CI
             }
@@ -53,7 +53,7 @@ export async function parseCliReleasesFile({
                 const release = serializers.generators.CliReleaseRequest.parseOrThrow(entry);
                 await action(release);
             } catch (e) {
-                const errorMessage = `Failed to parse and run action on release ${JSON.stringify(entry)}: ${(e as Error)?.message}`;
+                const errorMessage = `Failed to parse and run action on release ${JSON.stringify(entry, undefined, 2)}: ${(e as Error)?.message}`;
                 context.logger.error(errorMessage);
                 throw new Error(errorMessage); // Throw to fail CI
             }


### PR DESCRIPTION
## Description
Follow up from [this](https://buildwithfern.slack.com/archives/C05J55L8JES/p1750792102610959) slack conversation. Currently, these errors are logged but the script keeps running and thus people don't notice the failure. 

## Changes Made
- Throw parsing error, in addition to logging it, when encountered.

## Testing
Tested locally, will keep an eye on CI

