### PR TITLE
fix(cli): don't use header name default for global header example values that share names with endpoint headers

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/corti.json
@@ -5799,7 +5799,7 @@ navigation:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -5884,7 +5884,7 @@ navigation:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -5939,7 +5939,7 @@ navigation:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6055,7 +6055,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               codes:
@@ -6107,7 +6107,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             modelName: '"geography_modelName (Latest)" | "geography_modelName_version"'
             context:
@@ -6157,7 +6157,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -6207,7 +6207,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -6353,7 +6353,7 @@ types:
                     },
                   ],
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6459,7 +6459,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -6532,7 +6532,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6588,7 +6588,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -6727,7 +6727,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -6794,7 +6794,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             context:
               - type: facts
@@ -6945,7 +6945,7 @@ service:
             id: id
             documentId: documentId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -6994,7 +6994,7 @@ service:
             id: id
             documentId: documentId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -7039,7 +7039,7 @@ service:
             id: id
             documentId: documentId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -7104,7 +7104,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -7177,7 +7177,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -7216,7 +7216,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -7270,7 +7270,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "factId": "factId",
@@ -7353,7 +7353,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -7491,7 +7491,7 @@ service:
         - root.GetFactgroupsRequestInternalServerError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -7523,7 +7523,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               facts:
@@ -7571,7 +7571,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             facts:
               - text: text
@@ -7618,7 +7618,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             facts:
               - factId: factId
@@ -7678,7 +7678,7 @@ service:
             id: id
             factId: factId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             text: text
             source: core
@@ -7751,7 +7751,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "request": {
                     "encounter": {
@@ -7817,7 +7817,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -7858,7 +7858,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -7922,7 +7922,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -8004,7 +8004,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8140,7 +8140,7 @@ service:
         - root.GetInteractionsRequestGatewayTimeoutError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               interactions:
@@ -8196,7 +8196,7 @@ service:
         - root.PostInteractionsRequestGatewayTimeoutError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             encounter:
               identifier: identifier
@@ -8233,7 +8233,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -8284,7 +8284,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -8329,7 +8329,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -8381,7 +8381,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8462,7 +8462,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8566,7 +8566,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               recordings:
@@ -8661,7 +8661,7 @@ service:
             id: id
             recordingId: recordingId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -9224,7 +9224,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "key": "key",
@@ -9281,7 +9281,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -9340,7 +9340,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -9430,7 +9430,7 @@ service:
         - root.GetTemplateSectionsRequestInternalServerError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -9472,7 +9472,7 @@ service:
         - root.GetTemplatesRequestInternalServerError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -9508,7 +9508,7 @@ service:
         - path-parameters:
             key: key
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               date_updated: '2024-01-15T09:30:00Z'
@@ -9550,7 +9550,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -9653,7 +9653,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -9702,7 +9702,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -9766,7 +9766,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -9904,7 +9904,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               transcripts:
@@ -9978,7 +9978,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             recordingId: recordingId
             primaryLanguage: primaryLanguage
@@ -10032,7 +10032,7 @@ service:
             id: id
             transcriptId: transcriptId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -10083,7 +10083,7 @@ service:
             id: id
             transcriptId: transcriptId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-global-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-global-headers.json
@@ -86,7 +86,7 @@
                     "another_header": "another_header",
                     "my-api-key": "my-api-key",
                     "my-api-version": "my-api-version",
-                    "version": "version",
+                    "version": "2024-06-04",
                     "x-api-key": "x-api-key",
                   },
                   "path-parameters": {
@@ -145,7 +145,7 @@
                     "another_header": "another_header",
                     "my-api-key": "my-api-key",
                     "my-api-version": "my-api-version",
-                    "version": "version",
+                    "version": "2024-06-04",
                     "x-api-key": "x-api-key",
                   },
                   "path-parameters": {
@@ -238,7 +238,7 @@ service:
             another_header: another_header
             x-api-key: x-api-key
             my-api-version: my-api-version
-            version: version
+            version: '2024-06-04'
           request:
             stream: true
           response:
@@ -273,7 +273,7 @@ service:
             another_header: another_header
             x-api-key: x-api-key
             my-api-version: my-api-version
-            version: version
+            version: '2024-06-04'
           request:
             stream: false
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/corti.json
@@ -4251,7 +4251,7 @@ navigation:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -4336,7 +4336,7 @@ navigation:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -4391,7 +4391,7 @@ navigation:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -4507,7 +4507,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               codes:
@@ -4559,7 +4559,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             modelName: '"geography_modelName (Latest)" | "geography_modelName_version"'
             context:
@@ -4609,7 +4609,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -4659,7 +4659,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -4805,7 +4805,7 @@ types:
                     },
                   ],
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -4911,7 +4911,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -4984,7 +4984,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -5040,7 +5040,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -5179,7 +5179,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -5246,7 +5246,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             context:
               - type: facts
@@ -5397,7 +5397,7 @@ service:
             id: id
             documentId: documentId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -5446,7 +5446,7 @@ service:
             id: id
             documentId: documentId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -5491,7 +5491,7 @@ service:
             id: id
             documentId: documentId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -5556,7 +5556,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -5629,7 +5629,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -5668,7 +5668,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -5722,7 +5722,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "factId": "factId",
@@ -5805,7 +5805,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -5943,7 +5943,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -5975,7 +5975,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               facts:
@@ -6023,7 +6023,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             facts:
               - text: text
