### PR TITLE
chore(docs): match iconography

### DIFF
--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -115,7 +115,7 @@ Fern allows developers to instantly transform your OpenAPI into SDKs and Docs. E
   </Card>
   <Card
     title="Ask Fern"
-    icon="fa-regular fa-wand-sparkles" 
+    icon="fa-regular fa-sparkles" 
     href="/learn/ask-fern/overview"
   >
     Let users find answers in your documentation instantly 


### PR DESCRIPTION
match the icon for the Ask Fern card on the homepage with the tab's icon

https://github.com/fern-api/fern/blob/a1207a70aa96b60d76cfca81744064af0c3324d7/fern/docs.yml#L36