### PR TITLE
feat(go): Add support for raw response headers from `multipart/form-data` endpoints

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -302,7 +302,7 @@ jobs:
         uses: ./.github/actions/cached-seed
         with:
           generator-name: go-fiber
-          generator-path: generators/go
+          generator-path: generators/go generators/go-v2
 
   go-model:
     runs-on: Seed
@@ -316,7 +316,7 @@ jobs:
         uses: ./.github/actions/cached-seed
         with:
           generator-name: go-model
-          generator-path: generators/go
+          generator-path: generators/go generators/go-v2
 
   go-sdk:
     runs-on: Seed
@@ -330,7 +330,7 @@ jobs:
         uses: ./.github/actions/cached-seed
         with:
           generator-name: go-sdk
-          generator-path: generators/go
+          generator-path: generators/go generators/go-v2
 
   csharp-model:
     runs-on: Seed

--- a/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
+++ b/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
@@ -16,7 +16,8 @@ export const BaseGoCustomConfigSchema = z.object({
     inlinePathParameters: z.boolean().optional(),
     inlineFileProperties: z.boolean().optional(),
     packageLayout: z.enum(["flat", "nested"]).optional(),
-    union: z.string().optional()
+    union: z.enum(["v0", "v1"]).optional(),
+    useReaderForBytesRequest: z.boolean().optional()
 });
 
 export type BaseGoCustomConfigSchema = z.infer<typeof BaseGoCustomConfigSchema>;

--- a/generators/go-v2/ast/src/custom-config/DefaultBaseGoCustomConfigSchema.ts
+++ b/generators/go-v2/ast/src/custom-config/DefaultBaseGoCustomConfigSchema.ts
@@ -1,0 +1,9 @@
+import { BaseGoCustomConfigSchema } from "./BaseGoCustomConfigSchema";
+
+export const DefaultBaseGoCustomConfigSchema: BaseGoCustomConfigSchema = {
+    alwaysSendRequiredProperties: true,
+    inlinePathParameters: true,
+    inlineFileProperties: true,
+    useReaderForBytesRequest: true,
+    union: "v1"
+};

--- a/generators/go-v2/ast/src/index.ts
+++ b/generators/go-v2/ast/src/index.ts
@@ -1,5 +1,6 @@
 export { AbstractGoGeneratorContext, type FileLocation } from "./context/AbstractGoGeneratorContext";
 export { BaseGoCustomConfigSchema } from "./custom-config/BaseGoCustomConfigSchema";
+export { DefaultBaseGoCustomConfigSchema } from "./custom-config/DefaultBaseGoCustomConfigSchema";
 export { resolveRootImportPath } from "./custom-config/resolveRootImportPath";
 export * as go from "./go";
 export { GoFile } from "./ast/core/GoFile";

--- a/generators/go-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorCli.ts
@@ -1,5 +1,6 @@
 import { File, GeneratorNotificationService } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
+import { DefaultBaseGoCustomConfigSchema } from "@fern-api/go-ast";
 import { AbstractGoGeneratorCli } from "@fern-api/go-base";
 import { DynamicSnippetsGenerator } from "@fern-api/go-dynamic-snippets";
 
