### PR TITLE
fix(python): emit ERROR event for JSONDecodeError in listening websocket client

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.24.2
+  changelogEntry:
+    - summary: |
+        Emit ERROR events for JSON parsing errors in websocket connections.
+      type: fix
+  createdAt: '2025-07-09'
+  irVersion: 58
+
 - version: 4.24.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
@@ -210,9 +210,11 @@ class SocketClientGenerator:
                     writer.write_reference(self._context.core_utilities.get_event_type())
                     writer.write(".MESSAGE, parsed)")
                     writer.write_line()
-            writer.write("except ")
+            writer.write("except (")
             writer.write_reference(Websockets.get_websocket_exception())
-            writer.write(" as exc:")
+            writer.write(", ")
+            writer.write_reference(Json.JSONDecodeError())
+            writer.write(") as exc:")
             writer.write_line()
             with writer.indent():
                 writer.write("self._emit(")

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
@@ -2,6 +2,7 @@
 
 import json
 import typing
+from json.decoder import JSONDecodeError
 
 import websockets
 import websockets.sync.connection as websockets_sync_connection
@@ -43,7 +44,7 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
                 json_data = json.loads(raw_message)
                 parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
                 self._emit(EventType.MESSAGE, parsed)
-        except websockets.WebSocketException as exc:
+        except (websockets.WebSocketException, JSONDecodeError) as exc:
             self._emit(EventType.ERROR, exc)
         finally:
             self._emit(EventType.CLOSE, None)
@@ -117,7 +118,7 @@ class RealtimeSocketClient(EventEmitterMixin):
                 json_data = json.loads(raw_message)
                 parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
                 self._emit(EventType.MESSAGE, parsed)
-        except websockets.WebSocketException as exc:
+        except (websockets.WebSocketException, JSONDecodeError) as exc:
             self._emit(EventType.ERROR, exc)
         finally:
             self._emit(EventType.CLOSE, None)


### PR DESCRIPTION
We have introduced JSON decoding into the websocket clients and so should handle JSON errors where possible.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- In `start_listening()`, emit `ERROR` event upon catching `JSONDecodeError`.
- *Do not* modify `recv()`; instead, expect the user to handle, as with our other parsing errors.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed

## Release
- [x] Update `versions.yml`
