### PR TITLE
docs: Update welcome page content and formatting

### DIFF
--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -84,9 +84,7 @@ hide-toc: true
     right: -7%;
   }
 `}
-</style>
-
-<div className="background-wrapper">
+</style><div className="background-wrapper">
   <div className="gradient-radial hero-1 is-green"> </div>
   <div className="gradient-radial hero-2 is-blue"> </div>
   <div className="gradient-radial hero-3 is-green"> </div>
@@ -122,25 +120,29 @@ Fern allows developers to instantly transform your OpenAPI into SDKs and Docs. E
   </Card>
 </Cards>
 
-## Motivation
+## Motivation - this is my editable text
 
-Stripe, Twilio, and AWS have the resources to invest in internal tooling for developer 
-experience. They provide SDKs (aka client libraries) in multiple languages and developer documentation
-that stays up-to-date. 
+Stripe, Twilio, and AWS have the resources to invest in internal tooling for developer experience. They provide SDKs (aka client libraries) in multiple languages and developer documentation that stays up-to-date.
 
-We are building Fern to productize this process and make it accessible to all
-software companies.
+We are building Fern to productize this process and make it accessible to all software companies.
+
+### My test 1
+
+this is it!
 
 ## Get Support
 
 We love talking to users! Reach out via your preferred support channel so we can help you succeed with Fern.
 
 1. 💬 Message us in your Dedicated Slack Channel (for paid customers)
+
 2. 🤝 [Join our community Slack](https://buildwithfern.com/slack)
+
 3. 🐛 [File a GitHub Issue](https://github.com/fern-api/fern/issues)
+
 4. ✉️ [Email us](mailto:support@buildwithfern.com)
 
-We're lightning-fast with support - you'll typically hear back from us in hours, not days! 
+We're lightning-fast with support - you'll typically hear back from us in hours, not days!
 
 <ButtonGroup>
 <Button href="https://buildwithfern.com/contact" intent="primary" rightIcon="arrow-right" large>


### PR DESCRIPTION

Updates the welcome page content with editable text sections and improves formatting of the support section. Changes include:
- Added "Motivation - this is my editable text" section
- Added new "My test 1" section with placeholder content
- Improved readability of the support channels list with added spacing
- Fixed HTML/CSS formatting in the background wrapper section
- Maintained existing content structure while allowing for editable regions

These changes appear to be part of enabling visual editing capabilities while preserving the page's core content and layout.