@@ -32,9 +33,12 @@ export class SdkGeneratorCLI extends AbstractGoGeneratorCli<SdkCustomConfigSchem
     protected parseCustomConfigOrThrow(customConfig: unknown): SdkCustomConfigSchema {
         const parsed = customConfig != null ? SdkCustomConfigSchema.parse(customConfig) : undefined;
         if (parsed != null) {
-            return parsed;
+            return {
+                ...DefaultBaseGoCustomConfigSchema,
+                ...parsed
+            };
         }
-        return {};
+        return DefaultBaseGoCustomConfigSchema;
     }
 
     protected async publishPackage(context: SdkGeneratorContext): Promise<void> {

--- a/generators/go-v2/sdk/src/endpoint/request/BytesRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/BytesRequest.ts
@@ -18,4 +18,8 @@ export class BytesRequest extends EndpointRequest {
     public getRequestParameterType(): go.Type {
         return go.Type.bytes();
     }
+
+    public getRequestBodyBlock(): go.AstNode | undefined {
+        return undefined;
+    }
 }

--- a/generators/go-v2/sdk/src/endpoint/request/EndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/EndpointRequest.ts
@@ -13,8 +13,9 @@ export abstract class EndpointRequest {
     ) {}
 
     public abstract getRequestParameterType(): go.Type;
+    public abstract getRequestBodyBlock(): go.AstNode | undefined;
 
-    public getRequestReference(): go.AstNode {
+    public getRequestReference(): go.AstNode | undefined {
         return go.codeblock(this.getRequestParameterName());
     }
 

--- a/generators/go-v2/sdk/src/endpoint/request/ReferencedEndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/ReferencedEndpointRequest.ts
@@ -22,4 +22,8 @@ export class ReferencedEndpointRequest extends EndpointRequest {
     public getRequestParameterType(): go.Type {
         return this.context.goTypeMapper.convert({ reference: this.requestBodyShape });
     }
+
+    public getRequestBodyBlock(): go.AstNode | undefined {
+        return undefined;
+    }
 }

--- a/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
@@ -60,7 +60,10 @@ export class WrappedEndpointRequest extends EndpointRequest {
                     assertNever(requestBody);
             }
         }
-        if (this.context.shouldSkipWrappedRequest({ endpoint: this.endpoint, wrapper: this.wrapper })) {
+        if (
+            this.wrapper.onlyPathParameters ||
+            this.context.shouldSkipWrappedRequest({ endpoint: this.endpoint, wrapper: this.wrapper })
+        ) {
             return undefined;
         }
         return super.getRequestReference();

--- a/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
@@ -1,8 +1,22 @@
+import { assertNever } from "@fern-api/core-utils";
 import { go } from "@fern-api/go-ast";
+import { GoValueFormatter } from "@fern-api/go-ast/src/context/GoValueFormatter";
 
-import { HttpEndpoint, HttpService, SdkRequest, SdkRequestWrapper, ServiceId } from "@fern-fern/ir-sdk/api";
+import {
+    FileProperty,
+    FileUploadBodyProperty,
+    FileUploadRequest,
+    FileUploadRequestProperty,
+    HttpEndpoint,
+    HttpService,
+    Name,
+    SdkRequest,
+    SdkRequestWrapper,
+    ServiceId
+} from "@fern-fern/ir-sdk/api";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
+import { EndpointSignatureInfo } from "../EndpointSignatureInfo";
 import { EndpointRequest } from "./EndpointRequest";
 
 export declare namespace WrappedEndpointRequest {
@@ -30,5 +44,198 @@ export class WrappedEndpointRequest extends EndpointRequest {
         return go.Type.pointer(
             go.Type.reference(this.context.getRequestWrapperTypeReference(this.serviceId, this.wrapper.wrapperName))
         );
+    }
+
+    public getRequestReference(): go.AstNode | undefined {
+        const requestBody = this.endpoint.requestBody;
+        if (requestBody != null) {
+            switch (requestBody.type) {
+                case "fileUpload":
+                    return go.codeblock("writer.Buffer()");
+                case "inlinedRequestBody":
+                case "reference":
+                case "bytes":
+                    break;
+                default:
+                    assertNever(requestBody);
+            }
+        }
+        if (this.context.shouldSkipWrappedRequest({ endpoint: this.endpoint, wrapper: this.wrapper })) {
+            return undefined;
+        }
+        return super.getRequestReference();
+    }
+
+    public getRequestBodyBlock(): go.AstNode | undefined {
+        const requestBody = this.endpoint.requestBody;
+        if (requestBody == null) {
+            return undefined;
+        }
+        switch (requestBody.type) {
+            case "fileUpload":
+                return this.getRequestBodyBlockForFileUpload(requestBody);
+            case "inlinedRequestBody":
+            case "reference":
+            case "bytes":
+                return undefined;
+            default:
+                assertNever(requestBody);
+        }
+    }
+
+    private getRequestBodyBlockForFileUpload(fileUploadRequest: FileUploadRequest): go.AstNode {
+        return go.codeblock((writer) => {
+            writer.write(`writer := `);
+            writer.writeNode(this.context.callNewMultipartWriter([]));
+            writer.newLine();
+            fileUploadRequest.properties.forEach((property, idx) => {
+                if (idx > 0) {
+                    writer.writeNewLineIfLastLineNot();
+                }
+                this.writeFileUploadProperty({ writer, property });
+            });
+            writer.writeLine(`if err := writer.Close(); err != nil {`);
+            writer.indent();
+            writer.writeLine(`return nil, err`);
+            writer.dedent();
+            writer.writeLine(`}`);
+            writer.writeLine(`headers.Set("Content-Type", writer.ContentType())`);
+        });
+    }
+
+    private writeFileUploadProperty({
+        writer,
+        property
+    }: {
+        writer: go.Writer;
+        property: FileUploadRequestProperty;
+    }): void {
+        switch (property.type) {
+            case "file":
+                this.writeFileProperty({ writer, fileProperty: property.value });
+                break;
+            case "bodyProperty":
+                this.writeBodyProperty({ writer, bodyProperty: property });
+                break;
+            default:
+                assertNever(property);
+        }
+    }
+
+    private writeFileProperty({ writer, fileProperty }: { writer: go.Writer; fileProperty: FileProperty }): void {
+        switch (fileProperty.type) {
+            case "file":
+                this.writeFileUploadField({
+                    writer,
+                    key: fileProperty.key.wireValue,
+                    value: go.codeblock(
+                        this.getRequestPropertyReference({ fieldName: fileProperty.key.name, isFile: true })
+                    ),
+                    format: "file"
+                });
+                break;
+            case "fileArray":
+                writer.writeLine(
+                    `for _, f := range ${this.getRequestPropertyReference({ fieldName: fileProperty.key.name, isFile: true })} {`
+                );
+                writer.indent();
+                this.writeFileUploadField({
+                    writer,
+                    key: fileProperty.key.wireValue,
+                    value: go.codeblock("f"),
+                    format: "file"
+                });
+                writer.dedent();
+                writer.writeLine(`}`);
+                break;
+            default:
+                assertNever(fileProperty);
+        }
+    }
+
+    private writeBodyProperty({
+        writer,
+        bodyProperty
+    }: {
+        writer: go.Writer;
+        bodyProperty: FileUploadBodyProperty;
+    }): void {
+        const literal = this.context.maybeLiteral(bodyProperty.valueType);
+        if (literal != null) {
+            this.writeFileUploadField({
+                writer,
+                key: bodyProperty.name.wireValue,
+                value: go.codeblock(this.context.getLiteralAsString(literal)),
+                format: "field"
+            });
+            return;
+        }
+        const field = this.getRequestPropertyReference({ fieldName: bodyProperty.name.name });
+        const format = this.context.goValueFormatter.convert({
+            reference: bodyProperty.valueType,
+            value: go.codeblock(field)
+        });
+        const formatType = format.isPrimitive ? "field" : "json";
+        if (format.isIterable) {
+            writer.writeLine(`for _, part := range ${field} {`);
+            writer.indent();
+            this.writeFileUploadField({
+                writer,
+                key: bodyProperty.name.wireValue,
+                value: go.codeblock("part"),
+                format: formatType
+            });
+            writer.dedent();
+            writer.writeLine(`}`);
+            return;
+        }
+        if (format.isOptional) {
+            writer.writeNewLineIfLastLineNot();
+            writer.writeLine(`if ${field} != nil {`);
+            writer.indent();
+            this.writeFileUploadField({
+                writer,
+                key: bodyProperty.name.wireValue,
+                value: format.formatted,
+                format: formatType
+            });
+            writer.dedent();
+            writer.writeLine("}");
+            return;
+        }
+        this.writeFileUploadField({
+            writer,
+            key: bodyProperty.name.wireValue,
+            value: format.formatted,
+            format: formatType
+        });
+    }
+
+    private getRequestPropertyReference({ fieldName, isFile }: { fieldName: Name; isFile?: boolean }): string {
+        if (isFile && !this.context.customConfig.inlineFileProperties) {
+            return this.context.getParameterName(fieldName);
+        }
+        return `${this.getRequestParameterName()}.${this.context.getFieldName(fieldName)}`;
+    }
+
+    private writeFileUploadField({
+        writer,
+        key,
+        value,
+        format
+    }: {
+        writer: go.Writer;
+        key: string;
+        value: go.AstNode;
+        format: "file" | "field" | "json";
+    }): void {
+        const method = format === "file" ? "WriteFile" : format === "field" ? "WriteField" : "WriteJSON";
+        writer.write(`if err := writer.${method}("${key}", `);
+        writer.writeNode(value);
+        writer.writeLine(`); err != nil {`);
+        writer.indent();
+        writer.writeLine(`return nil, err`);
+        writer.dedent();
+        writer.writeLine(`}`);
     }
 }

--- a/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
@@ -1,6 +1,5 @@
 import { assertNever } from "@fern-api/core-utils";
 import { go } from "@fern-api/go-ast";
-import { GoValueFormatter } from "@fern-api/go-ast/src/context/GoValueFormatter";
 
 import {
     FileProperty,
@@ -16,7 +15,6 @@ import {
 } from "@fern-fern/ir-sdk/api";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
-import { EndpointSignatureInfo } from "../EndpointSignatureInfo";
 import { EndpointRequest } from "./EndpointRequest";
 
 export declare namespace WrappedEndpointRequest {
@@ -88,7 +86,7 @@ export class WrappedEndpointRequest extends EndpointRequest {
 
     private getRequestBodyBlockForFileUpload(fileUploadRequest: FileUploadRequest): go.AstNode {
         return go.codeblock((writer) => {
-            writer.write(`writer := `);
+            writer.write("writer := ");
             writer.writeNode(this.context.callNewMultipartWriter([]));
             writer.newLine();
             fileUploadRequest.properties.forEach((property, idx) => {
@@ -97,11 +95,11 @@ export class WrappedEndpointRequest extends EndpointRequest {
                 }
                 this.writeFileUploadProperty({ writer, property });
             });
-            writer.writeLine(`if err := writer.Close(); err != nil {`);
+            writer.writeLine("if err := writer.Close(); err != nil {");
             writer.indent();
-            writer.writeLine(`return nil, err`);
+            writer.writeLine("return nil, err");
             writer.dedent();
-            writer.writeLine(`}`);
+            writer.writeLine("}");
             writer.writeLine(`headers.Set("Content-Type", writer.ContentType())`);
         });
     }
@@ -149,7 +147,7 @@ export class WrappedEndpointRequest extends EndpointRequest {
                     format: "file"
                 });
                 writer.dedent();
-                writer.writeLine(`}`);
+                writer.writeLine("}");
                 break;
             default:
                 assertNever(fileProperty);
@@ -189,7 +187,7 @@ export class WrappedEndpointRequest extends EndpointRequest {
                 format: formatType
             });
             writer.dedent();
-            writer.writeLine(`}`);
+            writer.writeLine("}");
             return;
         }
         if (format.isOptional) {
@@ -235,10 +233,10 @@ export class WrappedEndpointRequest extends EndpointRequest {
         const method = format === "file" ? "WriteFile" : format === "field" ? "WriteField" : "WriteJSON";
         writer.write(`if err := writer.${method}("${key}", `);
         writer.writeNode(value);
-        writer.writeLine(`); err != nil {`);
+        writer.writeLine("); err != nil {");
         writer.indent();
-        writer.writeLine(`return nil, err`);
+        writer.writeLine("return nil, err");
         writer.dedent();
-        writer.writeLine(`}`);
+        writer.writeLine("}");
     }
 }

--- a/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/WrappedEndpointRequest.ts
@@ -100,7 +100,7 @@ export class WrappedEndpointRequest extends EndpointRequest {
             writer.writeLine("return nil, err");
             writer.dedent();
             writer.writeLine("}");
-            writer.writeLine(`headers.Set("Content-Type", writer.ContentType())`);
+            writer.writeLine('headers.Set("Content-Type", writer.ContentType())');
         });
     }
 

