### PR TITLE
fix(typescript): Change 2.0.0 release date to 2025-07-02 in versions.yml

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -18,7 +18,7 @@
         With these defaults, the generated SDKs will have _**ZERO**_ dependencies (excluding devDependencies and `ws` in case of WebSocket generation).
         As a result, the SDKs are smaller, faster, more secure, and easier to use.
       type: feat
-  createdAt: '2025-07-01'
+  createdAt: '2025-07-02'
   irVersion: 58
 
 - version: 1.10.6


### PR DESCRIPTION
## Description
Change 2.0.0 release date to 2025-07-02 in versions.yml

This should fix this ordering issue in the docs:
<img width="735" alt="Screenshot 2025-07-02 at 1 56 16 PM" src="https://github.com/user-attachments/assets/bc79256d-4088-4b94-b23b-0bb25da39f2f" />


## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

