### PR TITLE
feat(typescript): Improve generated package.json files

### DIFF
--- a/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
+++ b/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
@@ -36,7 +36,7 @@ export function constructNpmPackage({
                 version: outputMode.version,
                 private: isPackagePrivate,
                 publishInfo: undefined,
-                repoUrl: outputMode.repoUrl,
+                repoUrl: getRepoUrlFromUrl(outputMode.repoUrl),
                 license: generatorConfig.license?._visit({
                     basic: (basic) => basic.id,
                     custom: (custom) => `See ${custom.filename}`,
@@ -48,4 +48,39 @@ export function constructNpmPackage({
         default:
             throw new Error(`Encountered unknown output mode: ${outputMode}`);
     }
+}
+
+function getRepoUrlFromUrl(repoUrl: string): string {
+    if (repoUrl.startsWith("https://github.com/")) {
+        return `github:${removeGitSuffix(repoUrl).replace("https://github.com/", "")}`;
+    }
+    if (repoUrl.startsWith("ssh://github.com/")) {
+        return `github:${removeGitSuffix(repoUrl).replace("ssh://github.com/", "")}`;
+    }
+    if (repoUrl.startsWith("https://bitbucket.org/")) {
+        return `bitbucket:${removeGitSuffix(repoUrl).replace("https://bitbucket.org/", "")}`;
+    }
+    if (repoUrl.startsWith("ssh://bitbucket.org/")) {
+        return `bitbucket:${removeGitSuffix(repoUrl).replace("ssh://bitbucket.org/", "")}`;
+    }
+    if (repoUrl.startsWith("https://gitlab.com/")) {
+        return `gitlab:${removeGitSuffix(repoUrl).replace("https://gitlab.com/", "")}`;
+    }
+    if (repoUrl.startsWith("ssh://gitlab.com/")) {
+        return `gitlab:${removeGitSuffix(repoUrl).replace("ssh://gitlab.com/", "")}`;
+    }
+    if (!repoUrl.startsWith("git+")) {
+        repoUrl = `git+${repoUrl}`;
+    }
+    if (!repoUrl.endsWith(".git")) {
+        repoUrl = `${repoUrl}.git`;
+    }
+    return repoUrl;
+}
+
+function removeGitSuffix(repoUrl: string): string {
+    if (repoUrl.endsWith(".git")) {
+        return repoUrl.slice(0, -4);
+    }
+    return repoUrl;
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,28 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.2.0
+  changelogEntry:
+    - summary: |
+        Improve generated package.json files:
+        * Add `engines` field to specify minimum Node.js version supported as Node.js 18.
+        * Add `sideEffects: false`
+        * Add `README.md` and `LICENSE` to `files` array
+        * Use GitHub shorthand for `repository` field.
+
+        You can override these fields using the `packageJson` config:
+        ```yml
+        # In generators.yml
+        groups:
+          ts-sdk:
+            generators:
+              - name: fernapi/fern-typescript-node-sdk
+                config:
+                  packageJson:
+                    engines:
+                      node: ">=16.0.0"
+        ```
+      type: feat
+  createdAt: '2025-07-03'
+  irVersion: 58
 - version: 2.1.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/BundledTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/BundledTypescriptProject.ts
@@ -285,6 +285,10 @@ export * from "./${BundledTypescriptProject.TYPES_DIRECTORY}/${folder}";
             } as any;
 
             draft["packageManager"] = "yarn@1.22.22";
+            draft["engines"] = {
+                node: ">=18.0.0"
+            };
+            draft["sideEffects"] = false;
         });
 
         packageJson = mergeExtraConfigs(packageJson, this.extraConfigs);

--- a/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
@@ -273,7 +273,12 @@ export class SimpleTypescriptProject extends TypescriptProject {
                     }, {}),
                     "./package.json": "./package.json"
                 },
