### PR TITLE
fix: Skipped symlinking files for windows compatibility

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,1 @@
+# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,7 @@ jobs:
           }
           cd windows
           $process = Start-Process node -ArgumentList "$cliPath", "docs", "dev", "--log-level", "trace" -PassThru -RedirectStandardOutput "output.txt" -RedirectStandardError "error.txt"
-          Start-Sleep -Seconds 10
-          if (-not $process.HasExited) {
-            Stop-Process -Id $process.Id -Force
-          }
+          $process.WaitForExit(30000)
           $output = Get-Content "output.txt", "error.txt" -Raw
           if ($output -match "Failed to download docs preview bundle") {
             Write-Error "Found 'Failed to download docs preview bundle' in output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,27 +213,19 @@ jobs:
           $process = Start-Process node -ArgumentList "$cliPath", "docs", "dev", "--log-level", "trace" -PassThru -RedirectStandardOutput "output.txt" -RedirectStandardError "error.txt"
           $process.WaitForExit(30000)
           $output = Get-Content "output.txt", "error.txt" -Raw
-          
+
           # Check for the symlink skip log
           if ($output -match "Skipping symlink:") {
             Write-Host "✓ Found symlink skip logs - filter is working"
           } else {
             Write-Host "ℹ No symlinks found to skip"
           }
-          
+
           # Check for the original error (should not appear)
           if ($output -match "Failed to download docs preview bundle") {
             Write-Error "Found 'Failed to download docs preview bundle' in output"
             exit 1
           }
-          
-          # Check that the process completed successfully
-          if ($process.ExitCode -ne 0) {
-            Write-Error "Process failed with exit code: $($process.ExitCode)"
-            exit 1
-          }
-          
-          Write-Host "✓ Test passed - docs dev command completed successfully"
 
   live-test-dev-windows:
     environment: Fern Dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,10 +213,27 @@ jobs:
           $process = Start-Process node -ArgumentList "$cliPath", "docs", "dev", "--log-level", "trace" -PassThru -RedirectStandardOutput "output.txt" -RedirectStandardError "error.txt"
           $process.WaitForExit(30000)
           $output = Get-Content "output.txt", "error.txt" -Raw
+          
+          # Check for the symlink skip log
+          if ($output -match "Skipping symlink:") {
+            Write-Host "✓ Found symlink skip logs - filter is working"
+          } else {
+            Write-Host "ℹ No symlinks found to skip"
+          }
+          
+          # Check for the original error (should not appear)
           if ($output -match "Failed to download docs preview bundle") {
             Write-Error "Found 'Failed to download docs preview bundle' in output"
             exit 1
           }
+          
+          # Check that the process completed successfully
+          if ($process.ExitCode -ne 0) {
+            Write-Error "Process failed with exit code: $($process.ExitCode)"
+            exit 1
+          }
+          
+          Write-Host "✓ Test passed - docs dev command completed successfully"
 
   live-test-dev-windows:
     environment: Fern Dev

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,32 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+# Install Node.js
+RUN powershell -Command \
+    Invoke-WebRequest -Uri https://nodejs.org/dist/v18.19.0/node-v18.19.0-x64.msi -OutFile node.msi && \
+    Start-Process msiexec.exe -ArgumentList '/i', 'node.msi', '/quiet', '/norestart' -NoNewWindow -Wait && \
+    Remove-Item node.msi
+
+# Install npm and pnpm
+RUN npm install -g npm@latest pnpm
+
+# Set working directory
+WORKDIR C:\workspace
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Copy source code
+COPY packages/ ./packages/
+COPY .github/ ./.github/
+COPY scripts/ ./scripts/
+
+# Install dependencies
+RUN pnpm install
+
+# Build the CLI
+RUN pnpm --filter @fern-api/cli dist:cli:dev
+
+# Copy test script
+COPY test-windows.ps1 .
+
+CMD ["powershell", "-File", "test-windows.ps1"]

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -148,7 +148,7 @@ export async function downloadBundle({
         const absolutePathToBundleFolder = getPathToBundleFolder({ app });
         await mkdir(absolutePathToBundleFolder, { recursive: true });
         await decompress(outputZipPath, absolutePathToBundleFolder, {
-            filter: (file) => file.type !== 'symlink' // Skip symlinks for Windows compatibility
+            // filter: (file) => file.type !== 'symlink' // Skip symlinks for Windows compatibility
         });
         
         // write etag

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -147,8 +147,10 @@ export async function downloadBundle({
 
         const absolutePathToBundleFolder = getPathToBundleFolder({ app });
         await mkdir(absolutePathToBundleFolder, { recursive: true });
-        await decompress(outputZipPath, absolutePathToBundleFolder);
-
+        await decompress(outputZipPath, absolutePathToBundleFolder, {
+            filter: (file) => file.type !== 'symlink' // Skip symlinks for Windows compatibility
+        });
+        
         // write etag
         await writeFile(eTagFilepath, eTag);
         logger.debug(`Downloaded bundle to ${absolutePathToBundleFolder}`);

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -148,7 +148,13 @@ export async function downloadBundle({
         const absolutePathToBundleFolder = getPathToBundleFolder({ app });
         await mkdir(absolutePathToBundleFolder, { recursive: true });
         await decompress(outputZipPath, absolutePathToBundleFolder, {
-            // filter: (file) => file.type !== 'symlink' // Skip symlinks for Windows compatibility
+            filter: (file) => {
+                if (file.type === 'symlink') {
+                    logger.debug(`Skipping symlink: ${file.path}`);
+                    return false;
+                }
+                return true;
+            }
         });
         
         // write etag

--- a/test-windows.ps1
+++ b/test-windows.ps1
@@ -1,0 +1,55 @@
+Write-Host "=== Testing Fern CLI with Symlink Fix ==="
+
+# Test symlink creation (should fail)
+Write-Host "Testing symlink creation on Windows..."
+try {
+    New-Item -ItemType SymbolicLink -Path "test-link" -Target "test-target"
+    Write-Host "Symlink created successfully"
+} catch {
+    Write-Host "Symlink creation failed (expected): $($_.Exception.Message)"
+}
+
+# Test the built CLI
+Write-Host "Testing built Fern CLI..."
+$cliPath = "C:\workspace\packages\cli\cli\dist\dev\cli.cjs"
+
+if (-not (Test-Path $cliPath)) {
+    Write-Error "CLI path does not exist: $cliPath"
+    exit 1
+}
+
+Write-Host "CLI version:"
+& node $cliPath -v
+
+# Create a test project
+Write-Host "Creating test project..."
+& node $cliPath init --docs --yes
+
+# Test docs dev with trace logging
+Write-Host "Testing fern docs dev with symlink fix..."
+$process = Start-Process node -ArgumentList "$cliPath", "docs", "dev", "--log-level", "trace" -PassThru -RedirectStandardOutput "output.txt" -RedirectStandardError "error.txt"
+$process.WaitForExit(30000)
+
+$output = Get-Content "output.txt", "error.txt" -Raw
+
+# Check for symlink skip logs
+if ($output -match "Skipping symlink:") {
+    $symlinkCount = ($output | Select-String "Skipping symlink:").Count
+    Write-Host "✓ Found $symlinkCount symlink skip logs - filter is working"
+} else {
+    Write-Host "ℹ No symlinks found to skip"
+}
+
+# Check for the original error (should not appear)
+if ($output -match "Failed to download docs preview bundle") {
+    Write-Error "Found 'Failed to download docs preview bundle' in output"
+    exit 1
+}
+
+# Check that the process completed successfully
+if ($process.ExitCode -ne 0) {
+    Write-Error "Process failed with exit code: $($process.ExitCode)"
+    exit 1
+}
+
+Write-Host "✓ Test passed - docs dev command completed successfully with symlink fix"


### PR DESCRIPTION
## Description
Users were experiencing the following error in windows due to being unable to symlink files

```
>     Failed to download docs preview bundle. Error: Error: ENOENT: no such file or directory, link 'C:\GIT\sps-api-reference\.pnpm\react@19.0.0\node_modules\react' -> 'C:\Users\tgosselin\.fern\app-preview\.next\standal…
```

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- skipped symlinking files
- modified github actions test to wait for the process to exit

## Testing
<!-- Describe how you tested these changes -->
- [x] Modified github actions test

