### PR TITLE
fix(cli): disable group name check when the x-displayName is specified

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
@@ -580,13 +580,14 @@ export class OperationConverter extends AbstractOperationConverter {
     private getGroupDisplayName(group: string[] | undefined): string | undefined {
         let rawOperationTag = this.operation.tags?.[0];
         if (rawOperationTag != null) {
-            rawOperationTag = this.context.getDisplayNameForTag(rawOperationTag);
+            return rawOperationTag;
+            // rawOperationTag = this.context.getDisplayNameForTag(rawOperationTag);
         }
-        const baseGroupName = group?.[group.length - 1];
-        if (baseGroupName != null && rawOperationTag != null) {
-            const lowerCaseRawOperationTag = rawOperationTag.toLowerCase().replaceAll(" ", "");
-            return lowerCaseRawOperationTag === baseGroupName ? rawOperationTag : undefined;
-        }
+        // const baseGroupName = group?.[group.length - 1];
+        // if (baseGroupName != null && rawOperationTag != null) {
+        //     const lowerCaseRawOperationTag = rawOperationTag.toLowerCase().replaceAll(" ", "");
+        //     return lowerCaseRawOperationTag === baseGroupName ? rawOperationTag : undefined;
+        // }
         return undefined;
     }
 }


### PR DESCRIPTION
## Description
- disable group name check when the x-displayName is specified

## Testing
- [ ] Unit tests added/updated
- [X] Manual testing completed

<img width="223" height="978" alt="image" src="https://github.com/user-attachments/assets/a64ade85-cfa5-4354-acd8-bfca45506908" />

<img width="252" height="1117" alt="image" src="https://github.com/user-attachments/assets/0f34f1a1-d8e9-47f1-b3f3-0218d8d13e65" />