--- a/generators/go-v2/sdk/src/endpoint/utils/getEndpointRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/utils/getEndpointRequest.ts
@@ -3,6 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { HttpEndpoint, HttpService, SdkRequest, ServiceId } from "@fern-fern/ir-sdk/api";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
+import { EndpointSignatureInfo } from "../EndpointSignatureInfo";
 import { BytesRequest } from "../request/BytesRequest";
 import { EndpointRequest } from "../request/EndpointRequest";
 import { ReferencedEndpointRequest } from "../request/ReferencedEndpointRequest";
@@ -21,11 +22,6 @@ export function getEndpointRequest({
 }): EndpointRequest | undefined {
     if (endpoint.sdkRequest == null) {
         return undefined;
-    }
-    if (endpoint.sdkRequest.shape.type === "wrapper") {
-        if (context.shouldSkipWrappedRequest({ endpoint, wrapper: endpoint.sdkRequest.shape })) {
-            return undefined;
-        }
     }
     return createEndpointRequest({
         context,

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.4.0
+  changelogEntry:
+    - summary: |
+        Add support for receiving raw response headers from API calls with the new `WithRawResponse` client field
+        for multipart/form-data endpoints.
+      type: feat
+  createdAt: '2025-07-01'
+  irVersion: 58
+
 - version: 1.3.0
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/auth-environment-variables/service/raw_client.go
+++ b/seed/go-sdk/auth-environment-variables/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/auth-environment-variables/fern"
 	core "github.com/auth-environment-variables/fern/core"
 	internal "github.com/auth-environment-variables/fern/internal"
@@ -84,7 +83,7 @@ func (r *RawClient) GetWithHeader(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-Endpoint-Header", fmt.Sprintf("%v", request.XEndpointHeader))
+	headers.Add("X-Endpoint-Header", request.XEndpointHeader)
 	var response string
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/always-send-required-properties/service/raw_client.go
+++ b/seed/go-sdk/examples/always-send-required-properties/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/service/raw_client.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/client-name/service/raw_client.go
+++ b/seed/go-sdk/examples/client-name/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/exported-client-name/service/raw_client.go
+++ b/seed/go-sdk/examples/exported-client-name/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/no-custom-config/service/raw_client.go
+++ b/seed/go-sdk/examples/no-custom-config/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/readme-config/service/raw_client.go
+++ b/seed/go-sdk/examples/readme-config/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/examples/v0/service/raw_client.go
+++ b/seed/go-sdk/examples/v0/service/raw_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	context "context"
-	fmt "fmt"
 	fern "github.com/examples/fern"
 	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
@@ -136,7 +135,7 @@ func (r *RawClient) GetMetadata(
 		r.header.Clone(),
 		options.ToHeader(),
 	)
-	headers.Add("X-API-Version", fmt.Sprintf("%v", request.XApiVersion))
+	headers.Add("X-API-Version", request.XApiVersion)
 	var response *fern.Metadata
 	raw, err := r.caller.Call(
 		ctx,

--- a/seed/go-sdk/file-upload/package-name/service/raw_client.go
+++ b/seed/go-sdk/file-upload/package-name/service/raw_client.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	context "context"
+	fmt "fmt"
+	file "github.com/fern-api/file-upload-go"
 	core "github.com/fern-api/file-upload-go/core"
 	internal "github.com/fern-api/file-upload-go/internal"
 	option "github.com/fern-api/file-upload-go/option"
@@ -25,6 +27,507 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 		),
 		header: options.ToHeader(),
 	}
+}
+
+func (r *RawClient) Post(
+	ctx context.Context,
+	request *file.MyRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if request.MaybeString != nil {
+		if err := writer.WriteField("maybe_string", *request.MaybeString); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteField("integer", fmt.Sprintf("%v", request.Integer)); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteFile("file", request.File); err != nil {
+		return nil, err
+	}
+	for _, f := range request.FileList {
+		if err := writer.WriteFile("file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteFile("maybe_file", request.MaybeFile); err != nil {
+		return nil, err
+	}
+	for _, f := range request.MaybeFileList {
+		if err := writer.WriteFile("maybe_file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if request.MaybeInteger != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.OptionalListOfStrings {
+		if err := writer.WriteField("optional_list_of_strings", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.ListOfObjects {
+		if err := writer.WriteJSON("list_of_objects", part); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalMetadata != nil {
+		if err := writer.WriteJSON("optional_metadata", request.OptionalMetadata); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalObjectType != nil {
+		if err := writer.WriteJSON("optional_object_type", *request.OptionalObjectType); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalId != nil {
+		if err := writer.WriteField("optional_id", *request.OptionalId); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteJSON("alias_object", request.AliasObject); err != nil {
+		return nil, err
+	}
+	for _, part := range request.ListOfAliasObject {
+		if err := writer.WriteJSON("list_of_alias_object", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.AliasListOfObject {
+		if err := writer.WriteJSON("alias_list_of_object", part); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) JustFile(
+	ctx context.Context,
+	request *file.JustFileRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/just-file"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", request.File); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) JustFileWithQueryParams(
+	ctx context.Context,
+	request *file.JustFileWithQueryParamsRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/just-file-with-query-params"
+	queryParams, err := internal.QueryValues(request)
+	if err != nil {
+		return nil, err
+	}
+	if len(queryParams) > 0 {
+		endpointURL += "?" + queryParams.Encode()
+	}
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", request.File); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) WithContentType(
+	ctx context.Context,
+	request *file.WithContentTypeRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/with-content-type"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", request.File); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteField("foo", request.Foo); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteJSON("bar", request.Bar); err != nil {
+		return nil, err
+	}
+	if request.FooBar != nil {
+		if err := writer.WriteJSON("foo_bar", request.FooBar); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) WithFormEncoding(
+	ctx context.Context,
+	request *file.WithFormEncodingRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/with-form-encoding"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", request.File); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteField("foo", request.Foo); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteJSON("bar", request.Bar); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) WithFormEncodedContainers(
+	ctx context.Context,
+	request *file.MyOtherRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if request.MaybeString != nil {
+		if err := writer.WriteField("maybe_string", *request.MaybeString); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteField("integer", fmt.Sprintf("%v", request.Integer)); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteFile("file", request.File); err != nil {
+		return nil, err
+	}
+	for _, f := range request.FileList {
+		if err := writer.WriteFile("file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteFile("maybe_file", request.MaybeFile); err != nil {
+		return nil, err
+	}
+	for _, f := range request.MaybeFileList {
+		if err := writer.WriteFile("maybe_file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if request.MaybeInteger != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.OptionalListOfStrings {
+		if err := writer.WriteField("optional_list_of_strings", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.ListOfObjects {
+		if err := writer.WriteJSON("list_of_objects", part); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalMetadata != nil {
+		if err := writer.WriteJSON("optional_metadata", request.OptionalMetadata); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalObjectType != nil {
+		if err := writer.WriteJSON("optional_object_type", *request.OptionalObjectType); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalId != nil {
+		if err := writer.WriteField("optional_id", *request.OptionalId); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.ListOfObjectsWithOptionals {
+		if err := writer.WriteJSON("list_of_objects_with_optionals", part); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteJSON("alias_object", request.AliasObject); err != nil {
+		return nil, err
+	}
+	for _, part := range request.ListOfAliasObject {
+		if err := writer.WriteJSON("list_of_alias_object", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.AliasListOfObject {
+		if err := writer.WriteJSON("alias_list_of_object", part); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) OptionalArgs(
+	ctx context.Context,
+	request *file.OptionalArgsRequest,
+	opts ...option.RequestOption,
+) (*core.Response[string], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/optional-args"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	headers.Add("Content-Type", "multipart/form-data")
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("image_file", request.ImageFile); err != nil {
+		return nil, err
+	}
+	if request.Request != nil {
+		if err := writer.WriteJSON("request", request.Request); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	var response string
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+			Response:        &response,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[string]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       response,
+	}, nil
 }
 
 func (r *RawClient) Simple(

--- a/seed/go-sdk/file-upload/v0/service/raw_client.go
+++ b/seed/go-sdk/file-upload/v0/service/raw_client.go
@@ -2,9 +2,12 @@ package service
 
 import (
 	context "context"
+	fmt "fmt"
+	fern "github.com/file-upload/fern"
 	core "github.com/file-upload/fern/core"
 	internal "github.com/file-upload/fern/internal"
 	option "github.com/file-upload/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -25,6 +28,519 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 		),
 		header: options.ToHeader(),
 	}
+}
+
+func (r *RawClient) Post(
+	ctx context.Context,
+	file io.Reader,
+	fileList []io.Reader,
+	maybeFile io.Reader,
+	maybeFileList []io.Reader,
+	request *fern.MyRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if request.MaybeString != nil {
+		if err := writer.WriteField("maybe_string", *request.MaybeString); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteField("integer", fmt.Sprintf("%v", request.Integer)); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteFile("file", file); err != nil {
+		return nil, err
+	}
+	for _, f := range fileList {
+		if err := writer.WriteFile("file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteFile("maybe_file", maybeFile); err != nil {
+		return nil, err
+	}
+	for _, f := range maybeFileList {
+		if err := writer.WriteFile("maybe_file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if request.MaybeInteger != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.OptionalListOfStrings {
+		if err := writer.WriteField("optional_list_of_strings", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.ListOfObjects {
+		if err := writer.WriteJSON("list_of_objects", part); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalMetadata != nil {
+		if err := writer.WriteJSON("optional_metadata", request.OptionalMetadata); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalObjectType != nil {
+		if err := writer.WriteJSON("optional_object_type", *request.OptionalObjectType); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalId != nil {
+		if err := writer.WriteField("optional_id", *request.OptionalId); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteJSON("alias_object", request.AliasObject); err != nil {
+		return nil, err
+	}
+	for _, part := range request.ListOfAliasObject {
+		if err := writer.WriteJSON("list_of_alias_object", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.AliasListOfObject {
+		if err := writer.WriteJSON("alias_list_of_object", part); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) JustFile(
+	ctx context.Context,
+	file io.Reader,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/just-file"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", file); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) JustFileWithQueryParams(
+	ctx context.Context,
+	file io.Reader,
+	request *fern.JustFileWithQueryParamsRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/just-file-with-query-params"
+	queryParams, err := internal.QueryValues(request)
+	if err != nil {
+		return nil, err
+	}
+	if len(queryParams) > 0 {
+		endpointURL += "?" + queryParams.Encode()
+	}
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", file); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) WithContentType(
+	ctx context.Context,
+	file io.Reader,
+	request *fern.WithContentTypeRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/with-content-type"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", file); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteField("foo", request.Foo); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteJSON("bar", request.Bar); err != nil {
+		return nil, err
+	}
+	if request.FooBar != nil {
+		if err := writer.WriteJSON("foo_bar", request.FooBar); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) WithFormEncoding(
+	ctx context.Context,
+	file io.Reader,
+	request *fern.WithFormEncodingRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/with-form-encoding"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("file", file); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteField("foo", request.Foo); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteJSON("bar", request.Bar); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) WithFormEncodedContainers(
+	ctx context.Context,
+	file io.Reader,
+	fileList []io.Reader,
+	maybeFile io.Reader,
+	maybeFileList []io.Reader,
+	request *fern.MyOtherRequest,
+	opts ...option.RequestOption,
+) (*core.Response[any], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	writer := internal.NewMultipartWriter()
+	if request.MaybeString != nil {
+		if err := writer.WriteField("maybe_string", *request.MaybeString); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteField("integer", fmt.Sprintf("%v", request.Integer)); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteFile("file", file); err != nil {
+		return nil, err
+	}
+	for _, f := range fileList {
+		if err := writer.WriteFile("file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteFile("maybe_file", maybeFile); err != nil {
+		return nil, err
+	}
+	for _, f := range maybeFileList {
+		if err := writer.WriteFile("maybe_file_list", f); err != nil {
+			return nil, err
+		}
+	}
+	if request.MaybeInteger != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.OptionalListOfStrings {
+		if err := writer.WriteField("optional_list_of_strings", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.ListOfObjects {
+		if err := writer.WriteJSON("list_of_objects", part); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalMetadata != nil {
+		if err := writer.WriteJSON("optional_metadata", request.OptionalMetadata); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalObjectType != nil {
+		if err := writer.WriteJSON("optional_object_type", *request.OptionalObjectType); err != nil {
+			return nil, err
+		}
+	}
+	if request.OptionalId != nil {
+		if err := writer.WriteField("optional_id", *request.OptionalId); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.ListOfObjectsWithOptionals {
+		if err := writer.WriteJSON("list_of_objects_with_optionals", part); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.WriteJSON("alias_object", request.AliasObject); err != nil {
+		return nil, err
+	}
+	for _, part := range request.ListOfAliasObject {
+		if err := writer.WriteJSON("list_of_alias_object", part); err != nil {
+			return nil, err
+		}
+	}
+	for _, part := range request.AliasListOfObject {
+		if err := writer.WriteJSON("alias_list_of_object", part); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[any]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       nil,
+	}, nil
+}
+
+func (r *RawClient) OptionalArgs(
+	ctx context.Context,
+	imageFile io.Reader,
+	request *fern.OptionalArgsRequest,
+	opts ...option.RequestOption,
+) (*core.Response[string], error) {
+	options := core.NewRequestOptions(opts...)
+	baseURL := internal.ResolveBaseURL(
+		options.BaseURL,
+		r.baseURL,
+		"",
+	)
+	endpointURL := baseURL + "/optional-args"
+	headers := internal.MergeHeaders(
+		r.header.Clone(),
+		options.ToHeader(),
+	)
+	headers.Add("Content-Type", "multipart/form-data")
+	writer := internal.NewMultipartWriter()
+	if err := writer.WriteFile("image_file", imageFile); err != nil {
+		return nil, err
+	}
+	if request.Request != nil {
+		if err := writer.WriteJSON("request", request.Request); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	headers.Set("Content-Type", writer.ContentType())
+
+	var response string
+	raw, err := r.caller.Call(
+		ctx,
+		&internal.CallParams{
+			URL:             endpointURL,
+			Method:          http.MethodPost,
+			Headers:         headers,
+			MaxAttempts:     options.MaxAttempts,
+			BodyProperties:  options.BodyProperties,
+			QueryParameters: options.QueryParameters,
+			Client:          options.HTTPClient,
+			Request:         writer.Buffer(),
+			Response:        &response,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &core.Response[string]{
+		StatusCode: raw.StatusCode,
+		Header:     raw.Header,
+		Body:       response,
+	}, nil
 }
 
 func (r *RawClient) Simple(

--- a/seed/go-sdk/path-parameters/no-custom-config/organizations/raw_client.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/organizations/raw_client.go
@@ -75,9 +75,7 @@ func (r *RawClient) GetOrganization(
 
 func (r *RawClient) GetOrganizationUser(
 	ctx context.Context,
-	tenantId string,
-	organizationId string,
-	userId string,
+	request *fern.GetOrganizationUserRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[*fern.User], error) {
 	options := core.NewRequestOptions(opts...)
@@ -88,9 +86,9 @@ func (r *RawClient) GetOrganizationUser(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/organizations/%v/users/%v",
-		tenantId,
-		organizationId,
-		userId,
+		request.TenantId,
+		request.OrganizationId,
+		request.UserId,
 	)
 	headers := internal.MergeHeaders(
 		r.header.Clone(),
@@ -107,6 +105,7 @@ func (r *RawClient) GetOrganizationUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
+			Request:         request,
 			Response:        &response,
 		},
 	)

--- a/seed/go-sdk/path-parameters/no-custom-config/organizations/raw_client.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/organizations/raw_client.go
@@ -105,7 +105,6 @@ func (r *RawClient) GetOrganizationUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
-			Request:         request,
 			Response:        &response,
 		},
 	)

--- a/seed/go-sdk/path-parameters/no-custom-config/user/raw_client.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/user/raw_client.go
@@ -59,7 +59,6 @@ func (r *RawClient) GetUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
-			Request:         request,
 			Response:        &response,
 		},
 	)

--- a/seed/go-sdk/path-parameters/no-custom-config/user/raw_client.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/user/raw_client.go
@@ -30,8 +30,7 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 
 func (r *RawClient) GetUser(
 	ctx context.Context,
-	tenantId string,
-	userId string,
+	request *fern.GetUsersRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[*fern.User], error) {
 	options := core.NewRequestOptions(opts...)
@@ -42,8 +41,8 @@ func (r *RawClient) GetUser(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/user/%v",
-		tenantId,
-		userId,
+		request.TenantId,
+		request.UserId,
 	)
 	headers := internal.MergeHeaders(
 		r.header.Clone(),
@@ -60,6 +59,7 @@ func (r *RawClient) GetUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
+			Request:         request,
 			Response:        &response,
 		},
 	)
@@ -120,8 +120,6 @@ func (r *RawClient) CreateUser(
 
 func (r *RawClient) UpdateUser(
 	ctx context.Context,
-	tenantId string,
-	userId string,
 	request *fern.UpdateUserRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[*fern.User], error) {
@@ -133,8 +131,8 @@ func (r *RawClient) UpdateUser(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/user/%v",
-		tenantId,
-		userId,
+		request.TenantId,
+		request.UserId,
 	)
 	headers := internal.MergeHeaders(
 		r.header.Clone(),
@@ -167,8 +165,6 @@ func (r *RawClient) UpdateUser(
 
 func (r *RawClient) SearchUsers(
 	ctx context.Context,
-	tenantId string,
-	userId string,
 	request *fern.SearchUsersRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[[]*fern.User], error) {
@@ -180,8 +176,8 @@ func (r *RawClient) SearchUsers(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/user/%v/search",
-		tenantId,
-		userId,
+		request.TenantId,
+		request.UserId,
 	)
 	queryParams, err := internal.QueryValues(request)
 	if err != nil {

--- a/seed/go-sdk/path-parameters/package-name/organizations/raw_client.go
+++ b/seed/go-sdk/path-parameters/package-name/organizations/raw_client.go
@@ -75,9 +75,7 @@ func (r *RawClient) GetOrganization(
 
 func (r *RawClient) GetOrganizationUser(
 	ctx context.Context,
-	tenantId string,
-	organizationId string,
-	userId string,
+	request *path.GetOrganizationUserRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[*path.User], error) {
 	options := core.NewRequestOptions(opts...)
@@ -88,9 +86,9 @@ func (r *RawClient) GetOrganizationUser(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/organizations/%v/users/%v",
-		tenantId,
-		organizationId,
-		userId,
+		request.TenantId,
+		request.OrganizationId,
+		request.UserId,
 	)
 	headers := internal.MergeHeaders(
 		r.header.Clone(),
@@ -107,6 +105,7 @@ func (r *RawClient) GetOrganizationUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
+			Request:         request,
 			Response:        &response,
 		},
 	)

--- a/seed/go-sdk/path-parameters/package-name/organizations/raw_client.go
+++ b/seed/go-sdk/path-parameters/package-name/organizations/raw_client.go
@@ -105,7 +105,6 @@ func (r *RawClient) GetOrganizationUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
-			Request:         request,
 			Response:        &response,
 		},
 	)

--- a/seed/go-sdk/path-parameters/package-name/user/raw_client.go
+++ b/seed/go-sdk/path-parameters/package-name/user/raw_client.go
@@ -59,7 +59,6 @@ func (r *RawClient) GetUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
-			Request:         request,
 			Response:        &response,
 		},
 	)

--- a/seed/go-sdk/path-parameters/package-name/user/raw_client.go
+++ b/seed/go-sdk/path-parameters/package-name/user/raw_client.go
@@ -30,8 +30,7 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 
 func (r *RawClient) GetUser(
 	ctx context.Context,
-	tenantId string,
-	userId string,
+	request *path.GetUsersRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[*path.User], error) {
 	options := core.NewRequestOptions(opts...)
@@ -42,8 +41,8 @@ func (r *RawClient) GetUser(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/user/%v",
-		tenantId,
-		userId,
+		request.TenantId,
+		request.UserId,
 	)
 	headers := internal.MergeHeaders(
 		r.header.Clone(),
@@ -60,6 +59,7 @@ func (r *RawClient) GetUser(
 			BodyProperties:  options.BodyProperties,
 			QueryParameters: options.QueryParameters,
 			Client:          options.HTTPClient,
+			Request:         request,
 			Response:        &response,
 		},
 	)
@@ -120,8 +120,6 @@ func (r *RawClient) CreateUser(
 
 func (r *RawClient) UpdateUser(
 	ctx context.Context,
-	tenantId string,
-	userId string,
 	request *path.UpdateUserRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[*path.User], error) {
@@ -133,8 +131,8 @@ func (r *RawClient) UpdateUser(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/user/%v",
-		tenantId,
-		userId,
+		request.TenantId,
+		request.UserId,
 	)
 	headers := internal.MergeHeaders(
 		r.header.Clone(),
@@ -167,8 +165,6 @@ func (r *RawClient) UpdateUser(
 
 func (r *RawClient) SearchUsers(
 	ctx context.Context,
-	tenantId string,
-	userId string,
 	request *path.SearchUsersRequest,
 	opts ...option.RequestOption,
 ) (*core.Response[[]*path.User], error) {
@@ -180,8 +176,8 @@ func (r *RawClient) SearchUsers(
 	)
 	endpointURL := internal.EncodeURL(
 		baseURL+"/%v/user/%v/search",
-		tenantId,
-		userId,
+		request.TenantId,
+		request.UserId,
 	)
 	queryParams, err := internal.QueryValues(request)
 	if err != nil {

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -176,6 +176,7 @@ scripts:
 allowedFailures:
   - alias-extends
   - bytes
+  - bytes-download
   - enum
   - exhaustive
   - literal


### PR DESCRIPTION
As a follow-up to https://github.com/fern-api/fern/pull/7502, this adds support for retrieving raw response headers for `multipart/form-data` endpoints.