### PR TITLE
fix(typescript): Fix dependencies package.json merging

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 2.4.7
+  changelogEntry:
+    - summary: |
+        Make sure `extraDependencies`, `extraPeerDependencies`, `extraPeerDependenciesMeta`, and `extraDevDependencies` are always merged into _package.json_.
+        This was previously fixed for `shouldBundle: true`, but not for `shouldBundle: false` (default).
+        All dependencies should now come through.
+      type: fix
+  createdAt: "2025-07-09"
+  irVersion: 58
+
 - version: 2.4.6
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -7,7 +7,7 @@
         This was previously fixed for `shouldBundle: true`, but not for `shouldBundle: false` (default).
         All dependencies should now come through.
       type: fix
-  createdAt: "2025-07-09"
+  createdAt: "2025-07-10"
   irVersion: 58
 
 - version: 2.4.6

--- a/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
@@ -300,31 +300,36 @@ export class SimpleTypescriptProject extends TypescriptProject {
         };
 
         packageJson = produce(packageJson, (draft) => {
-            if (Object.keys(this.dependencies[DependencyType.PROD]).length > 0) {
-                draft.dependencies = {
-                    ...this.dependencies[DependencyType.PROD],
-                    ...this.extraDependencies
-                };
+            const dependencies = {
+                ...this.dependencies[DependencyType.PROD],
+                ...this.extraDependencies
+            };
+            if (Object.keys(dependencies).length > 0) {
+                draft.dependencies = dependencies;
             }
-            if (
-                Object.keys(this.dependencies[DependencyType.PEER]).length > 0 ||
-                Object.keys(this.extraPeerDependencies).length > 0
-            ) {
-                draft.peerDependencies = {
-                    ...this.dependencies[DependencyType.PEER],
-                    ...this.extraPeerDependencies
-                };
+
+            const peerDependencies = {
+                ...this.dependencies[DependencyType.PEER],
+                ...this.extraPeerDependencies
+            };
+            if (Object.keys(peerDependencies).length > 0) {
+                draft.peerDependencies = peerDependencies;
             }
+
             if (Object.keys(this.extraPeerDependenciesMeta).length > 0) {
                 draft.peerDependenciesMeta = {
                     ...this.extraPeerDependenciesMeta
                 };
             }
-            draft.devDependencies = {
+
+            const devDependencies = {
                 ...this.dependencies[DependencyType.DEV],
                 ...this.getDevDependencies(),
                 ...this.extraDevDependencies
             };
+            if (Object.keys(devDependencies).length > 0) {
+                draft.devDependencies = devDependencies;
+            }
 
             draft.browser = {
                 fs: false,

--- a/seed/ts-sdk/imdb/noScripts/package.json
+++ b/seed/ts-sdk/imdb/noScripts/package.json
@@ -38,6 +38,9 @@
         "test:browser": "jest --selectProjects browser",
         "test:wire": "jest --selectProjects wire"
     },
+    "dependencies": {
+        "lodash": "4.17.21"
+    },
     "devDependencies": {
         "webpack": "^5.97.1",
         "ts-loader": "^9.5.1",


### PR DESCRIPTION
## Description
Make sure `extraDependencies`, `extraPeerDependencies`, `extraPeerDependenciesMeta`, and `extraDevDependencies` are always merged into _package.json_.
        This was previously fixed for `shouldBundle: true`, but not for `shouldBundle: false` (default).
        All dependencies should now come through.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

