### PR TITLE
fix(java): dont fail hard on dollar signs in javadoc

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
@@ -336,8 +336,8 @@ public final class BuilderGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .returns(returnClass);
         if (enrichedObjectProperty.enrichedObjectProperty.docs().isPresent()) {
-            methodBuilder.addJavadoc(
-                    enrichedObjectProperty.enrichedObjectProperty.docs().get());
+            methodBuilder.addJavadoc(JavaDocUtils.render(
+                    enrichedObjectProperty.enrichedObjectProperty.docs().get()));
         }
         methodBuilder.addParameter(parameterSpecBuilder.build());
         return methodBuilder;

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.38.1
+  changelogEntry:
+    - summary: |
+        Fix JavaDoc generation to properly escape dollar signs ($) when using JavaPoet.
+
+        When generating JavaDoc comments with JavaPoet, dollar signs need to be escaped as `$$` to prevent 
+        JavaPoet from interpreting them as template variables. This ensures that dollar signs in documentation 
+        are rendered correctly in the final generated code.
+      type: fix
+  createdAt: '2025-06-23'
+  irVersion: 58
+
 - version: 2.38.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
This PR fixes the java generator so that it doesn't throw if a java doc has a $ sign in it (an effect of using java poet). 

## Changes Made
- See files changed. 

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

