### PR TITLE
fix(openapi): add missing query params to converted octet requests

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/assembly.json
@@ -5381,6 +5381,7 @@ types:
               "request": {
                 "body": "bytes",
                 "content-type": "application/octet-stream",
+                "query-parameters": undefined,
               },
               "response": {
                 "docs": "File uploaded successfully",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/corti.json
@@ -8516,6 +8516,7 @@ service:
               "request": {
                 "body": "bytes",
                 "content-type": "application/octet-stream",
+                "query-parameters": undefined,
               },
               "response": {
                 "docs": "Returns the recording ID in the response.",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/uploadcare.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/uploadcare.json
@@ -5933,6 +5933,7 @@ Log.d("TAG", file.toString())
               "request": {
                 "body": "bytes",
                 "content-type": "application/octet-stream",
+                "query-parameters": undefined,
               },
               "source": {
                 "openapi": "../openapi.json",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/assembly.json
@@ -3536,6 +3536,7 @@ types:
               "request": {
                 "body": "bytes",
                 "content-type": "application/octet-stream",
+                "query-parameters": undefined,
               },
               "response": {
                 "docs": "File uploaded successfully",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/corti.json
@@ -6968,6 +6968,7 @@ service:
               "request": {
                 "body": "bytes",
                 "content-type": "application/octet-stream",
+                "query-parameters": undefined,
               },
               "response": {
                 "docs": "Returns the recording ID in the response.",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/uploadcare.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/uploadcare.json
@@ -4732,6 +4732,7 @@ Log.d("TAG", file.toString())
               "request": {
                 "body": "bytes",
                 "content-type": "application/octet-stream",
+                "query-parameters": undefined,
               },
               "source": {
                 "openapi": "../openapi.json",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -599,6 +599,7 @@ function getRequest({
             value: {
                 body: "bytes",
                 "content-type": MediaType.APPLICATION_OCTET_STREAM,
+                "query-parameters": queryParameters,
                 ...(request.description ? { docs: request.description } : {})
             }
         };

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        Fixes the OpenAPI parser to correctly include query parameters in endpoints.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-06-28"
+  version: 0.64.26
+
+- changelogEntry:
+    - summary: |  
         Remove all org-specific legacy preview pins.
       type: feat
   irVersion: 58

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
-        Fixes the OpenAPI parser to correctly include query parameters in endpoints.
+        Fixes the OpenAPI parser to correctly include query parameters in `Content-Type: application/octet-stream` requests.
       type: fix
   irVersion: 58
   createdAt: "2025-06-28"


### PR DESCRIPTION
The returned object here is also missing a few other fields like `path-parameters` but `path-parameters` somehow makes its way through the converted definition. Didn't have time to investigate but probably worth looking into later..