### PR TITLE
chore(typescript): more websocket fixes

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/GeneratedWebsocketSocketClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedWebsocketSocketClassImpl.ts
@@ -453,7 +453,7 @@ export class GeneratedWebsocketSocketClassImpl implements GeneratedWebsocketSock
         return {
             kind: StructureKind.Method,
             name: "sendJson",
-            scope: Scope.Private,
+            scope: Scope.Protected,
             returnType: "void",
             parameters: [
                 {
@@ -477,7 +477,7 @@ export class GeneratedWebsocketSocketClassImpl implements GeneratedWebsocketSock
         return {
             kind: StructureKind.Method,
             name: "sendBinary",
-            scope: Scope.Private,
+            scope: Scope.Protected,
             returnType: "void",
             parameters: [
                 {

--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -166,7 +166,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 }),
                 ...(this.channel.queryParameters ?? []).map((queryParameter) => {
                     return {
-                        name: getPropertyKey(queryParameter.name.wireValue),
+                        name: this.getPropertyNameOfQueryParameter(queryParameter).propertyName,
                         type: getTextOfTsNode(context.type.getReferenceToType(queryParameter.valueType).typeNode),
                         hasQuestionToken: context.type.isOptional(queryParameter.valueType)
                     };
@@ -241,7 +241,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 ts.factory.createBindingElement(
                     undefined,
                     undefined,
-                    ts.factory.createIdentifier(queryParameter.name.wireValue)
+                    ts.factory.createIdentifier(this.getPropertyNameOfQueryParameter(queryParameter).propertyName)
                 )
             );
         }

--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -444,7 +444,8 @@ export class SdkGenerator {
         });
         this.websocketTypeSchemaGenerator = new WebsocketTypeSchemaGenerator({
             includeSerdeLayer: config.includeSerdeLayer,
-            omitUndefined: config.omitUndefined
+            omitUndefined: config.omitUndefined,
+            skipResponseValidation: config.skipResponseValidation
         });
         this.jestTestGenerator = new JestTestGenerator({
             ir: intermediateRepresentation,

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 2.4.2
+  changelogEntry:
+    - summary: |
+        Fixes a compile issue when WebSocket connect methods require query parameters with special characters. 
+        Fixes response deserialization in websockets to respect skipping validation. 
+      type: fix
+  irVersion: 58
+
 - version: 2.4.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/GeneratedWebsocketResponseSchemaImpl.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/GeneratedWebsocketResponseSchemaImpl.ts
@@ -12,6 +12,7 @@ export declare namespace GeneratedWebsocketResponseSchemaImpl {
         receiveMessages: WebSocketMessageBodyReference[];
         includeSerdeLayer: boolean;
         omitUndefined: boolean;
+        skipResponseValidation: boolean;
     }
 }
 
@@ -24,6 +25,7 @@ export class GeneratedWebsocketResponseSchemaImpl
     private receiveMessages: WebSocketMessageBodyReference[];
     private includeSerdeLayer: boolean;
     private omitUndefined: boolean;
+    private skipResponseValidation: boolean;
 
     constructor({
         packageId,
@@ -31,6 +33,7 @@ export class GeneratedWebsocketResponseSchemaImpl
         receiveMessages,
         includeSerdeLayer,
         omitUndefined,
+        skipResponseValidation,
         ...superInit
     }: GeneratedWebsocketResponseSchemaImpl.Init) {
         super(superInit);
@@ -39,6 +42,7 @@ export class GeneratedWebsocketResponseSchemaImpl
         this.receiveMessages = receiveMessages;
         this.includeSerdeLayer = includeSerdeLayer;
         this.omitUndefined = omitUndefined;
+        this.skipResponseValidation = skipResponseValidation;
     }
 
     public writeToFile(context: SdkContext): void {
@@ -51,7 +55,8 @@ export class GeneratedWebsocketResponseSchemaImpl
         }
         return this.getReferenceToZurgSchema(context).parse(referenceToRawResponse, {
             ...getSchemaOptions({
-                allowExtraFields: false,
+                allowExtraFields: true,
+                skipValidation: this.skipResponseValidation,
                 omitUndefined: this.omitUndefined
             })
         });

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/WebsocketTypeSchemaGenerator.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/WebsocketTypeSchemaGenerator.ts
@@ -8,6 +8,7 @@ export declare namespace WebsocketTypeSchemaGenerator {
     export interface Init {
         includeSerdeLayer: boolean;
         omitUndefined: boolean;
+        skipResponseValidation: boolean;
     }
 
     export namespace GeneratedWebsocketMessageBodySchema {
@@ -23,10 +24,12 @@ export declare namespace WebsocketTypeSchemaGenerator {
 export class WebsocketTypeSchemaGenerator {
     private includeSerdeLayer: boolean;
     private omitUndefined: boolean;
+    private skipResponseValidation: boolean;
 
-    constructor({ includeSerdeLayer, omitUndefined }: WebsocketTypeSchemaGenerator.Init) {
+    constructor({ includeSerdeLayer, omitUndefined, skipResponseValidation }: WebsocketTypeSchemaGenerator.Init) {
         this.includeSerdeLayer = includeSerdeLayer;
         this.omitUndefined = omitUndefined;
+        this.skipResponseValidation = skipResponseValidation;
     }
 
     public generateInlinedWebsocketMessageBodySchema({
@@ -41,7 +44,8 @@ export class WebsocketTypeSchemaGenerator {
             receiveMessages,
             typeName,
             includeSerdeLayer: this.includeSerdeLayer,
-            omitUndefined: this.omitUndefined
+            omitUndefined: this.omitUndefined,
+            skipResponseValidation: this.skipResponseValidation,
         });
     }
 }

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Socket.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Socket.ts
@@ -138,12 +138,14 @@ export class RealtimeSocket {
     }
 
     /** Send a binary payload to the websocket. */
-    private sendBinary(payload: ArrayBufferLike | Blob | ArrayBufferView): void {
+    protected sendBinary(payload: ArrayBufferLike | Blob | ArrayBufferView): void {
         this.socket.send(payload);
     }
 
     /** Send a JSON payload to the websocket. */
-    private sendJson(payload: SeedWebsocket.SendEvent | SeedWebsocket.SendSnakeCase | SeedWebsocket.SendEvent2): void {
+    protected sendJson(
+        payload: SeedWebsocket.SendEvent | SeedWebsocket.SendSnakeCase | SeedWebsocket.SendEvent2,
+    ): void {
         const jsonPayload = toJson(payload);
         this.socket.send(jsonPayload);
     }

--- a/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Socket.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Socket.ts
@@ -38,7 +38,10 @@ export class RealtimeSocket {
         const data = fromJson(event.data);
 
         const parsedResponse = serializers.RealtimeSocketResponse.parse(data, {
-            unrecognizedObjectKeys: "strip",
+            unrecognizedObjectKeys: "passthrough",
+            allowUnrecognizedUnionMembers: true,
+            allowUnrecognizedEnumValues: true,
+            skipValidation: true,
             omitUndefined: true,
         });
         if (parsedResponse.ok) {
@@ -171,7 +174,7 @@ export class RealtimeSocket {
     }
 
     /** Send a binary payload to the websocket. */
-    private sendBinary(payload: ArrayBufferLike | Blob | ArrayBufferView): void {
+    protected sendBinary(payload: ArrayBufferLike | Blob | ArrayBufferView): void {
         this.socket.send(payload);
     }
 }


### PR DESCRIPTION
## Description
Fixes a compile issue when WebSocket connect methods require query parameters with special characters. 
Fixes response deserialization in websockets to respect skipping validation. 

## Changes Made
- See changelog 

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

