### PR TITLE
fix(typescript): Make the BinaryResponse.bytes function optional

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 2.4.4
+  changelogEntry:
+    - summary: |
+        Make the `BinaryResponse.bytes` function optional because some versions of runtimes do not support the function on fetch `Response`.
+      type: fix
+  createdAt: '2025-07-09'
+  irVersion: 58
+
 - version: 2.4.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/BinaryResponse.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
-import { ResponseWithBody } from "./ResponseWithBody";
+import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /** 
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) 
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response)
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/accept-header/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/alias/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/any-auth/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/any-auth/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/auth-environment-variables/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/circular-references/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/content-type/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/cross-package-type-names/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/custom-auth/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/custom-auth/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/enum/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/enum/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/BinaryResponse.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/BinaryResponse.d.ts
@@ -1,5 +1,5 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -11,7 +11,10 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     * */
+    bytes?(): Promise<Uint8Array>;
+};
 export declare function getBinaryResponse(response: ResponseWithBody): BinaryResponse;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/BinaryResponse.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/BinaryResponse.js
@@ -2,13 +2,16 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getBinaryResponse = getBinaryResponse;
 function getBinaryResponse(response) {
-    return {
+    const binaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/BinaryResponse.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/BinaryResponse.d.mts
@@ -1,5 +1,5 @@
 import { ResponseWithBody } from "./ResponseWithBody.mjs";
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -11,7 +11,10 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     * */
+    bytes?(): Promise<Uint8Array>;
+};
 export declare function getBinaryResponse(response: ResponseWithBody): BinaryResponse;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/BinaryResponse.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/BinaryResponse.mjs
@@ -1,11 +1,14 @@
 export function getBinaryResponse(response) {
-    return {
+    const binaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/extends/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-download/stream/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-download/stream/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-download/wrapper/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-download/wrapper/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/folders/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/http-head/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /** 
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) 
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response)
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/license/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/literal/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/no-environment/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/nullable/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/object/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/optional/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/package-yml/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/pagination/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/pagination/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/path-parameters/default/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/path-parameters/default/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/plain-text/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/public-object/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/response-property/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/trace/serde-trace/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/unions/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/unions/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/validation/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/variables/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/version/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/BinaryResponse.ts
@@ -1,6 +1,6 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
 
-export interface BinaryResponse {
+export type BinaryResponse = {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
     bodyUsed: boolean;
     /**
@@ -12,18 +12,25 @@ export interface BinaryResponse {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-}
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
+     * Some versions of the Fetch API may not support this method.
+     */
+    bytes?(): Promise<Uint8Array>;
+};
 
 export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
-    return {
+    const binaryResponse: BinaryResponse = {
         get bodyUsed() {
             return response.bodyUsed;
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
         blob: response.blob.bind(response),
-        bytes: response.bytes.bind(response),
     };
+    if ("bytes" in response && typeof response.bytes === "function") {
+        binaryResponse.bytes = response.bytes.bind(response);
+    }
+
+    return binaryResponse;
 }


### PR DESCRIPTION
Make the `BinaryResponse.bytes` function optional because some versions of runtimes do not support the function on fetch `Response`

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

