### PR TITLE
chore(cli): remove legacy pin

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1245,7 +1245,7 @@ function addDocsPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
                 port,
                 bundlePath,
                 brokenLinks: argv.brokenLinks,
-                appPreview: argv.beta,
+                appPreview: argv.beta ?? true,
                 legacyPreview: argv.legacy || process.platform === "win32",
                 backendPort
             });

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1245,7 +1245,6 @@ function addDocsPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
                 port,
                 bundlePath,
                 brokenLinks: argv.brokenLinks,
-                appPreview: argv.beta ?? true,
                 legacyPreview: argv.legacy || process.platform === "win32",
                 backendPort
             });

--- a/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
@@ -11,7 +11,6 @@ export async function previewDocsWorkspace({
     port,
     bundlePath,
     brokenLinks,
-    appPreview,
     legacyPreview,
     backendPort
 }: {
@@ -20,7 +19,6 @@ export async function previewDocsWorkspace({
     port: number;
     bundlePath?: string;
     brokenLinks: boolean;
-    appPreview?: boolean;
     legacyPreview?: boolean;
     backendPort: number;
 }): Promise<void> {
@@ -30,7 +28,7 @@ export async function previewDocsWorkspace({
         return;
     }
 
-    if (legacyPreview || !appPreview) {
+    if (legacyPreview) {
         await cliContext.instrumentPostHogEvent({
             orgId: project.config.organization,
             command: "fern docs dev --legacy"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        Remove all legacy preview pins.
+      type: feat
+  irVersion: 58
+  createdAt: "2025-06-27"
+  version: 0.64.25
+
+- changelogEntry:
+    - summary: |  
         Added Server-Sent Events (SSE) support to Java stream implementation. The Java SDK generator now 
         supports SSE streaming alongside existing JSON streaming, enabling real-time incremental responses 
         for chat applications and live data feeds.

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
-        Remove all legacy preview pins.
+        Remove all org-specific legacy preview pins.
       type: feat
   irVersion: 58
   createdAt: "2025-06-27"


### PR DESCRIPTION
removes the legacy pin, tieing specific orgs to the legacy frontend
