### PR TITLE
docs: Convert welcome page to minimal markdown and remove styling

### DIFF
--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,4 +1,4 @@
-FeHIIIIIII
+HELLOOOOO
 
 Products
 --------

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,4 +1,4 @@
-HELLO!!!
+HELLOOO
 
 Products
 --------

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,4 +1,4 @@
-HELLOOO
+HELLOOOOOO
 
 Products
 --------

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,4 +1,4 @@
-HELLOOOOOO
+FeHIIIIIII
 
 Products
 --------

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,153 +1,39 @@
----
-title: The Fern Platform
-description: Input OpenAPI. Output SDKs and Docs.
-slug: /
-layout: overview
-hide-toc: true
----
-
-<style>
-{`
-  .background-wrapper {
-    filter: blur(13.5rem);
-    will-change: transform, filter;
-    transform-style: preserve-3d;
-    transform: translateZ(0);
-    z-index: -1;
-    width: 100%;
-    max-width: 86rem;
-    display: flex;
-    position: fixed;
-    inset: 0%;
-    margin-right: auto;
-    margin-left: auto;
-    pointer-events: none;
-    top: 0;
-    left: 0;
-    opacity: 0.5;
-  }
-  .gradient-radial.is-green {
-    background-color: #dbfdd3;
-  }
-  .gradient-radial.is-blue {
-    background-color: #a7bff7;
-  }
-  :is(.dark) .gradient-radial.is-green {
-    background-color: #17450A;
-  }
-  :is(.dark) .gradient-radial.is-blue {
-    background-color: #1E2E5A;
-  }
-  .gradient-radial {
-    will-change: transform;
-    transform-style: preserve-3d;
-    border-radius: 50%;
-    width: 12rem;
-    height: 19rem;
-    display: block;
-    position: absolute;
-    transform: translateZ(0);
-  }
-  .gradient-radial.hero-1 {
-    transform-style: preserve-3d;
-    transform: rotate(-34deg)scale(1.4,.5)
-    position: absolute;
-    top: 54%;
-    left: 0%;
-  }
-  .gradient-radial.hero-2 {
-    transform-style: preserve-3d;
-    transform: rotate(-74deg)scale(1.7,1.1);
-    position: absolute;
-    top: 40%;
-    left: -2%;
-  }
-  .gradient-radial.hero-3 {
-    transform-style: preserve-3d;
-    transform: rotate(-20deg)scaleY(1.4)
-    position: absolute;
-    top: 20%;
-    left: 8%;
-  }
-  .gradient-radial.hero-4 {
-    transform-style: preserve-3d;
-    transform: rotate(37deg)scale(1.1,1.5)
-    position: absolute;
-    top: 37%;
-    right: 11%;
-  }
-  .gradient-radial.hero-5 {
-    transform-style: preserve-3d;
-    transform: rotate(37deg)scale(.9,1.8)
-    position: absolute;
-    top: 52%;
-    right: -7%;
-  }
-`}
-</style>
-
-<div className="background-wrapper">
-  <div className="gradient-radial hero-1 is-green"> </div>
-  <div className="gradient-radial hero-2 is-blue"> </div>
-  <div className="gradient-radial hero-3 is-green"> </div>
-  <div className="gradient-radial hero-4 is-blue"> </div>
-  <div className="gradient-radial hero-5 is-blue"> </div>
-</div>
-
 Fern allows developers to instantly transform your OpenAPI into SDKs and Docs. Engineering teams build with Fern to offer a best-in-class developer experience.
 
-## Products
+Products
+--------
 
-<Cards cols={3}>
-  <Card
-    title="SDKs"
-    icon="fa-solid fa-code"
-    href="/learn/sdks/introduction/overview"
-  >
-    Generate client libraries in multiple languages
-  </Card>
-  <Card
-    title="Docs"
-    icon="fa-regular fa-book"
-    href="/learn/docs/getting-started/quickstart"
-  >
-    A beautiful, interactive documentation website
-  </Card>
-  <Card
-    title="AI Search"
-    icon="fa-solid fa-search" 
-    href="/learn/ai-search/overview"
-  >
-    Let users find answers in your documentation instantly 
-  </Card>
-</Cards>
+Generate client libraries in multiple languages
 
-## Motivation
+A beautiful, interactive documentation website
 
-Stripe, Twilio, and AWS have the resources to invest in internal tooling for developer 
-experience. They provide SDKs (aka client libraries) in multiple languages and developer documentation
-that stays up-to-date. 
+Let users find answers in your documentation instantly
 
-We are building Fern to productize this process and make it accessible to all
-software companies.
+Integrate LLM Agents Into Product
 
-## Get Support
+Motivation
+----------
+
+Stripe, Twilio, and AWS have the resources to invest in internal tooling for developer experience. They provide SDKs (aka client libraries) in multiple languages and developer documentation that stays up-to-date.
+
+We are building Fern to productize this process and make it accessible to all software companies.
+
+Get Support
+-----------
 
 We love talking to users! Reach out via your preferred support channel so we can help you succeed with Fern.
 
-1. 💬 Message us in your Dedicated Slack Channel (for paid customers)
-2. 🤝 [Join our community Slack](https://buildwithfern.com/slack)
-3. 🐛 [File a GitHub Issue](https://github.com/fern-api/fern/issues)
-4. ✉️ [Email us](mailto:support@buildwithfern.com)
+1.  💬 Message us in your Dedicated Slack Channel (for paid customers)
+    
+2.  🤝 [Join our community Slack](https://buildwithfern.com/slack)
+    
+3.  🐛 [File a GitHub Issue](https://github.com/fern-api/fern/issues)
+    
+4.  ✉️ [Email us](mailto:support@buildwithfern.com)
+    
 
-We're lightning-fast with support - you'll typically hear back from us in hours, not days! 
+We're lightning-fast with support - you'll typically hear back from us in hours, not days!
 
-<ButtonGroup>
-<Button href="https://buildwithfern.com/contact" intent="primary" rightIcon="arrow-right" large>
-  Schedule a demo with a product expert
-</Button>
+Schedule a demo with a product expert
 
-<Button href="https://buildwithfern.com/showcase" minimal large>
-  View our customer showcase
-</Button>
-</ButtonGroup>
+View our customer showcase

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,4 +1,4 @@
-Fern allows developers to instantly transform your OpenAPI into SDKs and Docs. Engineering teams build with Fern to offer a best-in-class developer experience.
+HELLO!!!
 
 Products
 --------
@@ -8,8 +8,6 @@ Generate client libraries in multiple languages
 A beautiful, interactive documentation website
 
 Let users find answers in your documentation instantly
-
-Integrate LLM Agents Into Product
 
 Motivation
 ----------


### PR DESCRIPTION

This PR simplifies the welcome page by converting it from a styled component-based layout to plain markdown format. All custom styling (CSS, gradients) and React components (Cards, ButtonGroup) have been removed while preserving the core content about Fern's products, motivation, and support channels.

The changes improve maintainability by using standard markdown syntax for headings, lists, and text formatting. Note: The "HELLOOOOO" text at the top appears to be unintentional and should be removed before merging.