### PR TITLE
fix(cli): process openapi and fern definition

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -79,6 +79,8 @@ export async function generateDocsWorkspace({
 
         const ossWorkspaces = await filterOssWorkspaces(project);
 
+        console.log(project.apiWorkspaces);
+
         await runRemoteGenerationForDocsWorkspace({
             organization: project.config.organization,
             apiWorkspaces: project.apiWorkspaces,

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -79,8 +79,6 @@ export async function generateDocsWorkspace({
 
         const ossWorkspaces = await filterOssWorkspaces(project);
 
-        console.log(project.apiWorkspaces);
-
         await runRemoteGenerationForDocsWorkspace({
             organization: project.config.organization,
             apiWorkspaces: project.apiWorkspaces,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        Previously if the OpenAPI parser v3 was enabled where the CLI would skip parsing any additional Fern Definitions
+        along the OpenAPI spec. With the fix, you can use whatever combination of OpenAPI Spec(s) and Fern Definitions that 
+        you would like.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-07-08"
+  version: 0.65.4
+
+- changelogEntry:
+    - summary: |  
         Update `fern init` for java and go SDKs.
       type: fix
   irVersion: 58

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -466,15 +466,15 @@ export class DocsDefinitionResolver {
     private getFernWorkspaceForApiSection(
         apiSection: docsYml.DocsNavigationItem.ApiSection
     ): AbstractAPIWorkspace<unknown> {
-        if (this.apiWorkspaces.length === 1 && this.apiWorkspaces[0] != null) {
-            return this.apiWorkspaces[0];
-        } else if (apiSection.apiName != null) {
+        if (apiSection.apiName != null) {
             const apiWorkspace = this.apiWorkspaces.find((workspace) => {
                 return workspace.workspaceName === apiSection.apiName;
             });
             if (apiWorkspace != null) {
                 return apiWorkspace;
             }
+        } else if (this.apiWorkspaces.length === 1 && this.apiWorkspaces[0] != null) {
+            return this.apiWorkspaces[0];
         }
         const errorMessage = apiSection.apiName
             ? `Failed to load API Definition '${apiSection.apiName}' referenced in docs`
@@ -483,13 +483,13 @@ export class DocsDefinitionResolver {
     }
 
     private getOpenApiWorkspaceForApiSection(apiSection: docsYml.DocsNavigationItem.ApiSection): OSSWorkspace {
-        if (this.ossWorkspaces.length === 1 && this.ossWorkspaces[0] != null) {
-            return this.ossWorkspaces[0];
-        } else if (apiSection.apiName != null) {
+        if (apiSection.apiName != null) {
             const ossWorkspace = this.ossWorkspaces.find((workspace) => workspace.workspaceName === apiSection.apiName);
             if (ossWorkspace != null) {
                 return ossWorkspace;
             }
+        } else if (this.ossWorkspaces.length === 1 && this.ossWorkspaces[0] != null) {
+            return this.ossWorkspaces[0];
         }
         const errorMessage = apiSection.apiName
             ? `Failed to load API Definition '${apiSection.apiName}' referenced in docs`


### PR DESCRIPTION
## Description
Previously if the OpenAPI parser v3 was enabled where the CLI would skip parsing any additional Fern Definitions
along the OpenAPI spec. With the fix, you can use whatever combination of OpenAPI Spec(s) and Fern Definitions that 
you would like.

## Changes Made
- See files changed

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

