### PR TITLE
fix(python): parse websocket responses as JSON before Pydantic parse

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.24.1
+  changelogEntry:
+    - summary: |
+        Parse websocket messages as JSON before Pydantic parsing.
+      type: fix
+  createdAt: '2025-07-07'
+  irVersion: 58
+
 - version: 4.24.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
@@ -201,9 +201,10 @@ class SocketClientGenerator:
                     f"{'async ' if is_async else ''}for raw_message in self.{self.WEBSOCKET_MEMBER_NAME}:"
                 )
                 with writer.indent():
+                    writer.write_line("json_data = json.loads(raw_message)")
                     writer.write("parsed = ")
                     writer.write_reference(self._context.core_utilities.get_parse_obj_as())
-                    writer.write(f"({self._get_response_type_name()}, raw_message)  # type: ignore")
+                    writer.write(f"({self._get_response_type_name()}, json_data)  # type: ignore")
                     writer.write_line()
                     writer.write("self._emit(")
                     writer.write_reference(self._context.core_utilities.get_event_type())
@@ -300,9 +301,10 @@ class SocketClientGenerator:
     def _get_recv_method_body(self, is_async: bool) -> CodeWriterFunction:
         def _get_recv_method_body(writer: AST.NodeWriter) -> None:
             writer.write_line(f"data = {'await ' if is_async else ''}self.{self.WEBSOCKET_MEMBER_NAME}.recv()")
+            writer.write_line("json_data = json.loads(data)")
             writer.write("return ")
             writer.write_reference(self._context.core_utilities.get_parse_obj_as())
-            writer.write(f"({self._get_response_type_name()}, data)  # type: ignore")
+            writer.write(f"({self._get_response_type_name()}, json_data)  # type: ignore")
 
         return _get_recv_method_body
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
@@ -40,7 +40,8 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
         self._emit(EventType.OPEN, None)
         try:
             async for raw_message in self._websocket:
-                parsed = parse_obj_as(RealtimeSocketClientResponse, raw_message)  # type: ignore
+                json_data = json.loads(raw_message)
+                parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
                 self._emit(EventType.MESSAGE, parsed)
         except websockets.WebSocketException as exc:
             self._emit(EventType.ERROR, exc)
@@ -73,7 +74,8 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
         Receive a message from the websocket connection.
         """
         data = await self._websocket.recv()
-        return parse_obj_as(RealtimeSocketClientResponse, data)  # type: ignore
+        json_data = json.loads(data)
+        return parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
 
     async def _send(self, data: typing.Any) -> None:
         """
@@ -112,7 +114,8 @@ class RealtimeSocketClient(EventEmitterMixin):
         self._emit(EventType.OPEN, None)
         try:
             for raw_message in self._websocket:
-                parsed = parse_obj_as(RealtimeSocketClientResponse, raw_message)  # type: ignore
+                json_data = json.loads(raw_message)
+                parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
                 self._emit(EventType.MESSAGE, parsed)
         except websockets.WebSocketException as exc:
             self._emit(EventType.ERROR, exc)
@@ -145,7 +148,8 @@ class RealtimeSocketClient(EventEmitterMixin):
         Receive a message from the websocket connection.
         """
         data = self._websocket.recv()
-        return parse_obj_as(RealtimeSocketClientResponse, data)  # type: ignore
+        json_data = json.loads(data)
+        return parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
 
     def _send(self, data: typing.Any) -> None:
         """


### PR DESCRIPTION
## Description
Resolves https://linear.app/buildwithfern/issue/FER-5636/sarvam-python-websocket-respones-are-not-being-parsed-into-json

Received websocket messages were assumed immediately Pydantic-parseable, using `parse_obj_as()`, but are actually `str`.

We now assume they are JSON strings and so parse as JSON before the Pydantic step.


## Changes Made
- Update two relevant methods in `SocketClientGenerator`

## Testing
- [x] Unit tests not failing
- [x] Manual testing completed -- seed output observed
- [x] Client code testing completed

