### PR TITLE
feat(cli): support x-fern-global-headers that are typed

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/ExampleEndpointFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/ExampleEndpointFactory.ts
@@ -10,7 +10,6 @@ import {
     FullExample,
     GlobalHeader,
     HeaderExample,
-    HeaderWithExample,
     NamedFullExample,
     PathParameterExample,
     PrimitiveSchemaValueWithExample,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernTypeExtension.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernTypeExtension.ts
@@ -6,7 +6,8 @@ import {
     Availability,
     LiteralSchemaValue,
     PrimitiveSchemaValueWithExample,
-    SchemaWithExample
+    SchemaWithExample,
+    Source
 } from "@fern-api/openapi-ir";
 
 import { getExtension } from "../../../getExtension";
@@ -345,8 +346,18 @@ export function getSchemaFromFernType({
                     namespace,
                     groupName
                 }),
-            named: () => {
-                return undefined;
+            named: (reference: string) => {
+                return SchemaWithExample.reference({
+                    schema: reference,
+                    nameOverride,
+                    generatedName,
+                    title,
+                    description,
+                    availability,
+                    namespace,
+                    groupName,
+                    source: Source.openapi({ file: "<memory>" })
+                });
             }
         }
     });

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,23 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        The extension `x-fern-global-headers` now supports a type field that can point to 
+        arbitrary schemas. For example you can do the following to describe a header 
+        that is an enum.
+        
+        ```yml
+        x-fern-global-headers:
+          - header: X-API-Version
+            name: version
+            type: VersionEnum
+        ```
+      type: feat
+  irVersion: 58
+  createdAt: "2025-07-12"
+  version: 0.65.11
+
+- changelogEntry:
+    - summary: |  
         Clarify `fern upgrade` command description.
       type: feat
   irVersion: 58


### PR DESCRIPTION
## Description
The extension `x-fern-global-headers` now supports a type field that can point to 
arbitrary schemas. For example you can do the following to describe a header 
that is an enum.

```yml
x-fern-global-headers:
  - header: X-API-Version
    name: version
    type: VersionEnum
```

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

