### PR TITLE
fix(typescript): websocket serde layer passes through unrecognized properties

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/GeneratedWebsocketSocketClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedWebsocketSocketClassImpl.ts
@@ -21,6 +21,9 @@ export declare namespace GeneratedWebsocketSocketClassImpl {
         includeSerdeLayer: boolean;
         channel: WebSocketChannel;
         serviceClassName: string;
+        retainOriginalCasing: boolean;
+        omitUndefined: boolean;
+        skipResponseValidation: boolean;
     }
 }
 
@@ -39,12 +42,18 @@ export class GeneratedWebsocketSocketClassImpl implements GeneratedWebsocketSock
     private readonly includeSerdeLayer: boolean;
     private readonly serviceClassName: string;
     private readonly packageId: PackageId;
+    private readonly retainOriginalCasing: boolean;
+    private readonly omitUndefined: boolean;
+    private readonly skipResponseValidation: boolean;
 
-    constructor({ packageId, includeSerdeLayer, channel, serviceClassName }: GeneratedWebsocketSocketClassImpl.Init) {
+    constructor({ packageId, includeSerdeLayer, channel, serviceClassName, retainOriginalCasing, omitUndefined, skipResponseValidation }: GeneratedWebsocketSocketClassImpl.Init) {
         this.includeSerdeLayer = includeSerdeLayer;
         this.channel = channel;
         this.packageId = packageId;
         this.serviceClassName = serviceClassName;
+        this.retainOriginalCasing = retainOriginalCasing;
+        this.omitUndefined = omitUndefined;
+        this.skipResponseValidation = skipResponseValidation;
     }
 
     public writeToFile(context: SdkContext): void {
@@ -560,12 +569,12 @@ export class GeneratedWebsocketSocketClassImpl implements GeneratedWebsocketSock
                 return context.typeSchema
                     .getSchemaOfTypeReference(subscribeMessage.bodyType)
                     .jsonOrThrow(referenceToRequestBody, {
-                        unrecognizedObjectKeys: "strip",
+                        unrecognizedObjectKeys: "passthrough",
                         allowUnrecognizedEnumValues: true,
                         allowUnrecognizedUnionMembers: true,
-                        skipValidation: true,
+                        skipValidation: this.skipResponseValidation,
                         breadcrumbsPrefix: [],
-                        omitUndefined: false
+                        omitUndefined: this.omitUndefined
                     });
         }
     }

--- a/generators/typescript/sdk/client-class-generator/src/WebsocketClassGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/WebsocketClassGenerator.ts
@@ -8,6 +8,9 @@ import { GeneratedWebsocketSocketClassImpl } from "./GeneratedWebsocketSocketCla
 export declare namespace WebsocketClassGenerator {
     export interface Init {
         intermediateRepresentation: IntermediateRepresentation;
+        retainOriginalCasing: boolean;
+        omitUndefined: boolean;
+        skipResponseValidation: boolean;
     }
 
     export namespace generateWebsocketSocket {
@@ -22,9 +25,15 @@ export declare namespace WebsocketClassGenerator {
 
 export class WebsocketClassGenerator {
     private intermediateRepresentation: IntermediateRepresentation;
+    private retainOriginalCasing: boolean;
+    private omitUndefined: boolean;
+    private skipResponseValidation: boolean;
 
-    constructor({ intermediateRepresentation }: WebsocketClassGenerator.Init) {
+    constructor({ intermediateRepresentation, retainOriginalCasing, omitUndefined, skipResponseValidation }: WebsocketClassGenerator.Init) {
         this.intermediateRepresentation = intermediateRepresentation;
+        this.retainOriginalCasing = retainOriginalCasing;
+        this.omitUndefined = omitUndefined;
+        this.skipResponseValidation = skipResponseValidation;
     }
 
     public generateWebsocketSocket({
@@ -37,7 +46,10 @@ export class WebsocketClassGenerator {
             packageId,
             channel,
             serviceClassName,
-            includeSerdeLayer
+            includeSerdeLayer,
+            retainOriginalCasing: this.retainOriginalCasing,
+            omitUndefined: this.omitUndefined,
+            skipResponseValidation: this.skipResponseValidation,
         });
     }
 }

--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -430,7 +430,10 @@ export class SdkGenerator {
             useDefaultRequestParameterValues: config.useDefaultRequestParameterValues
         });
         this.websocketGenerator = new WebsocketClassGenerator({
-            intermediateRepresentation
+            intermediateRepresentation,
+            retainOriginalCasing: config.retainOriginalCasing,
+            omitUndefined: config.omitUndefined,
+            skipResponseValidation: config.skipResponseValidation
         });
         this.genericAPISdkErrorGenerator = new GenericAPISdkErrorGenerator();
         this.timeoutSdkErrorGenerator = new TimeoutSdkErrorGenerator();

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 2.4.1
+  changelogEntry:
+    - summary: |
+        When serde layer is enabled, WebSocket channels now pass through unrecognized properties 
+        instead of stripping them to preserve forwards compatibility.
+      type: fix
+  irVersion: 58   
+
 - version: 2.4.0
   changelogEntry:
     - summary: Fixes bug with query parameter and path paramter serialization in URL for WebSocket channels.

--- a/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Socket.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Socket.ts
@@ -85,10 +85,11 @@ export class RealtimeSocket {
     public sendSend(message: SeedWebsocket.SendEvent): void {
         this.assertSocketIsOpen();
         const jsonPayload = SendEvent.jsonOrThrow(message, {
-            unrecognizedObjectKeys: "strip",
+            unrecognizedObjectKeys: "passthrough",
             allowUnrecognizedUnionMembers: true,
             allowUnrecognizedEnumValues: true,
             skipValidation: true,
+            omitUndefined: true,
         });
         this.socket.send(JSON.stringify(jsonPayload));
     }
@@ -96,10 +97,11 @@ export class RealtimeSocket {
     public sendSendSnakeCase(message: SeedWebsocket.SendSnakeCase): void {
         this.assertSocketIsOpen();
         const jsonPayload = SendSnakeCase.jsonOrThrow(message, {
-            unrecognizedObjectKeys: "strip",
+            unrecognizedObjectKeys: "passthrough",
             allowUnrecognizedUnionMembers: true,
             allowUnrecognizedEnumValues: true,
             skipValidation: true,
+            omitUndefined: true,
         });
         this.socket.send(JSON.stringify(jsonPayload));
     }
@@ -107,10 +109,11 @@ export class RealtimeSocket {
     public sendSend2(message: SeedWebsocket.SendEvent2): void {
         this.assertSocketIsOpen();
         const jsonPayload = SendEvent2.jsonOrThrow(message, {
-            unrecognizedObjectKeys: "strip",
+            unrecognizedObjectKeys: "passthrough",
             allowUnrecognizedUnionMembers: true,
             allowUnrecognizedEnumValues: true,
             skipValidation: true,
+            omitUndefined: true,
         });
         this.socket.send(JSON.stringify(jsonPayload));
     }


### PR DESCRIPTION
## Description
When serde layer is enabled, WebSocket channels now pass through unrecognized properties 
instead of stripping them to preserve forwards compatibility.

## Changes Made
- Pass through serde related config into the WebsocketClassGenerator
- When deserializing data mark the behavior as `passthrough` instead of `strip`

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed

