### PR TITLE
fix(typescript): Improve error response parsing

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/JestTestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/JestTestGenerator.ts
@@ -103,7 +103,7 @@ export class JestTestGenerator {
                         {
                             displayName: "browser",
                             preset: "ts-jest",
-                            testEnvironment: "<rootDir>/tests/BrowserTestEnvironment.ts",
+                            testEnvironment: "<rootDir>/${this.relativeTestPath}/BrowserTestEnvironment.ts",
                             moduleNameMapper: {
                                 "^(\\.{1,2}/.*)\\.js$": "$1",
                             },
@@ -123,7 +123,7 @@ export class JestTestGenerator {
                                 "^(\\.{1,2}/.*)\\.js$": "$1",
                             },
                             roots: ["<rootDir>/${this.relativeTestPath}/wire"],
-                            setupFilesAfterEnv: ${arrayOf(...setupFilesAfterEnv, "<rootDir>/tests/mock-server/setup.ts")},
+                            setupFilesAfterEnv: ${arrayOf(...setupFilesAfterEnv, `<rootDir>/${this.relativeTestPath}/mock-server/setup.ts`)},
                         }`
                                 : ""
                         }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.4.6
+  changelogEntry:
+    - summary: |
+        Parse HTTP error bodies as JSON if the response content-type header is JSON, otherwise fallback to text.
+      type: fix
+    - summary: |
+        Fix `bytes` fetcher test.
+      type: fix
+    - summary: |
+        Fix Jest configuration when a `packagePath` is specified in _generators.yml_ config.
+      type: fix
+  createdAt: "2025-07-09"
+  irVersion: 58
 
 - version: 2.4.5
   changelogEntry:
@@ -7,13 +20,13 @@
       type: fix
   createdAt: "2025-07-09"
   irVersion: 58
-  
+
 - version: 2.4.4
   changelogEntry:
     - summary: |
         Make the `BinaryResponse.bytes` function optional because some versions of runtimes do not support the function on fetch `Response`.
       type: fix
-  createdAt: '2025-07-09'
+  createdAt: "2025-07-09"
   irVersion: 58
 
 - version: 2.4.3

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/Fetcher.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse";
 import { Supplier } from "./Supplier";
 import { createRequestUrl } from "./createRequestUrl";
+import { getErrorResponseBody } from "./getErrorResponseBody";
 import { getFetchFn } from "./getFetchFn";
 import { getRequestBody } from "./getRequestBody";
 import { getResponseBody } from "./getResponseBody";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response)
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody
+                    body: await getErrorResponseBody(response)
                 },
                 rawResponse: toRawResponse(response)
             };

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/getErrorResponseBody.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json";
+import { getResponseBody } from "./getResponseBody";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/getResponseBody.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/getResponseBody.template.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse";
 import { isResponseWithBody } from "./ResponseWithBody";
+import { fromJson } from "../json";
 <% if (streamType === "wrapper") { %>
 import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper";
 <% } %>
@@ -31,7 +32,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/Fetcher.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/Fetcher.test.template.ts
@@ -243,7 +243,10 @@ describe("Test fetcherImpl", () => {
             const body = result.body as BinaryResponse;
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
-            expect(typeof body.bytes).toBe("function");
+            expect(typeof body.bytes).toBe("function");            
+            if(!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/accept-header/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/accept-header/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/accept-header/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/alias/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/alias/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/alias/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/alias/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/any-auth/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/any-auth/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/any-auth/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/any-auth/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/any-auth/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/any-auth/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/any-auth/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/any-auth/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/auth-environment-variables/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/auth-environment-variables/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/auth-environment-variables/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/circular-references/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/circular-references/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/circular-references/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/content-type/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/content-type/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/content-type/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/cross-package-type-names/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/cross-package-type-names/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/cross-package-type-names/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/custom-auth/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/custom-auth/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/custom-auth/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/custom-auth/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/custom-auth/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/custom-auth/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/custom-auth/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/custom-auth/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/enum/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/enum/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/enum/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/enum/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/enum/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/enum/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/enum/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/enum/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/bundle/package.json
+++ b/seed/ts-sdk/exhaustive/bundle/package.json
@@ -24,6 +24,9 @@
         "./package.json": "./package.json"
     },
     "types": "./types/index.d.ts",
+    "dependencies": {
+        "lodash-es": "^4.17.21"
+    },
     "devDependencies": {
         "webpack": "^5.97.1",
         "ts-loader": "^9.5.1",

--- a/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/bundle/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/bundle/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/custom-package-json/package.json
+++ b/seed/ts-sdk/exhaustive/custom-package-json/package.json
@@ -25,6 +25,11 @@
         "./package.json": "./package.json"
     },
     "types": "./types/index.d.ts",
+    "dependencies": {
+        "lodash-es": "^4.17.21",
+        "stream": "^0.0.2",
+        "qs": "^6.11.2"
+    },
     "devDependencies": {
         "webpack": "^5.97.1",
         "ts-loader": "^9.5.1",
@@ -50,9 +55,5 @@
     "engines": {
         "node": ">=16.0.0"
     },
-    "sideEffects": false,
-    "dependencies": {
-        "stream": "^0.0.2",
-        "qs": "^6.11.2"
-    }
+    "sideEffects": false
 }

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/dev-dependencies/package.json
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/package.json
@@ -24,6 +24,9 @@
         "./package.json": "./package.json"
     },
     "types": "./types/index.d.ts",
+    "dependencies": {
+        "lodash-es": "^4.17.21"
+    },
     "peerDependencies": {
         "openai": "^4.47.1"
     },

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/jsr/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/BinaryResponse.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/BinaryResponse.d.ts
@@ -14,7 +14,7 @@ export type BinaryResponse = {
     /**
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
      * Some versions of the Fetch API may not support this method.
-     * */
+     */
     bytes?(): Promise<Uint8Array>;
 };
 export declare function getBinaryResponse(response: ResponseWithBody): BinaryResponse;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/Fetcher.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/Fetcher.js
@@ -15,6 +15,7 @@ const json_js_1 = require("../json.js");
 const RawResponse_js_1 = require("./RawResponse.js");
 const Supplier_js_1 = require("./Supplier.js");
 const createRequestUrl_js_1 = require("./createRequestUrl.js");
+const getErrorResponseBody_js_1 = require("./getErrorResponseBody.js");
 const getFetchFn_js_1 = require("./getFetchFn.js");
 const getRequestBody_js_1 = require("./getRequestBody.js");
 const getResponseBody_js_1 = require("./getResponseBody.js");
@@ -55,11 +56,10 @@ function fetcherImpl(args) {
             const response = yield (0, requestWithRetries_js_1.requestWithRetries)(() => __awaiter(this, void 0, void 0, function* () {
                 return (0, makeRequest_js_1.makeRequest)(fetchFn, url, args.method, yield getHeaders(args), requestBody, args.timeoutMs, args.abortSignal, args.withCredentials, args.duplex);
             }), args.maxRetries);
-            const responseBody = yield (0, getResponseBody_js_1.getResponseBody)(response, args.responseType);
             if (response.status >= 200 && response.status < 400) {
                 return {
                     ok: true,
-                    body: responseBody,
+                    body: (yield (0, getResponseBody_js_1.getResponseBody)(response, args.responseType)),
                     headers: response.headers,
                     rawResponse: (0, RawResponse_js_1.toRawResponse)(response),
                 };
@@ -70,7 +70,7 @@ function fetcherImpl(args) {
                     error: {
                         reason: "status-code",
                         statusCode: response.status,
-                        body: responseBody,
+                        body: yield (0, getErrorResponseBody_js_1.getErrorResponseBody)(response),
                     },
                     rawResponse: (0, RawResponse_js_1.toRawResponse)(response),
                 };

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/getErrorResponseBody.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/getErrorResponseBody.d.ts
@@ -1,0 +1,1 @@
+export declare function getErrorResponseBody(response: Response): Promise<unknown>;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/getErrorResponseBody.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/getErrorResponseBody.js
@@ -1,0 +1,44 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getErrorResponseBody = getErrorResponseBody;
+const json_js_1 = require("../json.js");
+const getResponseBody_js_1 = require("./getResponseBody.js");
+function getErrorResponseBody(response) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var _a, _b, _c;
+        let contentType = (_a = response.headers.get("Content-Type")) === null || _a === void 0 ? void 0 : _a.toLowerCase();
+        if (contentType == null || contentType.length === 0) {
+            return (0, getResponseBody_js_1.getResponseBody)(response);
+        }
+        if (contentType.indexOf(";") !== -1) {
+            contentType = (_c = (_b = contentType.split(";")[0]) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+        }
+        switch (contentType) {
+            case "application/hal+json":
+            case "application/json":
+            case "application/ld+json":
+            case "application/problem+json":
+            case "application/vnd.api+json":
+            case "text/json":
+                const text = yield response.text();
+                return text.length > 0 ? (0, json_js_1.fromJson)(text) : undefined;
+            default:
+                if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                    const text = yield response.text();
+                    return text.length > 0 ? (0, json_js_1.fromJson)(text) : undefined;
+                }
+                // Fallback to plain text if content type is not recognized
+                // Even if no body is present, the response will be an empty string
+                return yield response.text();
+        }
+    });
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/getResponseBody.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/getResponseBody.js
@@ -12,6 +12,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getResponseBody = getResponseBody;
 const BinaryResponse_js_1 = require("./BinaryResponse.js");
 const ResponseWithBody_js_1 = require("./ResponseWithBody.js");
+const json_js_1 = require("../json.js");
 function getResponseBody(response, responseType) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!(0, ResponseWithBody_js_1.isResponseWithBody)(response)) {
@@ -35,7 +36,7 @@ function getResponseBody(response, responseType) {
         const text = yield response.text();
         if (text.length > 0) {
             try {
-                let responseBody = JSON.parse(text);
+                let responseBody = (0, json_js_1.fromJson)(text);
                 return responseBody;
             }
             catch (err) {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/BinaryResponse.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/BinaryResponse.d.mts
@@ -14,7 +14,7 @@ export type BinaryResponse = {
     /**
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
      * Some versions of the Fetch API may not support this method.
-     * */
+     */
     bytes?(): Promise<Uint8Array>;
 };
 export declare function getBinaryResponse(response: ResponseWithBody): BinaryResponse;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/Fetcher.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/Fetcher.mjs
@@ -11,6 +11,7 @@ import { toJson } from "../json.mjs";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.mjs";
 import { Supplier } from "./Supplier.mjs";
 import { createRequestUrl } from "./createRequestUrl.mjs";
+import { getErrorResponseBody } from "./getErrorResponseBody.mjs";
 import { getFetchFn } from "./getFetchFn.mjs";
 import { getRequestBody } from "./getRequestBody.mjs";
 import { getResponseBody } from "./getResponseBody.mjs";
@@ -51,11 +52,10 @@ export function fetcherImpl(args) {
             const response = yield requestWithRetries(() => __awaiter(this, void 0, void 0, function* () {
                 return makeRequest(fetchFn, url, args.method, yield getHeaders(args), requestBody, args.timeoutMs, args.abortSignal, args.withCredentials, args.duplex);
             }), args.maxRetries);
-            const responseBody = yield getResponseBody(response, args.responseType);
             if (response.status >= 200 && response.status < 400) {
                 return {
                     ok: true,
-                    body: responseBody,
+                    body: (yield getResponseBody(response, args.responseType)),
                     headers: response.headers,
                     rawResponse: toRawResponse(response),
                 };
@@ -66,7 +66,7 @@ export function fetcherImpl(args) {
                     error: {
                         reason: "status-code",
                         statusCode: response.status,
-                        body: responseBody,
+                        body: yield getErrorResponseBody(response),
                     },
                     rawResponse: toRawResponse(response),
                 };

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/getErrorResponseBody.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/getErrorResponseBody.d.mts
@@ -1,0 +1,1 @@
+export declare function getErrorResponseBody(response: Response): Promise<unknown>;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/getErrorResponseBody.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/getErrorResponseBody.mjs
@@ -1,0 +1,41 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+import { fromJson } from "../json.mjs";
+import { getResponseBody } from "./getResponseBody.mjs";
+export function getErrorResponseBody(response) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var _a, _b, _c;
+        let contentType = (_a = response.headers.get("Content-Type")) === null || _a === void 0 ? void 0 : _a.toLowerCase();
+        if (contentType == null || contentType.length === 0) {
+            return getResponseBody(response);
+        }
+        if (contentType.indexOf(";") !== -1) {
+            contentType = (_c = (_b = contentType.split(";")[0]) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+        }
+        switch (contentType) {
+            case "application/hal+json":
+            case "application/json":
+            case "application/ld+json":
+            case "application/problem+json":
+            case "application/vnd.api+json":
+            case "text/json":
+                const text = yield response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            default:
+                if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                    const text = yield response.text();
+                    return text.length > 0 ? fromJson(text) : undefined;
+                }
+                // Fallback to plain text if content type is not recognized
+                // Even if no body is present, the response will be an empty string
+                return yield response.text();
+        }
+    });
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/getResponseBody.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/getResponseBody.mjs
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { getBinaryResponse } from "./BinaryResponse.mjs";
 import { isResponseWithBody } from "./ResponseWithBody.mjs";
+import { fromJson } from "../json.mjs";
 export function getResponseBody(response, responseType) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!isResponseWithBody(response)) {
@@ -32,7 +33,7 @@ export function getResponseBody(response, responseType) {
         const text = yield response.text();
         if (text.length > 0) {
             try {
-                let responseBody = JSON.parse(text);
+                let responseBody = fromJson(text);
                 return responseBody;
             }
             catch (err) {

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/package-path/jest.config.mjs
+++ b/seed/ts-sdk/exhaustive/package-path/jest.config.mjs
@@ -17,7 +17,7 @@ export default {
         {
             displayName: "browser",
             preset: "ts-jest",
-            testEnvironment: "<rootDir>/tests/BrowserTestEnvironment.ts",
+            testEnvironment: "<rootDir>/src/test-packagePath/tests/BrowserTestEnvironment.ts",
             moduleNameMapper: {
                 "^(\.{1,2}/.*)\.js$": "$1",
             },
@@ -34,7 +34,7 @@ export default {
                 "^(\.{1,2}/.*)\.js$": "$1",
             },
             roots: ["<rootDir>/src/test-packagePath/tests/wire"],
-            setupFilesAfterEnv: ["<rootDir>/tests/mock-server/setup.ts"],
+            setupFilesAfterEnv: ["<rootDir>/src/test-packagePath/tests/mock-server/setup.ts"],
         },
     ],
     workerThreads: false,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/extends/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/extends/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/extends/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/extends/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-download/stream/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-download/stream/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-download/stream/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-download/stream/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-download/stream/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-download/stream/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-download/wrapper/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-download/wrapper/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-download/wrapper/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-download/wrapper/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-download/wrapper/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-download/wrapper/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper.js";
 
@@ -27,7 +28,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-download/wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper.js";
 
@@ -27,7 +28,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/folders/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/folders/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/folders/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/folders/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/http-head/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/http-head/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/http-head/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/BinaryResponse.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/BinaryResponse.ts
@@ -12,8 +12,8 @@ export type BinaryResponse = {
     arrayBuffer: () => Promise<ArrayBuffer>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
     blob: () => Promise<Blob>;
-    /** 
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) 
+    /**
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes)
      * Some versions of the Fetch API may not support this method.
      */
     bytes?(): Promise<Uint8Array>;
@@ -26,7 +26,7 @@ export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
         },
         stream: () => response.body,
         arrayBuffer: response.arrayBuffer.bind(response),
-        blob: response.blob.bind(response),
+        blob: response.blob.bind(response)
     };
     if ("bytes" in response && typeof response.bytes === "function") {
         binaryResponse.bytes = response.bytes.bind(response);

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response)
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody
+                    body: await getErrorResponseBody(response)
                 },
                 rawResponse: toRawResponse(response)
             };

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
@@ -27,7 +28,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/Fetcher.test.ts
@@ -243,7 +243,10 @@ describe("Test fetcherImpl", () => {
             const body = result.body as BinaryResponse;
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
-            expect(typeof body.bytes).toBe("function");
+            expect(typeof body.bytes).toBe("function");            
+            if(!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/license/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/license/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/license/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/license/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/literal/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/literal/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/literal/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/literal/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/no-environment/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/no-environment/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/no-environment/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/nullable/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/nullable/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/nullable/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/oauth-client-credentials/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/object/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/object/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/object/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/object/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/optional/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/optional/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/optional/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/optional/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/package-yml/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/package-yml/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/package-yml/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/pagination/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/pagination/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/pagination/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/pagination/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/pagination/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/pagination/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/pagination/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/pagination/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/path-parameters/default/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/path-parameters/default/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/path-parameters/default/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/default/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/path-parameters/default/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/default/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/path-parameters/default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/default/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/plain-text/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/plain-text/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/plain-text/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/public-object/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/public-object/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/public-object/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/query-parameters/serde-layer-query/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/response-property/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/response-property/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/response-property/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/streaming/no-serde-layer/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper.js";
 
@@ -27,7 +28,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/trace/serde-trace/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/trace/serde-trace/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/trace/serde-trace/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/trace/serde-trace/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/serde-trace/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/unions/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/unions/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/unions/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/unions/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/unions/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/unions/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/unions/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/unions/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/validation/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/validation/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/validation/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/validation/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/variables/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/variables/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/variables/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/version/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/version/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/version/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/version/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/Fetcher.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/Fetcher.ts
@@ -3,6 +3,7 @@ import { APIResponse } from "./APIResponse.js";
 import { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 import { Supplier } from "./Supplier.js";
 import { createRequestUrl } from "./createRequestUrl.js";
+import { getErrorResponseBody } from "./getErrorResponseBody.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { getRequestBody } from "./getRequestBody.js";
 import { getResponseBody } from "./getResponseBody.js";
@@ -100,12 +101,11 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 ),
             args.maxRetries,
         );
-        const responseBody = await getResponseBody(response, args.responseType);
 
         if (response.status >= 200 && response.status < 400) {
             return {
                 ok: true,
-                body: responseBody as R,
+                body: (await getResponseBody(response, args.responseType)) as R,
                 headers: response.headers,
                 rawResponse: toRawResponse(response),
             };
@@ -115,7 +115,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                 error: {
                     reason: "status-code",
                     statusCode: response.status,
-                    body: responseBody,
+                    body: await getErrorResponseBody(response),
                 },
                 rawResponse: toRawResponse(response),
             };

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/getErrorResponseBody.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/getErrorResponseBody.ts
@@ -1,0 +1,32 @@
+import { fromJson } from "../json.js";
+import { getResponseBody } from "./getResponseBody.js";
+
+export async function getErrorResponseBody(response: Response): Promise<unknown> {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+        return getResponseBody(response);
+    }
+
+    if (contentType.indexOf(";") !== -1) {
+        contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+        case "application/hal+json":
+        case "application/json":
+        case "application/ld+json":
+        case "application/problem+json":
+        case "application/vnd.api+json":
+        case "text/json":
+            const text = await response.text();
+            return text.length > 0 ? fromJson(text) : undefined;
+        default:
+            if (contentType.startsWith("application/vnd.") && contentType.endsWith("+json")) {
+                const text = await response.text();
+                return text.length > 0 ? fromJson(text) : undefined;
+            }
+
+            // Fallback to plain text if content type is not recognized
+            // Even if no body is present, the response will be an empty string
+            return await response.text();
+    }
+}

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,6 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
+import { fromJson } from "../json.js";
 
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (!isResponseWithBody(response)) {
@@ -25,7 +26,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     const text = await response.text();
     if (text.length > 0) {
         try {
-            let responseBody = JSON.parse(text);
+            let responseBody = fromJson(text);
             return responseBody;
         } catch (err) {
             return {

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/Fetcher.test.ts
@@ -242,6 +242,9 @@ describe("Test fetcherImpl", () => {
             expect(body).toBeDefined();
             expect(body.bodyUsed).toBe(false);
             expect(typeof body.bytes).toBe("function");
+            if (!body.bytes) {
+                return;
+            }
             const bytes = await body.bytes();
             expect(bytes).toBeInstanceOf(Uint8Array);
             const decoder = new TextDecoder();


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
* Parse HTTP error bodies as JSON if the response content-type header is JSON, otherwise fallback to text.
* Fix `bytes` fetcher test.
* Fix Jest configuration when a `packagePath` is specified in _generators.yml_ config.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

