### PR TITLE
fix(cli): fern check doesnt fail on global header examples

### DIFF
--- a/fern/pages/changelogs/cli/2025-06-25.mdx
+++ b/fern/pages/changelogs/cli/2025-06-25.mdx
@@ -1,3 +1,9 @@
+## 0.64.23
+**`(fix):`** Global headers are now used to create endpoint examples. When building endpoint examples, global headers 
+are automatically included in the headers section of each example. This ensures that all endpoints have consistent 
+header examples that match the global header configuration.
+
+
 ## 0.64.22
 **`(feat):`** Make proto file target field optional in generators.yml
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/ExampleEndpointFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/ExampleEndpointFactory.ts
@@ -8,9 +8,12 @@ import {
     EndpointWithExample,
     FernOpenapiIr,
     FullExample,
+    GlobalHeader,
     HeaderExample,
+    HeaderWithExample,
     NamedFullExample,
     PathParameterExample,
+    PrimitiveSchemaValueWithExample,
     QueryParameterExample,
     RequestWithExample,
     ResponseWithExample,
@@ -31,7 +34,8 @@ export class ExampleEndpointFactory {
 
     constructor(
         private readonly schemas: Record<string, SchemaWithExample>,
-        private readonly context: OpenAPIV3ParserContext
+        private readonly context: OpenAPIV3ParserContext,
+        private readonly globalHeaders: GlobalHeader[]
     ) {
         this.schemas = schemas;
         this.exampleTypeFactory = new ExampleTypeFactory(schemas, context.nonRequestReferencedSchemas, context);
@@ -261,6 +265,55 @@ export class ExampleEndpointFactory {
             } else if (example != null) {
                 headers.push({
                     name: header.name,
+                    value: example
+                });
+            }
+        }
+
+        // Add global headers to examples
+        for (const globalHeader of this.globalHeaders) {
+            const schema = globalHeader.schema != null ? convertSchemaToSchemaWithExample(globalHeader.schema) : SchemaWithExample.primitive({
+                nameOverride: undefined,
+                generatedName: "",
+                title: undefined,
+                description: undefined,
+                availability: undefined,
+                namespace: undefined,
+                groupName: undefined,
+                schema: PrimitiveSchemaValueWithExample.string({
+                    default: undefined,
+                    pattern: undefined,
+                    maxLength: undefined,
+                    minLength: undefined,
+                    example: undefined,
+                    format: undefined
+                })
+            });
+            
+            let example = this.exampleTypeFactory.buildExample({
+                schema,
+                exampleId: undefined,
+                example: undefined,
+                options: {
+                    name: globalHeader.header,
+                    isParameter: true,
+                    ignoreOptionals: true
+                }
+            });
+            
+            if (example != null && !isExamplePrimitive(example)) {
+                this.logger.warn(
+                    `Expected a primitive example but got ${example.type} for global header ${
+                        globalHeader.header
+                    } for ${endpoint.method.toUpperCase()} ${endpoint.path}`
+                );
+                example = undefined;
+            }
+            if (example == null) {
+                return [];
+            } else if (example != null) {
+                headers.push({
+                    name: globalHeader.header,
                     value: example
                 });
             }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -234,7 +234,7 @@ export function generateIr({
         };
     });
 
-    const exampleEndpointFactory = new ExampleEndpointFactory(schemasWithDiscriminants, context);
+    const exampleEndpointFactory = new ExampleEndpointFactory(schemasWithDiscriminants, context, globalHeaders);
     const endpoints = endpointsWithExample.map((endpointWithExample): Endpoint => {
         // if x-fern-examples is not present, generate an example
         const extensionExamples = endpointWithExample.examples;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/axle.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/axle.json
@@ -405,7 +405,10 @@
               "docs": "The Get Account method will return an Account object including high-level account information (e.g., name) and any children objects (e.g., Policies) associated with the Account. Please note that this method will NOT refresh the Account object.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -654,7 +657,9 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -690,7 +695,10 @@ service:
               "docs": "The Get Carrier method returns a Carrier object that include additional details about an Axle-supported insurance carrier.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -741,7 +749,10 @@ service:
               "docs": "The Get Carriers method returns an array of Carrier objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -844,7 +855,9 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -875,7 +888,9 @@ service:
         type: GetCarriersResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -907,7 +922,10 @@ service:
               "docs": "Start an Ignition session. Returns the ignitionUri to direct the user to authenticate.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "request": {
                     "redirectUri": "https://example.com/redirect",
                     "webhookUri": "https://example.com/webhook",
@@ -1060,7 +1078,9 @@ service:
         type: StartIgnitionResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           request:
             redirectUri: https://example.com/redirect
             webhookUri: https://example.com/webhook
@@ -1091,7 +1111,10 @@ service:
               "docs": "The Get Policy method returns a Policy object including high-level policy information (e.g., policy number) and any children objects (e.g., Coverages) associated with the Policy. Please note that this method will NOT refresh the Policy object.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -1260,7 +1283,9 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -1335,7 +1360,10 @@ service:
 Auth codes are ephemeral and expire after 10 minutes, while accessTokens do not expire.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "request": {
                     "authCode": "authCode",
                   },
@@ -1489,7 +1517,9 @@ service:
         type: ExchangeTokenResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           request:
             authCode: authCode
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/corti.json
@@ -5798,7 +5798,9 @@ navigation:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -5881,7 +5883,9 @@ navigation:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -5934,7 +5938,9 @@ navigation:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6048,7 +6054,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               codes:
@@ -6099,7 +6106,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             modelName: '"geography_modelName (Latest)" | "geography_modelName_version"'
             context:
@@ -6148,7 +6156,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -6197,7 +6206,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "documentId": "documentId",
                     "id": "id",
@@ -6341,7 +6352,9 @@ types:
                       "name": "from string",
                     },
                   ],
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6445,7 +6458,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "documentId": "documentId",
                     "id": "id",
@@ -6516,7 +6531,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6570,7 +6587,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "documentId": "documentId",
                     "id": "id",
@@ -6707,7 +6726,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -6773,7 +6793,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             context:
               - type: facts
@@ -6923,7 +6944,8 @@ service:
         - path-parameters:
             id: id
             documentId: documentId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -6971,7 +6993,8 @@ service:
         - path-parameters:
             id: id
             documentId: documentId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -7015,7 +7038,8 @@ service:
         - path-parameters:
             id: id
             documentId: documentId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -7079,7 +7103,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -7150,7 +7176,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -7187,7 +7215,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -7239,7 +7269,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "factId": "factId",
                     "id": "id",
@@ -7320,7 +7352,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -7456,7 +7490,8 @@ service:
       errors:
         - root.GetFactgroupsRequestInternalServerError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -7487,7 +7522,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               facts:
@@ -7534,7 +7570,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             facts:
               - text: text
@@ -7580,7 +7617,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             facts:
               - factId: factId
@@ -7639,7 +7677,8 @@ service:
         - path-parameters:
             id: id
             factId: factId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             text: text
             source: core
@@ -7711,7 +7750,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "request": {
                     "encounter": {
                       "identifier": "identifier",
@@ -7775,7 +7816,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -7814,7 +7857,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -7876,7 +7921,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "interactions": [
@@ -7956,7 +8003,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -8090,7 +8139,8 @@ service:
         - root.GetInteractionsRequestForbiddenError
         - root.GetInteractionsRequestGatewayTimeoutError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               interactions:
@@ -8145,7 +8195,8 @@ service:
         - root.PostInteractionsRequestInternalServerError
         - root.PostInteractionsRequestGatewayTimeoutError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           request:
             encounter:
               identifier: identifier
@@ -8181,7 +8232,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -8231,7 +8283,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -8275,7 +8328,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -8326,7 +8380,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                     "recordingId": "recordingId",
@@ -8405,7 +8461,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -8506,7 +8564,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               recordings:
@@ -8600,7 +8659,8 @@ service:
         - path-parameters:
             id: id
             recordingId: recordingId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -9162,7 +9222,9 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "key": "key",
                   },
@@ -9217,7 +9279,9 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -9274,7 +9338,9 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -9362,7 +9428,8 @@ service:
         - root.GetTemplateSectionsRequestUnauthorizedError
         - root.GetTemplateSectionsRequestInternalServerError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -9403,7 +9470,8 @@ service:
         - root.GetTemplatesRequestUnauthorizedError
         - root.GetTemplatesRequestInternalServerError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -9438,7 +9506,8 @@ service:
       examples:
         - path-parameters:
             key: key
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               date_updated: '2024-01-15T09:30:00Z'
@@ -9479,7 +9548,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -9580,7 +9651,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                     "transcriptId": "transcriptId",
@@ -9627,7 +9700,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                     "transcriptId": "transcriptId",
@@ -9689,7 +9764,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -9825,7 +9902,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               transcripts:
@@ -9898,7 +9976,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             recordingId: recordingId
             primaryLanguage: primaryLanguage
@@ -9951,7 +10030,8 @@ service:
         - path-parameters:
             id: id
             transcriptId: transcriptId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -10001,7 +10081,8 @@ service:
         - path-parameters:
             id: id
             transcriptId: transcriptId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/merge.json
@@ -9725,7 +9725,9 @@ Fetch from the `LIST TimeOffs` endpoint and filter by `ID` to show all time off 
               "docs": "Get details for a linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "category": "hris",
@@ -9778,7 +9780,8 @@ service:
         type: root.AccountDetails
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 0496d4c2-42e6-4072-80b3-7b69bfdc76fd
@@ -9913,7 +9916,9 @@ service:
               "docs": "Returns a list of models and actions available for an account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "available_model_operations": [
@@ -9989,7 +9994,8 @@ service:
         type: root.AvailableActions
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               integration:
@@ -10035,7 +10041,9 @@ service:
               "docs": "Returns a list of `BankInfo` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -10163,7 +10171,9 @@ service:
               "docs": "Returns a `BankInfo` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -10372,7 +10382,8 @@ service:
         type: root.PaginatedBankInfoList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -10432,7 +10443,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: fd1e0fb5-8f92-4ec9-9f32-179cf732867d
@@ -10473,7 +10485,9 @@ service:
               "docs": "Returns a list of `Benefit` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -10579,7 +10593,9 @@ service:
               "docs": "Returns a `Benefit` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -10718,7 +10734,8 @@ service:
         type: root.PaginatedBenefitList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -10773,7 +10790,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 3fe5ae7a-f1ba-4529-b7af-84e86dc6d232
@@ -10815,7 +10833,9 @@ service:
               "docs": "Returns a list of `Company` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -10913,7 +10933,9 @@ service:
               "docs": "Returns a `Company` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -11038,7 +11060,8 @@ service:
         type: root.PaginatedCompanyList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -11087,7 +11110,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 1b998423-db0a-4037-a4cf-f79c60cb67b3
@@ -11125,7 +11149,9 @@ service:
               "docs": "Delete a linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                 },
               ],
               "method": "POST",
@@ -11153,7 +11179,8 @@ service:
       source:
         openapi: ../openapi.yml
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
   source:
     openapi: ../openapi.yml
 ",
@@ -11173,7 +11200,9 @@ service:
               "docs": "Returns a list of `EmployeePayrollRun` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -11335,7 +11364,9 @@ service:
               "docs": "Returns an `EmployeePayrollRun` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -11645,7 +11676,8 @@ service:
         type: root.PaginatedEmployeePayrollRunList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -11725,7 +11757,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: fb8c55b6-1cb8-4b4c-9fb6-17924231619d
@@ -11830,7 +11863,9 @@ service:
               "docs": "Creates an `Employee` object with the given values.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "model": {},
                   },
@@ -11964,7 +11999,9 @@ service:
               "docs": "Ignores a specific row based on the `model_id` in the url. These records will have their properties set to null, and will not be updated in future syncs. The "reason" and "message" fields in the request body will be stored for audit purposes.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "model_id": "model_id",
                   },
@@ -12009,7 +12046,9 @@ service:
               "docs": "Returns a list of `Employee` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -12229,7 +12268,9 @@ service:
               "docs": "Returns metadata for `Employee` POSTs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "has_conditional_params": true,
@@ -12265,7 +12306,9 @@ service:
               "docs": "Returns an `Employee` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -15908,7 +15951,8 @@ service:
         type: root.PaginatedEmployeeList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -15984,7 +16028,8 @@ service:
         type: root.EmployeeResponse
         status-code: 201
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             model: {}
           response:
@@ -16093,7 +16138,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 0958cbc6-6040-430a-848e-aafacbadf4ae
@@ -16166,7 +16212,8 @@ service:
       examples:
         - path-parameters:
             model_id: model_id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           request:
             reason: GENERAL_CUSTOMER_REQUEST
     metaPostRetrieve:
@@ -16181,7 +16228,8 @@ service:
         type: root.MetaResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               request_schema:
@@ -16212,7 +16260,9 @@ service:
               "docs": "Returns a list of `Employment` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -16333,7 +16383,9 @@ service:
               "docs": "Returns an `Employment` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -16905,7 +16957,8 @@ service:
         type: root.PaginatedEmploymentList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -16969,7 +17022,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 65d8ffd0-211b-4ba4-b85a-fbe2ce220982
@@ -17014,7 +17068,9 @@ service:
               "docs": "Force re-sync of all models. This is available for all organizations via the dashboard. Force re-sync is also available programmatically via API for monthly, quarterly, and highest sync frequency customers on the Core, Professional, or Enterprise plans. Doing so will consume a sync credit for the relevant linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": [
                       {
@@ -17071,7 +17127,8 @@ service:
         type: list<root.SyncStatus>
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               - model_name: Employee
@@ -17201,7 +17258,9 @@ service:
               "docs": "Returns a list of `Group` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -17307,7 +17366,9 @@ service:
               "docs": "Returns a `Group` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -17447,7 +17508,8 @@ service:
         type: root.PaginatedGroupList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -17499,7 +17561,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 134e0111-0f67-44f6-98f0-597000290bb3
@@ -18365,7 +18428,9 @@ service:
               "docs": "Returns a list of `Location` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -18473,7 +18538,9 @@ service:
               "docs": "Returns a `Location` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -18614,7 +18681,8 @@ service:
         type: root.PaginatedLocationList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -18672,7 +18740,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: f5e6a151-f44e-449a-afb1-8fd781905958
@@ -18716,7 +18785,9 @@ service:
               "docs": "Pull data from an endpoint not currently supported by Merge.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "method": "GET",
                     "path": "/scooters",
@@ -18867,7 +18938,8 @@ service:
         type: root.RemoteResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             method: GET
             path: /scooters
@@ -18903,7 +18975,9 @@ service:
               "docs": "Returns a list of `PayGroup` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -18995,7 +19069,9 @@ service:
               "docs": "Returns a `PayGroup` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -19114,7 +19190,8 @@ service:
         type: root.PaginatedPayGroupList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -19158,7 +19235,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: fd1e0fb5-8f92-4ec9-9f32-179cf732867d
@@ -19194,7 +19272,9 @@ service:
               "docs": "Returns a list of `PayrollRun` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -19324,7 +19404,9 @@ service:
               "docs": "Returns a `PayrollRun` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -19611,7 +19693,8 @@ service:
         type: root.PaginatedPayrollRunList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -19665,7 +19748,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 37336947-b3d4-4a4c-a310-ab6ab510e079
@@ -19806,7 +19890,9 @@ service:
               "docs": "Get a linked account's selective syncs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "name": "Employees that started on or after January 1st, 2022",
                   "response": {
                     "body": [
@@ -19843,7 +19929,9 @@ service:
               "docs": "Replace a linked account's selective syncs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "name": "Employees that started on or after January 1st, 2022",
                   "request": {
                     "sync_configurations": [
@@ -19902,7 +19990,9 @@ service:
               "docs": "Get metadata for the conditions available to a linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "name": "Employees that started on or after January 1st, 2022",
                   "response": {
                     "body": {
@@ -19983,7 +20073,8 @@ service:
         status-code: 200
       examples:
         - name: Employees that started on or after January 1st, 2022
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               - linked_account_conditions:
@@ -20014,7 +20105,8 @@ service:
         status-code: 200
       examples:
         - name: Employees that started on or after January 1st, 2022
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           request:
             sync_configurations:
               - linked_account_conditions: []
@@ -20050,7 +20142,8 @@ service:
         status-code: 200
       examples:
         - name: Employees that started on or after January 1st, 2022
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -20086,7 +20179,9 @@ service:
               "docs": "Get syncing status. Possible values: `DISABLED`, `DONE`, `FAILED`, `PARTIALLY_SYNCED`, `PAUSED`, `SYNCING`",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -20166,7 +20261,8 @@ service:
         type: root.PaginatedSyncStatusList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -20198,7 +20294,9 @@ service:
               "docs": "Returns a list of `Team` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -20299,7 +20397,9 @@ service:
               "docs": "Returns a `Team` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -20431,7 +20531,8 @@ service:
         type: root.PaginatedTeamList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -20481,7 +20582,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 13a72919-9fae-4f54-81ca-ddfd8712a1ba
@@ -20518,7 +20620,9 @@ service:
               "docs": "Creates a `TimeOff` object with the given values.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "model": {},
                   },
@@ -20628,7 +20732,9 @@ service:
               "docs": "Returns a list of `TimeOff` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -20769,7 +20875,9 @@ service:
               "docs": "Returns metadata for `TimeOff` POSTs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "has_conditional_params": true,
@@ -20805,7 +20913,9 @@ service:
               "docs": "Returns a `TimeOff` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -21257,7 +21367,8 @@ service:
         type: root.PaginatedTimeOffList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -21312,7 +21423,8 @@ service:
         type: root.TimeOffResponse
         status-code: 201
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             model: {}
           response:
@@ -21395,7 +21507,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 91b2b905-e866-40c8-8be2-efe53827a0aa
@@ -21432,7 +21545,8 @@ service:
         type: root.MetaResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               request_schema:
@@ -21463,7 +21577,9 @@ service:
               "docs": "Returns a list of `TimeOffBalance` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -21585,7 +21701,9 @@ service:
               "docs": "Returns a `TimeOffBalance` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -21779,7 +21897,8 @@ service:
         type: root.PaginatedTimeOffBalanceList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -21837,7 +21956,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 91b2b905-e866-40c8-8be2-efe53827a0aa
@@ -21876,7 +21996,9 @@ service:
               "docs": "Creates a `WebhookReceiver` object with the given values.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "event": "event",
                     "is_active": true,
@@ -21937,7 +22059,9 @@ service:
               "docs": "Returns a list of `WebhookReceiver` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": [
                       {
@@ -21985,7 +22109,8 @@ service:
         type: list<root.WebhookReceiver>
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               - event: event
@@ -22017,7 +22142,8 @@ service:
         type: root.WebhookReceiver
         status-code: 201
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             event: event
             is_active: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-global-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-global-headers.json
@@ -82,7 +82,13 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "another_header": "another_header",
+                    "my-api-key": "my-api-key",
+                    "my-api-version": "my-api-version",
+                    "version": "2024-06-04",
+                    "x-api-key": "x-api-key",
+                  },
                   "path-parameters": {
                     "userId": "userId",
                   },
@@ -135,7 +141,13 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "another_header": "another_header",
+                    "my-api-key": "my-api-key",
+                    "my-api-version": "my-api-version",
+                    "version": "2024-06-04",
+                    "x-api-key": "x-api-key",
+                  },
                   "path-parameters": {
                     "userId": "userId",
                   },
@@ -221,7 +233,12 @@ service:
       examples:
         - path-parameters:
             userId: userId
-          headers: {}
+          headers:
+            my-api-key: my-api-key
+            another_header: another_header
+            x-api-key: x-api-key
+            my-api-version: my-api-version
+            version: '2024-06-04'
           request:
             stream: true
           response:
@@ -251,7 +268,12 @@ service:
       examples:
         - path-parameters:
             userId: userId
-          headers: {}
+          headers:
+            my-api-key: my-api-key
+            another_header: another_header
+            x-api-key: x-api-key
+            my-api-version: my-api-version
+            version: '2024-06-04'
           request:
             stream: false
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-parameter-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-parameter-name.json
@@ -14,7 +14,9 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-API-Version": "X-API-Version",
+                  },
                   "path-parameters": {
                     "id": "userId",
                   },
@@ -83,7 +85,8 @@
             id: userId
           query-parameters:
             foo: foo
-          headers: {}
+          headers:
+            X-API-Version: X-API-Version
           response:
             body: string
   source:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-global-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-global-headers.json
@@ -226,6 +226,36 @@
                 },
                 "type": "primitive"
               }
+            },
+            {
+              "name": "my-api-key",
+              "value": {
+                "value": {
+                  "value": "my-api-key",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            {
+              "name": "another_header",
+              "value": {
+                "value": {
+                  "value": "another_header",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            {
+              "name": "version",
+              "value": {
+                "value": {
+                  "value": "2024-06-04",
+                  "type": "string"
+                },
+                "type": "literal"
+              }
             }
           ],
           "request": {
@@ -484,6 +514,36 @@
                   "type": "string"
                 },
                 "type": "primitive"
+              }
+            },
+            {
+              "name": "my-api-key",
+              "value": {
+                "value": {
+                  "value": "my-api-key",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            {
+              "name": "another_header",
+              "value": {
+                "value": {
+                  "value": "another_header",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            {
+              "name": "version",
+              "value": {
+                "value": {
+                  "value": "2024-06-04",
+                  "type": "string"
+                },
+                "type": "literal"
               }
             }
           ],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/axle.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/axle.json
@@ -405,7 +405,10 @@
               "docs": "The Get Account method will return an Account object including high-level account information (e.g., name) and any children objects (e.g., Policies) associated with the Account. Please note that this method will NOT refresh the Account object.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -654,7 +657,9 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -690,7 +695,10 @@ service:
               "docs": "The Get Carrier method returns a Carrier object that include additional details about an Axle-supported insurance carrier.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -741,7 +749,10 @@ service:
               "docs": "The Get Carriers method returns an array of Carrier objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -844,7 +855,9 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -875,7 +888,9 @@ service:
         type: GetCarriersResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -907,7 +922,10 @@ service:
               "docs": "Start an Ignition session. Returns the ignitionUri to direct the user to authenticate.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "request": {
                     "redirectUri": "https://example.com/redirect",
                     "webhookUri": "https://example.com/webhook",
@@ -1060,7 +1078,9 @@ service:
         type: StartIgnitionResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           request:
             redirectUri: https://example.com/redirect
             webhookUri: https://example.com/webhook
@@ -1091,7 +1111,10 @@ service:
               "docs": "The Get Policy method returns a Policy object including high-level policy information (e.g., policy number) and any children objects (e.g., Coverages) associated with the Policy. Please note that this method will NOT refresh the Policy object.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -1260,7 +1283,9 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           response:
             body:
               success: true
@@ -1335,7 +1360,10 @@ service:
 Auth codes are ephemeral and expire after 10 minutes, while accessTokens do not expire.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "x-client-id": "x-client-id",
+                    "x-client-secret": "x-client-secret",
+                  },
                   "request": {
                     "authCode": "authCode",
                   },
@@ -1489,7 +1517,9 @@ service:
         type: ExchangeTokenResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            x-client-id: x-client-id
+            x-client-secret: x-client-secret
           request:
             authCode: authCode
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/corti.json
@@ -4250,7 +4250,9 @@ navigation:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -4333,7 +4335,9 @@ navigation:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -4386,7 +4390,9 @@ navigation:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -4500,7 +4506,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               codes:
@@ -4551,7 +4558,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             modelName: '"geography_modelName (Latest)" | "geography_modelName_version"'
             context:
@@ -4600,7 +4608,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -4649,7 +4658,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "documentId": "documentId",
                     "id": "id",
@@ -4793,7 +4804,9 @@ types:
                       "name": "from string",
                     },
                   ],
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -4897,7 +4910,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "documentId": "documentId",
                     "id": "id",
@@ -4968,7 +4983,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -5022,7 +5039,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "documentId": "documentId",
                     "id": "id",
@@ -5159,7 +5178,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -5225,7 +5245,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             context:
               - type: facts
@@ -5375,7 +5396,8 @@ service:
         - path-parameters:
             id: id
             documentId: documentId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -5423,7 +5445,8 @@ service:
         - path-parameters:
             id: id
             documentId: documentId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -5467,7 +5490,8 @@ service:
         - path-parameters:
             id: id
             documentId: documentId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -5531,7 +5555,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -5602,7 +5628,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -5639,7 +5667,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -5691,7 +5721,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "factId": "factId",
                     "id": "id",
@@ -5772,7 +5804,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -5908,7 +5942,8 @@ service:
       errors:
         - root.InternalServerError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -5939,7 +5974,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               facts:
@@ -5986,7 +6022,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             facts:
               - text: text
@@ -6032,7 +6069,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             facts:
               - factId: factId
@@ -6091,7 +6129,8 @@ service:
         - path-parameters:
             id: id
             factId: factId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             text: text
             source: core
@@ -6163,7 +6202,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "request": {
                     "encounter": {
                       "identifier": "identifier",
@@ -6227,7 +6268,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6266,7 +6309,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6328,7 +6373,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "interactions": [
@@ -6408,7 +6455,9 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6542,7 +6591,8 @@ service:
         - root.ForbiddenError
         - root.GatewayTimeoutError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               interactions:
@@ -6597,7 +6647,8 @@ service:
         - root.InternalServerError
         - root.GatewayTimeoutError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           request:
             encounter:
               identifier: identifier
@@ -6633,7 +6684,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -6683,7 +6735,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -6727,7 +6780,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -6778,7 +6832,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                     "recordingId": "recordingId",
@@ -6857,7 +6913,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -6958,7 +7016,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               recordings:
@@ -7050,7 +7109,8 @@ service:
         - path-parameters:
             id: id
             recordingId: recordingId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -7612,7 +7672,9 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "key": "key",
                   },
@@ -7667,7 +7729,9 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -7724,7 +7788,9 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "response": {
                     "body": {
                       "data": [
@@ -7812,7 +7878,8 @@ service:
         - root.UnauthorizedError
         - root.InternalServerError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -7853,7 +7920,8 @@ service:
         - root.UnauthorizedError
         - root.InternalServerError
       examples:
-        - headers: {}
+        - headers:
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -7888,7 +7956,8 @@ service:
       examples:
         - path-parameters:
             key: key
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               date_updated: '2024-01-15T09:30:00Z'
@@ -7929,7 +7998,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -8030,7 +8101,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                     "transcriptId": "transcriptId",
@@ -8077,7 +8150,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                     "transcriptId": "transcriptId",
@@ -8139,7 +8214,9 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "Tenant-Name": "copiloteu",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -8275,7 +8352,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               transcripts:
@@ -8348,7 +8426,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           request:
             recordingId: recordingId
             primaryLanguage: primaryLanguage
@@ -8399,7 +8478,8 @@ service:
         - path-parameters:
             id: id
             transcriptId: transcriptId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -8446,7 +8526,8 @@ service:
         - path-parameters:
             id: id
             transcriptId: transcriptId
-          headers: {}
+          headers:
+            Tenant-Name: copiloteu
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/merge.json
@@ -9725,7 +9725,9 @@ Fetch from the `LIST TimeOffs` endpoint and filter by `ID` to show all time off 
               "docs": "Get details for a linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "category": "hris",
@@ -9778,7 +9780,8 @@ service:
         type: root.AccountDetails
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 0496d4c2-42e6-4072-80b3-7b69bfdc76fd
@@ -9913,7 +9916,9 @@ service:
               "docs": "Returns a list of models and actions available for an account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "available_model_operations": [
@@ -9989,7 +9994,8 @@ service:
         type: root.AvailableActions
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               integration:
@@ -10035,7 +10041,9 @@ service:
               "docs": "Returns a list of `BankInfo` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -10163,7 +10171,9 @@ service:
               "docs": "Returns a `BankInfo` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -10372,7 +10382,8 @@ service:
         type: root.PaginatedBankInfoList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -10432,7 +10443,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: fd1e0fb5-8f92-4ec9-9f32-179cf732867d
@@ -10473,7 +10485,9 @@ service:
               "docs": "Returns a list of `Benefit` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -10579,7 +10593,9 @@ service:
               "docs": "Returns a `Benefit` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -10718,7 +10734,8 @@ service:
         type: root.PaginatedBenefitList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -10773,7 +10790,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 3fe5ae7a-f1ba-4529-b7af-84e86dc6d232
@@ -10815,7 +10833,9 @@ service:
               "docs": "Returns a list of `Company` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -10913,7 +10933,9 @@ service:
               "docs": "Returns a `Company` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -11038,7 +11060,8 @@ service:
         type: root.PaginatedCompanyList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -11087,7 +11110,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 1b998423-db0a-4037-a4cf-f79c60cb67b3
@@ -11125,7 +11149,9 @@ service:
               "docs": "Delete a linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                 },
               ],
               "method": "POST",
@@ -11153,7 +11179,8 @@ service:
       source:
         openapi: ../openapi.yml
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
   source:
     openapi: ../openapi.yml
 ",
@@ -11173,7 +11200,9 @@ service:
               "docs": "Returns a list of `EmployeePayrollRun` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -11335,7 +11364,9 @@ service:
               "docs": "Returns an `EmployeePayrollRun` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -11645,7 +11676,8 @@ service:
         type: root.PaginatedEmployeePayrollRunList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -11725,7 +11757,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: fb8c55b6-1cb8-4b4c-9fb6-17924231619d
@@ -11830,7 +11863,9 @@ service:
               "docs": "Creates an `Employee` object with the given values.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "model": {},
                   },
@@ -11964,7 +11999,9 @@ service:
               "docs": "Ignores a specific row based on the `model_id` in the url. These records will have their properties set to null, and will not be updated in future syncs. The "reason" and "message" fields in the request body will be stored for audit purposes.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "model_id": "model_id",
                   },
@@ -12009,7 +12046,9 @@ service:
               "docs": "Returns a list of `Employee` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -12229,7 +12268,9 @@ service:
               "docs": "Returns metadata for `Employee` POSTs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "has_conditional_params": true,
@@ -12265,7 +12306,9 @@ service:
               "docs": "Returns an `Employee` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -15908,7 +15951,8 @@ service:
         type: root.PaginatedEmployeeList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -15984,7 +16028,8 @@ service:
         type: root.EmployeeResponse
         status-code: 201
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             model: {}
           response:
@@ -16093,7 +16138,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 0958cbc6-6040-430a-848e-aafacbadf4ae
@@ -16166,7 +16212,8 @@ service:
       examples:
         - path-parameters:
             model_id: model_id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           request:
             reason: GENERAL_CUSTOMER_REQUEST
     metaPostRetrieve:
@@ -16181,7 +16228,8 @@ service:
         type: root.MetaResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               request_schema:
@@ -16212,7 +16260,9 @@ service:
               "docs": "Returns a list of `Employment` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -16333,7 +16383,9 @@ service:
               "docs": "Returns an `Employment` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -16905,7 +16957,8 @@ service:
         type: root.PaginatedEmploymentList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -16969,7 +17022,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 65d8ffd0-211b-4ba4-b85a-fbe2ce220982
@@ -17014,7 +17068,9 @@ service:
               "docs": "Force re-sync of all models. This is available for all organizations via the dashboard. Force re-sync is also available programmatically via API for monthly, quarterly, and highest sync frequency customers on the Core, Professional, or Enterprise plans. Doing so will consume a sync credit for the relevant linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": [
                       {
@@ -17071,7 +17127,8 @@ service:
         type: list<root.SyncStatus>
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               - model_name: Employee
@@ -17201,7 +17258,9 @@ service:
               "docs": "Returns a list of `Group` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -17307,7 +17366,9 @@ service:
               "docs": "Returns a `Group` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -17447,7 +17508,8 @@ service:
         type: root.PaginatedGroupList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -17499,7 +17561,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 134e0111-0f67-44f6-98f0-597000290bb3
@@ -18365,7 +18428,9 @@ service:
               "docs": "Returns a list of `Location` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -18473,7 +18538,9 @@ service:
               "docs": "Returns a `Location` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -18614,7 +18681,8 @@ service:
         type: root.PaginatedLocationList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -18672,7 +18740,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: f5e6a151-f44e-449a-afb1-8fd781905958
@@ -18716,7 +18785,9 @@ service:
               "docs": "Pull data from an endpoint not currently supported by Merge.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "method": "GET",
                     "path": "/scooters",
@@ -18867,7 +18938,8 @@ service:
         type: root.RemoteResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             method: GET
             path: /scooters
@@ -18903,7 +18975,9 @@ service:
               "docs": "Returns a list of `PayGroup` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -18995,7 +19069,9 @@ service:
               "docs": "Returns a `PayGroup` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -19114,7 +19190,8 @@ service:
         type: root.PaginatedPayGroupList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -19158,7 +19235,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: fd1e0fb5-8f92-4ec9-9f32-179cf732867d
@@ -19194,7 +19272,9 @@ service:
               "docs": "Returns a list of `PayrollRun` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -19324,7 +19404,9 @@ service:
               "docs": "Returns a `PayrollRun` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -19611,7 +19693,8 @@ service:
         type: root.PaginatedPayrollRunList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -19665,7 +19748,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 37336947-b3d4-4a4c-a310-ab6ab510e079
@@ -19806,7 +19890,9 @@ service:
               "docs": "Get a linked account's selective syncs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "name": "Employees that started on or after January 1st, 2022",
                   "response": {
                     "body": [
@@ -19843,7 +19929,9 @@ service:
               "docs": "Replace a linked account's selective syncs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "name": "Employees that started on or after January 1st, 2022",
                   "request": {
                     "sync_configurations": [
@@ -19902,7 +19990,9 @@ service:
               "docs": "Get metadata for the conditions available to a linked account.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "name": "Employees that started on or after January 1st, 2022",
                   "response": {
                     "body": {
@@ -19983,7 +20073,8 @@ service:
         status-code: 200
       examples:
         - name: Employees that started on or after January 1st, 2022
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               - linked_account_conditions:
@@ -20014,7 +20105,8 @@ service:
         status-code: 200
       examples:
         - name: Employees that started on or after January 1st, 2022
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           request:
             sync_configurations:
               - linked_account_conditions: []
@@ -20050,7 +20142,8 @@ service:
         status-code: 200
       examples:
         - name: Employees that started on or after January 1st, 2022
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -20086,7 +20179,9 @@ service:
               "docs": "Get syncing status. Possible values: `DISABLED`, `DONE`, `FAILED`, `PARTIALLY_SYNCED`, `PAUSED`, `SYNCING`",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -20166,7 +20261,8 @@ service:
         type: root.PaginatedSyncStatusList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -20198,7 +20294,9 @@ service:
               "docs": "Returns a list of `Team` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -20299,7 +20397,9 @@ service:
               "docs": "Returns a `Team` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -20431,7 +20531,8 @@ service:
         type: root.PaginatedTeamList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -20481,7 +20582,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 13a72919-9fae-4f54-81ca-ddfd8712a1ba
@@ -20518,7 +20620,9 @@ service:
               "docs": "Creates a `TimeOff` object with the given values.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "model": {},
                   },
@@ -20628,7 +20732,9 @@ service:
               "docs": "Returns a list of `TimeOff` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -20769,7 +20875,9 @@ service:
               "docs": "Returns metadata for `TimeOff` POSTs.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "has_conditional_params": true,
@@ -20805,7 +20913,9 @@ service:
               "docs": "Returns a `TimeOff` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -21257,7 +21367,8 @@ service:
         type: root.PaginatedTimeOffList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -21312,7 +21423,8 @@ service:
         type: root.TimeOffResponse
         status-code: 201
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             model: {}
           response:
@@ -21395,7 +21507,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 91b2b905-e866-40c8-8be2-efe53827a0aa
@@ -21432,7 +21545,8 @@ service:
         type: root.MetaResponse
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               request_schema:
@@ -21463,7 +21577,9 @@ service:
               "docs": "Returns a list of `TimeOffBalance` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -21585,7 +21701,9 @@ service:
               "docs": "Returns a `TimeOffBalance` object with the given `id`.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "path-parameters": {
                     "id": "id",
                   },
@@ -21779,7 +21897,8 @@ service:
         type: root.PaginatedTimeOffBalanceList
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -21837,7 +21956,8 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers: {}
+          headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               id: 91b2b905-e866-40c8-8be2-efe53827a0aa
@@ -21876,7 +21996,9 @@ service:
               "docs": "Creates a `WebhookReceiver` object with the given values.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "request": {
                     "event": "event",
                     "is_active": true,
@@ -21937,7 +22059,9 @@ service:
               "docs": "Returns a list of `WebhookReceiver` objects.",
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-Account-Token": "X-Account-Token",
+                  },
                   "response": {
                     "body": [
                       {
@@ -21985,7 +22109,8 @@ service:
         type: list<root.WebhookReceiver>
         status-code: 200
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           response:
             body:
               - event: event
@@ -22017,7 +22142,8 @@ service:
         type: root.WebhookReceiver
         status-code: 201
       examples:
-        - headers: {}
+        - headers:
+            X-Account-Token: X-Account-Token
           request:
             event: event
             is_active: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-global-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-global-headers.json
@@ -82,7 +82,13 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "another_header": "another_header",
+                    "my-api-key": "my-api-key",
+                    "my-api-version": "my-api-version",
+                    "version": "2024-06-04",
+                    "x-api-key": "x-api-key",
+                  },
                   "path-parameters": {
                     "userId": "userId",
                   },
@@ -135,7 +141,13 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "another_header": "another_header",
+                    "my-api-key": "my-api-key",
+                    "my-api-version": "my-api-version",
+                    "version": "2024-06-04",
+                    "x-api-key": "x-api-key",
+                  },
                   "path-parameters": {
                     "userId": "userId",
                   },
@@ -221,7 +233,12 @@ service:
       examples:
         - path-parameters:
             userId: userId
-          headers: {}
+          headers:
+            my-api-key: my-api-key
+            another_header: another_header
+            x-api-key: x-api-key
+            my-api-version: my-api-version
+            version: '2024-06-04'
           request:
             stream: true
           response:
@@ -251,7 +268,12 @@ service:
       examples:
         - path-parameters:
             userId: userId
-          headers: {}
+          headers:
+            my-api-key: my-api-key
+            another_header: another_header
+            x-api-key: x-api-key
+            my-api-version: my-api-version
+            version: '2024-06-04'
           request:
             stream: false
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-parameter-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-parameter-name.json
@@ -14,7 +14,9 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {},
+                  "headers": {
+                    "X-API-Version": "X-API-Version",
+                  },
                   "path-parameters": {
                     "id": "userId",
                   },
@@ -83,7 +85,8 @@
             id: userId
           query-parameters:
             foo: foo
-          headers: {}
+          headers:
+            X-API-Version: X-API-Version
           response:
             body: string
   source:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -111,13 +111,10 @@ function convertHeaderExamples({
     context: OpenApiIrConverterContext;
     namedFullExamples: NamedFullExample[];
 }): Record<string, RawSchemas.ExampleTypeReferenceSchema> {
-    const globalHeaderNames = context.builder.getGlobalHeaderNames();
     const result: Record<string, RawSchemas.ExampleTypeReferenceSchema> = {};
     namedFullExamples.forEach((namedFullExample) => {
         const convertedExample = convertFullExample(namedFullExample.value);
-        if (globalHeaderNames.has(namedFullExample.name)) {
-            return;
-        } else if (convertedExample != null) {
+        if (convertedExample != null) {
             result[namedFullExample.name] = convertedExample;
         }
     });

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Global headers are now used to create endpoint examples. When building endpoint examples, global headers 
+        are automatically included in the headers section of each example. This ensures that all endpoints have consistent 
+        header examples that match the global header configuration.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-25"
+  version: 0.64.23
+
+- changelogEntry:
+    - summary: |
         Make proto file target field optional in generators.yml
       type: feat
   irVersion: 58


### PR DESCRIPTION
## Description
Now that fern check evaluates global headers, the OpenAPI parser needs to generate those examples. 

## Changes Made
- Include global headers in endpoint example generation

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