@@ -6070,7 +6070,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             facts:
               - factId: factId
@@ -6130,7 +6130,7 @@ service:
             id: id
             factId: factId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             text: text
             source: core
@@ -6203,7 +6203,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "request": {
                     "encounter": {
@@ -6269,7 +6269,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6310,7 +6310,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6374,7 +6374,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -6456,7 +6456,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6592,7 +6592,7 @@ service:
         - root.GatewayTimeoutError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               interactions:
@@ -6648,7 +6648,7 @@ service:
         - root.GatewayTimeoutError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             encounter:
               identifier: identifier
@@ -6685,7 +6685,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -6736,7 +6736,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -6781,7 +6781,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request: {}
           response:
             body:
@@ -6833,7 +6833,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -6914,7 +6914,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -7018,7 +7018,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               recordings:
@@ -7111,7 +7111,7 @@ service:
             id: id
             recordingId: recordingId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value
@@ -7674,7 +7674,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "key": "key",
@@ -7731,7 +7731,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -7790,7 +7790,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "response": {
                     "body": {
@@ -7880,7 +7880,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -7922,7 +7922,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               data:
@@ -7958,7 +7958,7 @@ service:
         - path-parameters:
             key: key
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               date_updated: '2024-01-15T09:30:00Z'
@@ -8000,7 +8000,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8103,7 +8103,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8152,7 +8152,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8216,7 +8216,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Tenant-Name": "Tenant-Name",
+                    "Tenant-Name": "copiloteu",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -8354,7 +8354,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               transcripts:
@@ -8428,7 +8428,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           request:
             recordingId: recordingId
             primaryLanguage: primaryLanguage
@@ -8480,7 +8480,7 @@ service:
             id: id
             transcriptId: transcriptId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               id: id
@@ -8528,7 +8528,7 @@ service:
             id: id
             transcriptId: transcriptId
           headers:
-            Tenant-Name: Tenant-Name
+            Tenant-Name: copiloteu
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-global-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-global-headers.json
@@ -86,7 +86,7 @@
                     "another_header": "another_header",
                     "my-api-key": "my-api-key",
                     "my-api-version": "my-api-version",
-                    "version": "version",
+                    "version": "2024-06-04",
                     "x-api-key": "x-api-key",
                   },
                   "path-parameters": {
@@ -145,7 +145,7 @@
                     "another_header": "another_header",
                     "my-api-key": "my-api-key",
                     "my-api-version": "my-api-version",
-                    "version": "version",
+                    "version": "2024-06-04",
                     "x-api-key": "x-api-key",
                   },
                   "path-parameters": {
@@ -238,7 +238,7 @@ service:
             another_header: another_header
             x-api-key: x-api-key
             my-api-version: my-api-version
-            version: version
+            version: '2024-06-04'
           request:
             stream: true
           response:
@@ -273,7 +273,7 @@ service:
             another_header: another_header
             x-api-key: x-api-key
             my-api-version: my-api-version
-            version: version
+            version: '2024-06-04'
           request:
             stream: false
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -37,7 +37,7 @@ export function buildEndpointExample({
     const hasEndpointHeaders = endpointExample.headers != null && endpointExample.headers.length > 0;
     const hasGlobalHeaders = Object.keys(context.builder.getGlobalHeaders()).length > 0;
 
-    const endpointHeaderNames = new Set(endpointExample.headers?.map(header => header.name) ?? []);
+    const endpointHeaderNames = new Set(endpointExample.headers?.map((header) => header.name) ?? []);
 
     if (hasEndpointHeaders || hasGlobalHeaders) {
         const namedFullExamples: NamedFullExample[] = [

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -36,13 +36,18 @@ export function buildEndpointExample({
 
     const hasEndpointHeaders = endpointExample.headers != null && endpointExample.headers.length > 0;
     const hasGlobalHeaders = Object.keys(context.builder.getGlobalHeaders()).length > 0;
+
+    const endpointHeaderNames = new Set(endpointExample.headers?.map(header => header.name) ?? []);
+
     if (hasEndpointHeaders || hasGlobalHeaders) {
         const namedFullExamples: NamedFullExample[] = [
             ...(endpointExample.headers ?? []),
-            ...(Object.entries(context.builder.getGlobalHeaders()).map(([header, schema]) => ({
-                name: header,
-                value: FullExample.primitive(PrimitiveExample.string(header))
-            })) ?? [])
+            ...(Object.entries(context.builder.getGlobalHeaders())
+                .filter(([header]) => !endpointHeaderNames.has(header))
+                .map(([header, schema]) => ({
+                    name: header,
+                    value: FullExample.primitive(PrimitiveExample.string(header))
+                })) ?? [])
         ];
 
         example.headers = convertHeaderExamples({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        Global header examples are only used when a corresponding endpoint header with the same name is not present.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-07-08"
+  version: 0.65.2
+
+- changelogEntry:
+    - summary: |  
         Re-release changes from 0.65.0.
       type: chore
   irVersion: 58


### PR DESCRIPTION
## Description
- `globalHeaders` in v1 parser are inferred based on frequency of usage
- examples for these `globalHeaders` are created based on the header name, not the actual value 
## Changes Made
- deduplicate `globalHeaders` that share names with endpoint headers, and use the example value from the endpoint-level header definition/schema

## Testing
- [X] Unit tests added/updated
- [X] Manual testing completed

