### PR TITLE
chore(docs): OpenAPI Export config block

### DIFF
--- a/fern/pages/api-definition/fern-definition/export-openapi.mdx
+++ b/fern/pages/api-definition/fern-definition/export-openapi.mdx
@@ -11,13 +11,15 @@ Update your `generators.yml` file:
 
 <CodeBlock title="generators.yml">
 ```yaml
-- name: fernapi/fern-openapi
-  version: 0.1.7
-  config:
-    format: yaml # options are yaml or json
-  output:
-    location: local-file-system
-    path: ../openapi # relative path to output location
+generators:
+  openapi:
+    - name: fernapi/fern-openapi
+      version: 0.1.7
+      config:
+        format: yaml # options are yaml or json
+      output:
+        location: local-file-system
+        path: ../openapi # relative path to output location
 ```
 </CodeBlock>
 


### PR DESCRIPTION
Add formatting to make copying and pasting easier for the OpenAPI exporter