-                files: [SimpleTypescriptProject.DIST_DIRECTORY, SimpleTypescriptProject.REFERENCE_FILENAME],
+                files: [
+                    SimpleTypescriptProject.DIST_DIRECTORY,
+                    SimpleTypescriptProject.REFERENCE_FILENAME,
+                    SimpleTypescriptProject.README_FILENAME,
+                    SimpleTypescriptProject.LICENSE_FILENAME
+                ],
                 scripts: {
                     [SimpleTypescriptProject.FORMAT_SCRIPT_NAME]: "prettier . --write --ignore-unknown",
                     [SimpleTypescriptProject.BUILD_SCRIPT_NAME]: `yarn ${SimpleTypescriptProject.BUILD_CJS_SCRIPT_NAME} && yarn ${SimpleTypescriptProject.BUILD_ESM_SCRIPT_NAME}`,
@@ -330,6 +335,10 @@ export class SimpleTypescriptProject extends TypescriptProject {
             } as any;
 
             draft["packageManager"] = "yarn@1.22.22";
+            draft["engines"] = {
+                node: ">=18.0.0"
+            };
+            draft["sideEffects"] = false;
         });
 
         packageJson = mergeExtraConfigs(packageJson, this.extraConfigs);

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -31,59 +31,61 @@ export declare namespace TypescriptProject {
 }
 
 export abstract class TypescriptProject {
-    protected static DEFAULT_SRC_DIRECTORY = "src" as const;
-    protected static TEST_DIRECTORY = "tests" as const;
-    protected static DIST_DIRECTORY = "dist" as const;
-    protected static SCRIPTS_DIRECTORY_NAME = "scripts" as const;
+    protected static readonly DEFAULT_SRC_DIRECTORY = "src";
+    protected static readonly TEST_DIRECTORY = "tests";
+    protected static readonly DIST_DIRECTORY = "dist";
+    protected static readonly SCRIPTS_DIRECTORY_NAME = "scripts";
 
-    protected static CJS_DIRECTORY = "cjs" as const;
-    protected static ESM_DIRECTORY = "esm" as const;
-    protected static TYPES_DIRECTORY = "types" as const;
+    protected static readonly CJS_DIRECTORY = "cjs";
+    protected static readonly ESM_DIRECTORY = "esm";
+    protected static readonly TYPES_DIRECTORY = "types";
 
-    protected static BUILD_SCRIPT_FILENAME = "build.js" as const;
-    protected static NODE_DIST_DIRECTORY = "node" as const;
-    protected static BROWSER_DIST_DIRECTORY = "browser" as const;
-    protected static BROWSER_ESM_DIST_DIRECTORY =
+    protected static readonly BUILD_SCRIPT_FILENAME = "build.js";
+    protected static readonly NODE_DIST_DIRECTORY = "node";
+    protected static readonly BROWSER_DIST_DIRECTORY = "browser";
+    protected static readonly BROWSER_ESM_DIST_DIRECTORY =
         `${TypescriptProject.BROWSER_DIST_DIRECTORY}/${TypescriptProject.ESM_DIRECTORY}` as const;
-    protected static BROWSER_CJS_DIST_DIRECTORY =
+    protected static readonly BROWSER_CJS_DIST_DIRECTORY =
         `${TypescriptProject.BROWSER_DIST_DIRECTORY}/${TypescriptProject.CJS_DIRECTORY}` as const;
-    protected static API_BUNDLE_FILENAME = "index.js" as const;
+    protected static readonly API_BUNDLE_FILENAME = "index.js";
 
-    protected static PRETTIER_RC_FILENAME = ".prettierrc.yml" as const;
-    protected static TS_CONFIG_BASE_FILENAME = "tsconfig.base.json" as const;
-    protected static TS_CONFIG_FILENAME = "tsconfig.json" as const;
-    protected static TS_CONFIG_ESM_FILENAME = "tsconfig.esm.json" as const;
-    protected static TS_CONFIG_CJS_FILENAME = "tsconfig.cjs.json" as const;
-    protected static PACKAGE_JSON_FILENAME = "package.json" as const;
-    protected static JSR_JSON_FILENAME = "jsr.json" as const;
-    protected static GIT_IGNORE_FILENAME = ".gitignore" as const;
-    protected static NPM_IGNORE_FILENAME = ".npmignore" as const;
-    protected static FERN_IGNORE_FILENAME = ".fernignore" as const;
-    protected static REFERENCE_FILENAME = "reference.md" as const;
+    protected static readonly PRETTIER_RC_FILENAME = ".prettierrc.yml";
+    protected static readonly TS_CONFIG_BASE_FILENAME = "tsconfig.base.json";
+    protected static readonly TS_CONFIG_FILENAME = "tsconfig.json";
+    protected static readonly TS_CONFIG_ESM_FILENAME = "tsconfig.esm.json";
+    protected static readonly TS_CONFIG_CJS_FILENAME = "tsconfig.cjs.json";
+    protected static readonly PACKAGE_JSON_FILENAME = "package.json";
+    protected static readonly JSR_JSON_FILENAME = "jsr.json";
+    protected static readonly GIT_IGNORE_FILENAME = ".gitignore";
+    protected static readonly NPM_IGNORE_FILENAME = ".npmignore";
+    protected static readonly FERN_IGNORE_FILENAME = ".fernignore";
+    protected static readonly REFERENCE_FILENAME = "reference.md";
+    protected static readonly README_FILENAME = "README.md";
+    protected static readonly LICENSE_FILENAME = "LICENSE";
 
-    protected static FORMAT_SCRIPT_NAME = "format" as const;
-    protected static COMPILE_SCRIPT_NAME = "compile" as const;
-    protected static BUNDLE_SCRIPT_NAME = "bundle" as const;
-    protected static BUILD_SCRIPT_NAME = "build" as const;
-    protected static BUILD_CJS_SCRIPT_NAME = "build:cjs" as const;
-    protected static BUILD_ESM_SCRIPT_NAME = "build:esm" as const;
+    protected static readonly FORMAT_SCRIPT_NAME = "format";
+    protected static readonly COMPILE_SCRIPT_NAME = "compile";
+    protected static readonly BUNDLE_SCRIPT_NAME = "bundle";
+    protected static readonly BUILD_SCRIPT_NAME = "build";
+    protected static readonly BUILD_CJS_SCRIPT_NAME = "build:cjs";
+    protected static readonly BUILD_ESM_SCRIPT_NAME = "build:esm";
 
-    private exportSerde: boolean;
-    protected npmPackage: NpmPackage | undefined;
-    protected dependencies: PackageDependencies;
-    protected extraConfigs: Record<string, unknown> | undefined;
-    protected outputJsr: boolean;
-    protected volume = new Volume();
-    public tsMorphProject: Project;
-    public extraFiles: Record<string, string>;
-    protected extraDependencies: Record<string, string>;
-    protected extraDevDependencies: Record<string, string>;
-    protected extraPeerDependenciesMeta: Record<string, unknown>;
-    protected extraPeerDependencies: Record<string, string>;
-    protected extraScripts: Record<string, string>;
-    protected packagePath: string;
+    private readonly exportSerde: boolean;
+    protected readonly npmPackage: NpmPackage | undefined;
+    protected readonly dependencies: PackageDependencies;
+    protected readonly extraConfigs: Record<string, unknown> | undefined;
+    protected readonly outputJsr: boolean;
+    protected readonly volume = new Volume();
+    public readonly tsMorphProject: Project;
+    public readonly extraFiles: Record<string, string>;
+    protected readonly extraDependencies: Record<string, string>;
+    protected readonly extraDevDependencies: Record<string, string>;
+    protected readonly extraPeerDependenciesMeta: Record<string, unknown>;
+    protected readonly extraPeerDependencies: Record<string, string>;
+    protected readonly extraScripts: Record<string, string>;
+    protected readonly packagePath: string;
 
-    private runScripts: boolean;
+    private readonly runScripts: boolean;
 
     constructor({
         npmPackage,

--- a/seed/ts-sdk/accept-header/package.json
+++ b/seed/ts-sdk/accept-header/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/accept-header",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/accept-header/fern",
+    "repository": "github:accept-header/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/alias-extends/package.json
+++ b/seed/ts-sdk/alias-extends/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/alias-extends",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/alias-extends/fern",
+    "repository": "github:alias-extends/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/alias/package.json
+++ b/seed/ts-sdk/alias/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/alias",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/alias/fern",
+    "repository": "github:alias/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/any-auth/package.json
+++ b/seed/ts-sdk/any-auth/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/any-auth",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/any-auth/fern",
+    "repository": "github:any-auth/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/api-wide-base-path/package.json
+++ b/seed/ts-sdk/api-wide-base-path/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/api-wide-base-path",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/api-wide-base-path/fern",
+    "repository": "github:api-wide-base-path/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/audiences/no-custom-config/package.json
+++ b/seed/ts-sdk/audiences/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/audiences",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/audiences/fern",
+    "repository": "github:audiences/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/audiences/with-partner-audience/package.json
+++ b/seed/ts-sdk/audiences/with-partner-audience/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/audiences",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/audiences/fern",
+    "repository": "github:audiences/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/auth-environment-variables/package.json
+++ b/seed/ts-sdk/auth-environment-variables/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/auth-environment-variables",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/auth-environment-variables/fern",
+    "repository": "github:auth-environment-variables/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/basic-auth-environment-variables/package.json
+++ b/seed/ts-sdk/basic-auth-environment-variables/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/basic-auth-environment-variables",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/basic-auth-environment-variables/fern",
+    "repository": "github:basic-auth-environment-variables/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/basic-auth/package.json
+++ b/seed/ts-sdk/basic-auth/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/basic-auth",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/basic-auth/fern",
+    "repository": "github:basic-auth/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/bearer-token-environment-variable/package.json
+++ b/seed/ts-sdk/bearer-token-environment-variable/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/bearer-token-environment-variable",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/bearer-token-environment-variable/fern",
+    "repository": "github:bearer-token-environment-variable/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/bytes-upload/package.json
+++ b/seed/ts-sdk/bytes-upload/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/bytes-upload",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/bytes-upload/fern",
+    "repository": "github:bytes-upload/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/circular-references-advanced/package.json
+++ b/seed/ts-sdk/circular-references-advanced/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/circular-references-advanced",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/circular-references-advanced/fern",
+    "repository": "github:circular-references-advanced/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/circular-references/package.json
+++ b/seed/ts-sdk/circular-references/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/circular-references",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/circular-references/fern",
+    "repository": "github:circular-references/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/content-type/package.json
+++ b/seed/ts-sdk/content-type/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/content-type",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/content-type/fern",
+    "repository": "github:content-type/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/cross-package-type-names/package.json
+++ b/seed/ts-sdk/cross-package-type-names/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/cross-package-type-names",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/cross-package-type-names/fern",
+    "repository": "github:cross-package-type-names/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/custom-auth/package.json
+++ b/seed/ts-sdk/custom-auth/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/custom-auth",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/custom-auth/fern",
+    "repository": "github:custom-auth/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/enum/package.json
+++ b/seed/ts-sdk/enum/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/enum",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/enum/fern",
+    "repository": "github:enum/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/error-property/union-utils/package.json
+++ b/seed/ts-sdk/error-property/union-utils/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/error-property",
     "version": "0.0.1",
     "private": true,
-    "repository": "https://github.com/error-property/fern",
+    "repository": "github:error-property/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/examples/examples-with-api-reference/package.json
+++ b/seed/ts-sdk/examples/examples-with-api-reference/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/examples",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/examples/fern",
+    "repository": "github:examples/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/examples/retain-original-casing/package.json
+++ b/seed/ts-sdk/examples/retain-original-casing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/examples",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/examples/fern",
+    "repository": "github:examples/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/package.json
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/package.json
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/bigint/package.json
+++ b/seed/ts-sdk/exhaustive/bigint/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/bundle/package.json
+++ b/seed/ts-sdk/exhaustive/bundle/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
         "compile": "tsc",
@@ -43,5 +43,9 @@
         "os": false,
         "path": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/custom-package-json/package.json
+++ b/seed/ts-sdk/exhaustive/custom-package-json/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.2",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
         "compile": "tsc",
@@ -47,6 +47,10 @@
         "execa": false
     },
     "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=16.0.0"
+    },
+    "sideEffects": false,
     "dependencies": {
         "stream": "^0.0.2",
         "qs": "^6.11.2"

--- a/seed/ts-sdk/exhaustive/dev-dependencies/package.json
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
         "compile": "tsc",
@@ -51,5 +51,9 @@
         "os": false,
         "path": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/jsr/package.json
+++ b/seed/ts-sdk/exhaustive/jsr/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/no-custom-config/package.json
+++ b/seed/ts-sdk/exhaustive/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/node-fetch/package.json
+++ b/seed/ts-sdk/exhaustive/node-fetch/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -59,5 +61,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/package.json
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/package-path/package.json
+++ b/seed/ts-sdk/exhaustive/package-path/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/package.json
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/serde-layer/package.json
+++ b/seed/ts-sdk/exhaustive/serde-layer/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/package.json
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/with-audiences/package.json
+++ b/seed/ts-sdk/exhaustive/with-audiences/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/exhaustive",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/exhaustive/fern",
+    "repository": "github:exhaustive/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/extends/package.json
+++ b/seed/ts-sdk/extends/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/extends",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/extends/fern",
+    "repository": "github:extends/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/extra-properties/package.json
+++ b/seed/ts-sdk/extra-properties/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/extra-properties",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/extra-properties/fern",
+    "repository": "github:extra-properties/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-download/file-download-response-headers/package.json
+++ b/seed/ts-sdk/file-download/file-download-response-headers/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-download",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-download/fern",
+    "repository": "github:file-download/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-download/no-custom-config/package.json
+++ b/seed/ts-sdk/file-download/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-download",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-download/fern",
+    "repository": "github:file-download/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-download/stream/package.json
+++ b/seed/ts-sdk/file-download/stream/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-download",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-download/fern",
+    "repository": "github:file-download/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-download/wrapper/package.json
+++ b/seed/ts-sdk/file-download/wrapper/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-download",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-download/fern",
+    "repository": "github:file-download/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -59,5 +61,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-upload/form-data-node16/package.json
+++ b/seed/ts-sdk/file-upload/form-data-node16/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-upload",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-upload/fern",
+    "repository": "github:file-upload/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -60,5 +62,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-upload/inline/package.json
+++ b/seed/ts-sdk/file-upload/inline/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-upload",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-upload/fern",
+    "repository": "github:file-upload/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-upload/no-custom-config/package.json
+++ b/seed/ts-sdk/file-upload/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-upload",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-upload/fern",
+    "repository": "github:file-upload/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-upload/serde/package.json
+++ b/seed/ts-sdk/file-upload/serde/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-upload",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-upload/fern",
+    "repository": "github:file-upload/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/file-upload/wrapper/package.json
+++ b/seed/ts-sdk/file-upload/wrapper/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/file-upload",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/file-upload/fern",
+    "repository": "github:file-upload/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -59,5 +61,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/folders/package.json
+++ b/seed/ts-sdk/folders/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/folders",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/folders/fern",
+    "repository": "github:folders/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/http-head/package.json
+++ b/seed/ts-sdk/http-head/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/http-head",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/http-head/fern",
+    "repository": "github:http-head/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/idempotency-headers/package.json
+++ b/seed/ts-sdk/idempotency-headers/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/idempotency-headers",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/idempotency-headers/fern",
+    "repository": "github:idempotency-headers/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/imdb/branded-string-aliases/package.json
+++ b/seed/ts-sdk/imdb/branded-string-aliases/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/imdb",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/imdb/fern",
+    "repository": "github:imdb/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/imdb/no-custom-config/package.json
+++ b/seed/ts-sdk/imdb/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/imdb",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/imdb/fern",
+    "repository": "github:imdb/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/imdb/noScripts/package.json
+++ b/seed/ts-sdk/imdb/noScripts/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/imdb",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/imdb/fern",
+    "repository": "github:imdb/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/imdb/omit-undefined/package.json
+++ b/seed/ts-sdk/imdb/omit-undefined/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/imdb",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/imdb/fern",
+    "repository": "github:imdb/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/license/package.json
+++ b/seed/ts-sdk/license/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/license",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/license/fern",
+    "repository": "github:license/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/literal/package.json
+++ b/seed/ts-sdk/literal/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/literal",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/literal/fern",
+    "repository": "github:literal/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/mixed-case/no-custom-config/package.json
+++ b/seed/ts-sdk/mixed-case/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/mixed-case",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/mixed-case/fern",
+    "repository": "github:mixed-case/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/mixed-case/retain-original-casing/package.json
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/mixed-case",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/mixed-case/fern",
+    "repository": "github:mixed-case/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/mixed-file-directory/package.json
+++ b/seed/ts-sdk/mixed-file-directory/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/mixed-file-directory",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/mixed-file-directory/fern",
+    "repository": "github:mixed-file-directory/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/multi-line-docs/package.json
+++ b/seed/ts-sdk/multi-line-docs/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/multi-line-docs",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/multi-line-docs/fern",
+    "repository": "github:multi-line-docs/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/multi-url-environment-no-default/package.json
+++ b/seed/ts-sdk/multi-url-environment-no-default/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/multi-url-environment-no-default",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/multi-url-environment-no-default/fern",
+    "repository": "github:multi-url-environment-no-default/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/multi-url-environment/package.json
+++ b/seed/ts-sdk/multi-url-environment/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/multi-url-environment",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/multi-url-environment/fern",
+    "repository": "github:multi-url-environment/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/no-environment/package.json
+++ b/seed/ts-sdk/no-environment/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/no-environment",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/no-environment/fern",
+    "repository": "github:no-environment/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/nullable/package.json
+++ b/seed/ts-sdk/nullable/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/nullable",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/nullable/fern",
+    "repository": "github:nullable/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/oauth-client-credentials-custom/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-custom/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/oauth-client-credentials-custom",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/oauth-client-credentials-custom/fern",
+    "repository": "github:oauth-client-credentials-custom/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/oauth-client-credentials-default/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-default/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/oauth-client-credentials-default",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/oauth-client-credentials-default/fern",
+    "repository": "github:oauth-client-credentials-default/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/oauth-client-credentials-environment-variables",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/oauth-client-credentials-environment-variables/fern",
+    "repository": "github:oauth-client-credentials-environment-variables/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/oauth-client-credentials-nested-root",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/oauth-client-credentials-nested-root/fern",
+    "repository": "github:oauth-client-credentials-nested-root/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/oauth-client-credentials-nested-root",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/oauth-client-credentials-nested-root/fern",
+    "repository": "github:oauth-client-credentials-nested-root/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/oauth-client-credentials/package.json
+++ b/seed/ts-sdk/oauth-client-credentials/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/oauth-client-credentials",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/oauth-client-credentials/fern",
+    "repository": "github:oauth-client-credentials/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/object/package.json
+++ b/seed/ts-sdk/object/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/object",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/object/fern",
+    "repository": "github:object/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/objects-with-imports/package.json
+++ b/seed/ts-sdk/objects-with-imports/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/objects-with-imports",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/objects-with-imports/fern",
+    "repository": "github:objects-with-imports/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/optional/package.json
+++ b/seed/ts-sdk/optional/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/optional",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/optional/fern",
+    "repository": "github:optional/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/package-yml/package.json
+++ b/seed/ts-sdk/package-yml/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/package-yml",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/package-yml/fern",
+    "repository": "github:package-yml/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/pagination-custom/package.json
+++ b/seed/ts-sdk/pagination-custom/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/pagination-custom",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/pagination-custom/fern",
+    "repository": "github:pagination-custom/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/pagination/package.json
+++ b/seed/ts-sdk/pagination/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/pagination",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/pagination/fern",
+    "repository": "github:pagination/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/path-parameters/default/package.json
+++ b/seed/ts-sdk/path-parameters/default/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/path-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/path-parameters/fern",
+    "repository": "github:path-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/package.json
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/path-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/path-parameters/fern",
+    "repository": "github:path-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/package.json
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/path-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/path-parameters/fern",
+    "repository": "github:path-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/package.json
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/path-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/path-parameters/fern",
+    "repository": "github:path-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/path-parameters/retain-original-casing/package.json
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/path-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/path-parameters/fern",
+    "repository": "github:path-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/plain-text/package.json
+++ b/seed/ts-sdk/plain-text/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/plain-text",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/plain-text/fern",
+    "repository": "github:plain-text/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/public-object/package.json
+++ b/seed/ts-sdk/public-object/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/public-object",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/public-object/fern",
+    "repository": "github:public-object/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/query-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/query-parameters/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/query-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/query-parameters/fern",
+    "repository": "github:query-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/query-parameters/serde-layer-query/package.json
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/query-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/query-parameters/fern",
+    "repository": "github:query-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/request-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/request-parameters/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/request-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/request-parameters/fern",
+    "repository": "github:request-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/package.json
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/request-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/request-parameters/fern",
+    "repository": "github:request-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/package.json
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/request-parameters",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/request-parameters/fern",
+    "repository": "github:request-parameters/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/reserved-keywords/package.json
+++ b/seed/ts-sdk/reserved-keywords/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/reserved-keywords",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/reserved-keywords/fern",
+    "repository": "github:reserved-keywords/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/response-property/package.json
+++ b/seed/ts-sdk/response-property/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/response-property",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/response-property/fern",
+    "repository": "github:response-property/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -111,6 +111,8 @@ fixtures:
           browser:
             command-exists: false
             execa: false
+          engines:
+            node: ">=16.0.0"
       outputFolder: custom-package-json
     - customConfig:
         retainOriginalCasing: true

--- a/seed/ts-sdk/server-sent-event-examples/package.json
+++ b/seed/ts-sdk/server-sent-event-examples/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/server-sent-event-examples",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/server-sent-event-examples/fern",
+    "repository": "github:server-sent-event-examples/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/server-sent-events/package.json
+++ b/seed/ts-sdk/server-sent-events/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/server-sent-events",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/server-sent-events/fern",
+    "repository": "github:server-sent-events/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/simple-fhir/package.json
+++ b/seed/ts-sdk/simple-fhir/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/simple-fhir",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/simple-fhir/fern",
+    "repository": "github:simple-fhir/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/single-url-environment-default/package.json
+++ b/seed/ts-sdk/single-url-environment-default/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/single-url-environment-default",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/single-url-environment-default/fern",
+    "repository": "github:single-url-environment-default/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/single-url-environment-no-default/package.json
+++ b/seed/ts-sdk/single-url-environment-no-default/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/single-url-environment-no-default",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/single-url-environment-no-default/fern",
+    "repository": "github:single-url-environment-no-default/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/streaming-parameter/package.json
+++ b/seed/ts-sdk/streaming-parameter/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/streaming-parameter",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/streaming-parameter/fern",
+    "repository": "github:streaming-parameter/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/package.json
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/streaming",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/streaming/fern",
+    "repository": "github:streaming/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/streaming/no-custom-config/package.json
+++ b/seed/ts-sdk/streaming/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/streaming",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/streaming/fern",
+    "repository": "github:streaming/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/streaming/no-serde-layer/package.json
+++ b/seed/ts-sdk/streaming/no-serde-layer/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/streaming",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/streaming/fern",
+    "repository": "github:streaming/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/streaming/wrapper/package.json
+++ b/seed/ts-sdk/streaming/wrapper/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/streaming",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/streaming/fern",
+    "repository": "github:streaming/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -59,5 +61,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/trace/exhaustive/package.json
+++ b/seed/ts-sdk/trace/exhaustive/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/trace",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/trace/fern",
+    "repository": "github:trace/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/trace/no-custom-config/package.json
+++ b/seed/ts-sdk/trace/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/trace",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/trace/fern",
+    "repository": "github:trace/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/trace/serde-no-throwing/package.json
+++ b/seed/ts-sdk/trace/serde-no-throwing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/trace",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/trace/fern",
+    "repository": "github:trace/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/trace/serde-trace/package.json
+++ b/seed/ts-sdk/trace/serde-trace/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/trace",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/trace/fern",
+    "repository": "github:trace/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -67,5 +69,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/ts-express-casing/package.json
+++ b/seed/ts-sdk/ts-express-casing/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/ts-express-casing",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/ts-express-casing/fern",
+    "repository": "github:ts-express-casing/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/ts-inline-types/inline/package.json
+++ b/seed/ts-sdk/ts-inline-types/inline/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/ts-inline-types",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/ts-inline-types/fern",
+    "repository": "github:ts-inline-types/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/ts-inline-types/no-inline/package.json
+++ b/seed/ts-sdk/ts-inline-types/no-inline/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/ts-inline-types",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/ts-inline-types/fern",
+    "repository": "github:ts-inline-types/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/package.json
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/undiscriminated-unions",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/undiscriminated-unions/fern",
+    "repository": "github:undiscriminated-unions/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/package.json
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/undiscriminated-unions",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/undiscriminated-unions/fern",
+    "repository": "github:undiscriminated-unions/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/unions/package.json
+++ b/seed/ts-sdk/unions/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/unions",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/unions/fern",
+    "repository": "github:unions/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/unknown/no-custom-config/package.json
+++ b/seed/ts-sdk/unknown/no-custom-config/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/unknown",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/unknown/fern",
+    "repository": "github:unknown/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/unknown/unknown-as-any/package.json
+++ b/seed/ts-sdk/unknown/unknown-as-any/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/unknown",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/unknown/fern",
+    "repository": "github:unknown/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/validation/package.json
+++ b/seed/ts-sdk/validation/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/validation",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/validation/fern",
+    "repository": "github:validation/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/variables/package.json
+++ b/seed/ts-sdk/variables/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/variables",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/variables/fern",
+    "repository": "github:variables/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/version-no-default/package.json
+++ b/seed/ts-sdk/version-no-default/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/version-no-default",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/version-no-default/fern",
+    "repository": "github:version-no-default/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/version/package.json
+++ b/seed/ts-sdk/version/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/version",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/version/fern",
+    "repository": "github:version/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/websocket/no-serde/package.json
+++ b/seed/ts-sdk/websocket/no-serde/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/websocket",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/websocket/fern",
+    "repository": "github:websocket/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -59,5 +61,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/websocket/no-websocket-clients/package.json
+++ b/seed/ts-sdk/websocket/no-websocket-clients/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/websocket",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/websocket/fern",
+    "repository": "github:websocket/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -24,7 +24,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -55,5 +57,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }

--- a/seed/ts-sdk/websocket/serde/package.json
+++ b/seed/ts-sdk/websocket/serde/package.json
@@ -2,7 +2,7 @@
     "name": "@fern/websocket",
     "version": "0.0.1",
     "private": false,
-    "repository": "https://github.com/websocket/fern",
+    "repository": "github:websocket/fern",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
@@ -36,7 +36,9 @@
     },
     "files": [
         "dist",
-        "reference.md"
+        "reference.md",
+        "README.md",
+        "LICENSE"
     ],
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
@@ -71,5 +73,9 @@
         "path": false,
         "stream": false
     },
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false
 }


### PR DESCRIPTION
## Description
Improve generated package.json files:
* Add `engines` field to specify minimum Node.js version supported as Node.js 18.
* Add `sideEffects: false`
* Add `README.md` and `LICENSE` to `files` array
* Use GitHub shorthand for `repository` field.

You can override these fields using the `packageJson` config:
```yml
# In generators.yml
groups:
  ts-sdk:
    generators:
      - name: fernapi/fern-typescript-node-sdk
        config:
          packageJson:
            engines:
              node: ">=16.0.0"
```

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

