### PR TITLE
docs: Clean up OpenAPI auth documentation formatting and examples

### DIFF
--- a/fern/pages/api-definition/openapi/auth.mdx
+++ b/fern/pages/api-definition/openapi/auth.mdx
@@ -1,11 +1,11 @@
 ---
 title: Authentication
-subtitle: Model auth schemes such as bearer, basic, and api key. 
+subtitle: Model auth schemes such as bearer, basic, and api key.
 ---
 
-Configuring authentication schemes happens in the `components.securitySchemes` section of OpenAPI. 
+Configuring authentication schemes happens in the `components.securitySchemes` section of OpenAPI.
 
-```yml title="openapi.yml" {2-3}
+```yml
 components: 
   securitySchemes: 
     ...
@@ -24,11 +24,13 @@ security:
 ```
 </Note>
 
+There are more things that you can integrate with.
+
 ## Bearer security scheme
 
-Start by defining a `bearer` security scheme in your `openapi.yml`: 
+Start by defining a `bearer` security scheme in your `openapi.yml`:
 
-```yml title="openapi.yml" {3-5}
+```yml
 components:
   securitySchemes:
     BearerAuth:
@@ -36,19 +38,17 @@ components:
       scheme: bearer
 ```
 
-This will generate an SDK where the user would have to provide 
-a mandatory argument called `token`. 
+This will generate an SDK where the user would have to provide a mandatory argument called `token`.
 
-```ts index.ts
+```ts
 const client = new Client({
   token: "ey34..."
 })
 ```
 
-If you want to control variable naming and the environment variable to scan, 
-use the configuration below: 
+If you want to control variable naming and the environment variable to scan, use the configuration below:
 
-```yaml title="openapi.yml" {6-8}
+```yaml
 components:
   securitySchemes:
     BearerAuth:
@@ -59,9 +59,9 @@ components:
         env: PLANTSTORE_API_KEY
 ```
 
-The generated SDK would look like: 
+The generated SDK would look like:
 
-```ts index.ts
+```ts
 
 // Uses process.env.PLANTSTORE_API_KEY
 let client = new Client(); 
@@ -74,9 +74,9 @@ client = new Client({
 
 ## Basic security scheme
 
-Start by defining a `basic` security scheme in your `openapi.yml`: 
+Start by defining a `basic` security scheme in your `openapi.yml`:
 
-```yaml title="openapi.yml" {3-5}
+```yaml
 components:
   securitySchemes:
     BasicAuth:
@@ -84,20 +84,18 @@ components:
       scheme: basic
 ```
 
-This will generate an SDK where the user would have to provide 
-a mandatory arguments called `username` and `password`. 
+This will generate an SDK where the user would have to provide a mandatory arguments called `username` and `password`.
 
-```ts index.ts
+```ts
 const client = new Client({
   username: "joeschmoe"
   password: "ey34..."
 })
 ```
 
-If you want to control variable naming and environment variables to scan, 
-use the configuration below: 
+If you want to control variable naming and environment variables to scan, use the configuration below:
 
-```yaml title="openapi.yml" {6-12}
+```yaml
 components:
   securitySchemes:
     BasicAuth:
@@ -112,9 +110,9 @@ components:
           env: PLANTSTORE_CLIENT_SECRET
 ```
 
-The generated SDK would look like: 
+The generated SDK would look like:
 
-```ts index.ts
+```ts
 
 // Uses process.env.PLANTSTORE_CLIENT_ID and process.env.PLANTSTORE_CLIENT_SECRET
 let client = new Client(); 
@@ -128,9 +126,9 @@ client = new Client({
 
 ## ApiKey security scheme
 
-Start by defining an `apiKey` security scheme in your `openapi.yml`: 
+Start by defining an `apiKey` security scheme in your `openapi.yml`:
 
-```yml title="openapi.yml" {3-5}
+```yml
 components: 
   securitySchemes: 
     ApiKey: 
@@ -139,19 +137,17 @@ components:
       name: X_API_KEY
 ```
 
-This will generate an SDK where the user would have to provide 
-a mandatory argument called `apiKey`. 
+This will generate an SDK where the user would have to provide a mandatory argument called `apiKey`.
 
-```ts index.ts
+```ts
 const client = new Client({
   apiKey: "ey34..."
 })
 ```
 
-If you want to control variable naming and environment variables to scan, 
-use the configuration below: 
+If you want to control variable naming and environment variables to scan, use the configuration below:
 
-```yaml title="openapi.yml" {7-10}
+```yaml
 components: 
   securitySchemes: 
     ApiKey: 
@@ -164,9 +160,9 @@ components:
         prefix: "Token " # Optional      
 ```
 
-The generated SDK would look like: 
+The generated SDK would look like:
 
-```ts index.ts
+```ts
 
 // Uses process.env.PLANTSTORE_API_KEY
 let client = new Client(); 
@@ -179,11 +175,9 @@ client = new Client({
 
 ## Multiple security schemes
 
-If you would like to define multiple security schemes, simply 
-list them under `components.securitySchemes`. For example, if you wanted to support 
-`basic` and `apiKey` security schemes, see the example below: 
+If you would like to define multiple security schemes, simply list them under `components.securitySchemes`. For example, if you wanted to support `basic` and `apiKey` security schemes, see the example below:
 
-```yaml title="openapi.yml" {3,6}
+```yaml
 components: 
   securitySchemes: 
     BearerAuth:


### PR DESCRIPTION

This PR improves the readability and consistency of the OpenAPI authentication documentation by:
- Removing unnecessary title annotations from code blocks
- Standardizing code block formatting
- Fixing whitespace and line endings
- Adding a note about additional integration options
- Improving text formatting and readability by removing unnecessary line breaks
- Maintaining the same comprehensive coverage of bearer, basic, and API key authentication schemes

The changes are primarily formatting improvements to make the documentation cleaner and more consistent, while preserving all the technical content and examples.