### PR TITLE
fix(cli): Update bufbuild/protobuf dep

### DIFF
--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -54,6 +54,7 @@
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fern-definition-validator": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/protoc-gen-fern": "workspace:*",
     "@fern-api/generators-validator": "workspace:*",
     "@fern-api/init": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -21,7 +21,7 @@ import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin, login } from "@fern-api/login";
 import { FernCliError, LoggableFernCliError } from "@fern-api/task-context";
 
-import { protocGenFern } from "../../generation/protoc-gen-fern/src/protoc-gen-fern";
+import { protocGenFern } from "@fern-api/protoc-gen-fern";
 import { LoadOpenAPIStatus, loadOpenAPIFromUrl } from "../../init/src/utils/loadOpenApiFromUrl";
 import { CliContext } from "./cli-context/CliContext";
 import { getLatestVersionOfCli } from "./cli-context/upgrade-utils/getLatestVersionOfCli";

--- a/packages/cli/cli/tsconfig.json
+++ b/packages/cli/cli/tsconfig.json
@@ -52,6 +52,9 @@
       "path": "../generation/remote-generation/remote-workspace-runner"
     },
     {
+      "path": "../generation/protoc-gen-fern"
+    },
+    {
       "path": "../init"
     },
     {

--- a/packages/cli/generation/protoc-gen-fern/package.json
+++ b/packages/cli/generation/protoc-gen-fern/package.json
@@ -30,7 +30,7 @@
     "depcheck": "depcheck",
     "dist": "tsc --project build.tsconfig.json --outDir ./dist/cjs"
   },
-  "dependencies": {
+  "devDependencies": {
     "@bufbuild/protobuf": "^2.2.5",
     "@bufbuild/protoplugin": "2.2.5",
     "@fern-api/configs": "workspace:*",
@@ -41,9 +41,7 @@
     "@fern-api/v2-importer-commons": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "openapi-types": "^12.1.3",
-    "lodash-es": "^4.17.21"
-  },
-  "devDependencies": {
+    "lodash-es": "^4.17.21",
     "@trivago/prettier-plugin-sort-imports": "^5.2.1",
     "@types/lodash-es": "^4.17.12",
     "@types/jest": "^29.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5572,6 +5572,9 @@ importers:
       '@fern-api/project-loader':
         specifier: workspace:*
         version: link:../project-loader
+      '@fern-api/protoc-gen-fern':
+        specifier: workspace:*
+        version: link:../generation/protoc-gen-fern
       '@fern-api/register':
         specifier: workspace:*
         version: link:../register
@@ -7379,7 +7382,7 @@ importers:
         version: 2.1.9(@types/node@18.15.3)(jsdom@20.0.3)(sass@1.89.2)(terser@5.43.1)
 
   packages/cli/generation/protoc-gen-fern:
-    dependencies:
+    devDependencies:
       '@bufbuild/protobuf':
         specifier: ^2.2.5
         version: 2.5.2
@@ -7407,13 +7410,6 @@ importers:
       '@fern-api/v2-importer-commons':
         specifier: workspace:*
         version: link:../../api-importers/v2-importer-commons
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
-      openapi-types:
-        specifier: ^12.1.3
-        version: 12.1.3
-    devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.1
         version: 5.2.2(@vue/compiler-sfc@3.5.17)(prettier@3.5.3)
@@ -7432,6 +7428,12 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.57.1
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       prettier:
         specifier: ^3.4.2
         version: 3.5.3


### PR DESCRIPTION
This updates the internal dependency on `@fern-api/protoc-gen-fern` and moves all of its dependencies to `devDependencies` for `tsup` bundling.