### PR TITLE
fix(python): allow use of websockets>=14 via their legacy client

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.24.3
+  changelogEntry:
+    - summary: |
+        Support websockets>=14 by using legacy client.
+      type: fix
+  createdAt: '2025-07-09'
+  irVersion: 58
+
 - version: 4.24.2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/external_dependencies/websockets.py
+++ b/generators/python/src/fern_python/external_dependencies/websockets.py
@@ -11,7 +11,7 @@ WEBSOCKETS_MODULE = AST.Module.external(
 )
 
 WEBSOCKETS_LEGACY_CLIENT_MODULE = AST.Module.external(
-    # allows use of websockets<14
+    # allows use of websockets>=14 alongside earlier
     # see https://websockets.readthedocs.io/en/stable/howto/upgrade.html to migrate away
     module_path=("websockets", "legacy", "client"),
     dependency=AST.Dependency(

--- a/generators/python/src/fern_python/external_dependencies/websockets.py
+++ b/generators/python/src/fern_python/external_dependencies/websockets.py
@@ -89,8 +89,17 @@ class Websockets:
         def write(writer: AST.NodeWriter) -> None:
             writer.write_reference(
                 AST.Reference(
-                    import_=AST.ReferenceImport(module=WEBSOCKETS_LEGACY_CLIENT_MODULE),
-                    qualified_name_excluding_import=("connect",),
+                    import_=AST.ReferenceImport(
+                        module=WEBSOCKETS_LEGACY_CLIENT_MODULE,
+                        named_import="connect",
+                        alias="websockets_client_connect",
+                        alternative_import=AST.ReferenceImport(
+                            module=WEBSOCKETS_MODULE,
+                            named_import="connect",
+                            alias="websockets_client_connect",
+                        ),
+                    ),
+                    qualified_name_excluding_import=(),
                 )
             )
             writer.write(f"({url}, extra_headers={headers})")

--- a/generators/python/src/fern_python/external_dependencies/websockets.py
+++ b/generators/python/src/fern_python/external_dependencies/websockets.py
@@ -10,6 +10,17 @@ WEBSOCKETS_MODULE = AST.Module.external(
     ),
 )
 
+WEBSOCKETS_LEGACY_CLIENT_MODULE = AST.Module.external(
+    # allows use of websockets<14
+    # see https://websockets.readthedocs.io/en/stable/howto/upgrade.html to migrate away
+    module_path=("websockets", "legacy", "client"),
+    dependency=AST.Dependency(
+        name="websockets",
+        version=">=12.0",
+        compatibility=DependencyCompatibility.EXACT,
+    ),
+)
+
 WEBSOCKETS_SYNC_CLIENT_MODULE = AST.Module.external(
     module_path=("websockets", "sync", "client"),
     dependency=AST.Dependency(
@@ -48,8 +59,15 @@ class Websockets:
     @staticmethod
     def get_async_websocket_client_protocol() -> AST.ClassReference:
         return AST.ClassReference(
-            qualified_name_excluding_import=("WebSocketClientProtocol",),
-            import_=AST.ReferenceImport(module=WEBSOCKETS_MODULE),
+            qualified_name_excluding_import=(),
+            import_=AST.ReferenceImport(
+                module=WEBSOCKETS_LEGACY_CLIENT_MODULE,
+                named_import="WebSocketClientProtocol",
+                alternative_import=AST.ReferenceImport(
+                    module=WEBSOCKETS_MODULE,
+                    named_import="WebSocketClientProtocol",
+                ),
+            ),
         )
 
     @staticmethod
@@ -71,7 +89,7 @@ class Websockets:
         def write(writer: AST.NodeWriter) -> None:
             writer.write_reference(
                 AST.Reference(
-                    import_=AST.ReferenceImport(module=WEBSOCKETS_MODULE),
+                    import_=AST.ReferenceImport(module=WEBSOCKETS_LEGACY_CLIENT_MODULE),
                     qualified_name_excluding_import=("connect",),
                 )
             )

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
@@ -4,7 +4,7 @@ import typing
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
-import websockets
+import websockets.legacy.client
 import websockets.sync.client as websockets_sync_client
 from ..core.api_error import ApiError
 from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
@@ -132,7 +132,7 @@ class AsyncRealtimeClient:
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
         try:
-            async with websockets.connect(ws_url, extra_headers=headers) as protocol:
+            async with websockets.legacy.client.connect(ws_url, extra_headers=headers) as protocol:
                 yield AsyncRealtimeSocketClient(websocket=protocol)
         except websockets.exceptions.InvalidStatusCode as exc:
             status_code: int = exc.status_code

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
@@ -4,13 +4,17 @@ import typing
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
-import websockets.legacy.client
 import websockets.sync.client as websockets_sync_client
 from ..core.api_error import ApiError
 from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from ..core.request_options import RequestOptions
 from .raw_client import AsyncRawRealtimeClient, RawRealtimeClient
 from .socket_client import AsyncRealtimeSocketClient, RealtimeSocketClient
+
+try:
+    from websockets.legacy.client import connect as websockets_client_connect  # type: ignore
+except ImportError:
+    from websockets import connect as websockets_client_connect  # type: ignore
 
 
 class RealtimeClient:
@@ -132,7 +136,7 @@ class AsyncRealtimeClient:
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
         try:
-            async with websockets.legacy.client.connect(ws_url, extra_headers=headers) as protocol:
+            async with websockets_client_connect(ws_url, extra_headers=headers) as protocol:
                 yield AsyncRealtimeSocketClient(websocket=protocol)
         except websockets.exceptions.InvalidStatusCode as exc:
             status_code: int = exc.status_code

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
@@ -4,12 +4,16 @@ import typing
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
-import websockets.legacy.client
 import websockets.sync.client as websockets_sync_client
 from ..core.api_error import ApiError
 from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from ..core.request_options import RequestOptions
 from .socket_client import AsyncRealtimeSocketClient, RealtimeSocketClient
+
+try:
+    from websockets.legacy.client import connect as websockets_client_connect  # type: ignore
+except ImportError:
+    from websockets import connect as websockets_client_connect  # type: ignore
 
 
 class RawRealtimeClient:
@@ -109,7 +113,7 @@ class AsyncRawRealtimeClient:
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
         try:
-            async with websockets.legacy.client.connect(ws_url, extra_headers=headers) as protocol:
+            async with websockets_client_connect(ws_url, extra_headers=headers) as protocol:
                 yield AsyncRealtimeSocketClient(websocket=protocol)
         except websockets.exceptions.InvalidStatusCode as exc:
             status_code: int = exc.status_code

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
@@ -4,7 +4,7 @@ import typing
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
-import websockets
+import websockets.legacy.client
 import websockets.sync.client as websockets_sync_client
 from ..core.api_error import ApiError
 from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
@@ -109,7 +109,7 @@ class AsyncRawRealtimeClient:
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
         try:
-            async with websockets.connect(ws_url, extra_headers=headers) as protocol:
+            async with websockets.legacy.client.connect(ws_url, extra_headers=headers) as protocol:
                 yield AsyncRealtimeSocketClient(websocket=protocol)
         except websockets.exceptions.InvalidStatusCode as exc:
             status_code: int = exc.status_code

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
@@ -16,11 +16,16 @@ from .types.send_event import SendEvent
 from .types.send_event_2 import SendEvent2
 from .types.send_snake_case import SendSnakeCase
 
+try:
+    from websockets.legacy.client import WebSocketClientProtocol  # type: ignore
+except ImportError:
+    from websockets import WebSocketClientProtocol  # type: ignore
+
 RealtimeSocketClientResponse = typing.Union[ReceiveEvent, ReceiveSnakeCase, ReceiveEvent2, ReceiveEvent3]
 
 
 class AsyncRealtimeSocketClient(EventEmitterMixin):
-    def __init__(self, *, websocket: websockets.WebSocketClientProtocol):
+    def __init__(self, *, websocket: WebSocketClientProtocol):
         super().__init__()
         self._websocket = websocket
 


### PR DESCRIPTION
## Description

Resolves https://linear.app/buildwithfern/issue/FER-5648/python-sdk-sarvam-support-websockets-package-before-and-after-v14

We recently allowed `websockets>=12`, which means we should be compatible with the changed API in `websockets` v14.

## Changes Made
- Imports are changed to use `websockets`' legacy client & client protocol clases when available (in v14) and the existing ones when not.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests -- awaiting run of existing
- [x] Manual testing completed

