### PR TITLE
fix(python): ensure websockets.exceptions imported for websocket connect methods

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.25.1
+  changelogEntry:
+    - summary: |
+        Correctly import websockets exceptions.
+      type: fix
+  createdAt: '2025-07-10'
+  irVersion: 58
+
 - version: 4.25.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/external_dependencies/websockets.py
+++ b/generators/python/src/fern_python/external_dependencies/websockets.py
@@ -39,6 +39,15 @@ WEBSOCKETS_SYNC_CONNECTION_MODULE = AST.Module.external(
     ),
 )
 
+WEBSOCKETS_EXCEPTIONS_MODULE = AST.Module.external(
+    module_path=("websockets", "exceptions"),
+    dependency=AST.Dependency(
+        name="websockets",
+        version=">=12.0",
+        compatibility=DependencyCompatibility.EXACT,
+    ),
+)
+
 WEBSOCKETS_SYNC_EXCEPTION_MODULE = AST.Module.external(
     module_path=("websockets", "sync", "exceptions"),
     dependency=AST.Dependency(
@@ -82,6 +91,13 @@ class Websockets:
         return AST.ClassReference(
             qualified_name_excluding_import=("WebSocketException",),
             import_=AST.ReferenceImport(module=WEBSOCKETS_MODULE),
+        )
+
+    @staticmethod
+    def get_invalid_status_code_exception() -> AST.ClassReference:
+        return AST.ClassReference(
+            qualified_name_excluding_import=("InvalidStatusCode",),
+            import_=AST.ReferenceImport(module=WEBSOCKETS_EXCEPTIONS_MODULE),
         )
 
     @staticmethod

--- a/generators/python/src/fern_python/generators/sdk/client_generator/websocket_connect_method_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/websocket_connect_method_generator.py
@@ -344,7 +344,11 @@ class WebsocketConnectMethodGenerator:
                     body=body,
                     handlers=[
                         AST.ExceptHandler(
-                            exception_type="websockets.exceptions.InvalidStatusCode",
+                            exception_type=AST.Expression(
+                                AST.ReferenceNode(
+                                    reference=Websockets.get_invalid_status_code_exception()
+                                ),
+                            ),
                             name="exc",
                             body=[
                                 AST.VariableDeclaration(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
@@ -4,6 +4,7 @@ import typing
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
+import websockets.exceptions
 import websockets.sync.client as websockets_sync_client
 from ..core.api_error import ApiError
 from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
@@ -4,6 +4,7 @@ import typing
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
+import websockets.exceptions
 import websockets.sync.client as websockets_sync_client
 from ..core.api_error import ApiError
 from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper


### PR DESCRIPTION
`WebsocketConnectMethodGenerator` referred to `websockets.exceptions.InvalidStatusCode` as a string, assuming it to be available.

This assumption was broken in a recent change, so instead we refer to it via AST, to trigger automatic import.

## Changes Made
- Refer to exception via `AST.ReferenceNode` in `WebsocketConnectMethodGenerator`

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated -- running
- [x] Manual testing completed: linter now passes

## Deploy
- [x] Update `versions.yml`
