### PR TITLE
DO NOT MERGE fix(cli): change type assumption of apiVersionScheme type

### DIFF
--- a/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
+++ b/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
@@ -194,7 +194,30 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
     }
 
     public setApiVersion(apiVersionScheme: unknown): void {
-        this.rootApiFile.version = apiVersionScheme as RawSchemas.VersionDeclarationSchema;
+        // TODO: Validate the apiVersionSchema since it's being set incorrectly
+        // IR looks something like this:
+
+        //     "apiVersion": {
+        //         "version": {
+        //             "header": "X-API-Version",
+        //             "default": "2024-10-25",
+        //             "values": [
+        //                 "2024-10-25",
+        //                 "2025-07-30"
+        //             ]
+        //     }
+        // },   
+
+        // So we should set this.rootApiFile.version to apiVersionSchema[<version-param-name>] instead of apiVersionScheme
+
+        try {
+            const versionKey = Object.keys(apiVersionScheme as Record<string, RawSchemas.VersionDeclarationSchema>)[0];
+            if (versionKey != null) {
+                this.rootApiFile.version = (apiVersionScheme as Record<string, RawSchemas.VersionDeclarationSchema>)[versionKey];
+            }
+        } catch (err) {
+            return;
+        }
     }
 
     public getEnvironmentType(): "single" | "multi" | undefined {


### PR DESCRIPTION
## Description
- change type assumption of apiVersionScheme type

## Changes Made
- use the first key of `apiVersionScheme` if its an object

## Testing
- [ ] Unit tests added/updated
- [X] Manual testing completed

