### PR TITLE
chore(typescript): Update node version in Dockerfile to 20.19.0

### DIFF
--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.0
+FROM node:20.19.0-alpine3.20
 
 RUN apk --no-cache add git zip
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18-alpine3.20
+FROM node:20.19.0
 
 RUN apk --no-cache add git zip
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 2.4.4
+  changelogEntry:
+    - summary: |
+        Update Node version in Dockerfile to 20.19.0.
+      type: fix
+  createdAt: '2025-07-09'
+  irVersion: 58
+
 - version: 2.4.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
A client wants the minimum compatible version of Node in their SDK to be 20.19.0, but we need to update the version of Node in this Dockerfile to make that happen