### PR TITLE
fix(typescript): Improve withJson MSW predicate

### DIFF
--- a/generators/typescript/asIs/tests/mock-server/withJson.ts
+++ b/generators/typescript/asIs/tests/mock-server/withJson.ts
@@ -75,8 +75,14 @@ function findMismatches(actual: any, expected: any): Record<string, { actual: an
 
     for (const key of allKeys) {
         if (!expectedKeys.includes(key)) {
+            if (actual[key] === undefined) {
+                continue; // Skip undefined values in actual
+            }
             mismatches[key] = { actual: actual[key], expected: undefined };
         } else if (!actualKeys.includes(key)) {
+            if (expected[key] === undefined) {
+                continue; // Skip undefined values in expected
+            }
             mismatches[key] = { actual: undefined, expected: expected[key] };
         } else if (
             typeof actual[key] === "object" &&

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 2.4.3
+  changelogEntry:
+    - summary: |
+        Fix an issue where a property set to `undefined` would not match with a property that is missing in the `withJson` MSW predicate.
+      type: fix
+  irVersion: 58
+
 - version: 2.4.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Fix an issue where a property set to `undefined` would not match with a property that is missing in the `withJson` MSW predicate.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

