### PR TITLE
fix(docs): Update preview-your-sdk-locally.mdx

### DIFF
--- a/fern/pages/sdks/getting-started/preview-your-sdk-locally.mdx
+++ b/fern/pages/sdks/getting-started/preview-your-sdk-locally.mdx
@@ -23,7 +23,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 3.0.0
+        version: 4.23.2
         output:
           location: pypi
           package-name: imdb


### PR DESCRIPTION
## Description
Update the example generator version in Python 

## Changes Made
Changed version from 3.0.0 (that doesnt actually exist) to a more current version that does exist 4.23.2

## Testing
Tested that version 4.23.2 works for the python generator

