### PR TITLE
feat(swift): inject coding keys into generated structs

### DIFF
--- a/generators/swift/codegen/src/ast/Struct.ts
+++ b/generators/swift/codegen/src/ast/Struct.ts
@@ -1,4 +1,5 @@
 import { AccessLevel } from "./AccessLevel";
+import type { EnumWithRawValues } from "./EnumWithRawValues";
 import { Property } from "./Property";
 import { AstNode, Writer } from "./core";
 
@@ -8,6 +9,7 @@ export declare namespace Struct {
         accessLevel?: AccessLevel;
         conformances?: string[];
         properties: Property[];
+        nestedTypes?: (Struct | EnumWithRawValues)[];
     }
 }
 
@@ -16,13 +18,15 @@ export class Struct extends AstNode {
     public readonly accessLevel?: AccessLevel;
     public readonly conformances?: string[];
     public readonly properties: Property[];
+    public readonly nestedTypes?: (Struct | EnumWithRawValues)[];
 
-    public constructor({ accessLevel, name, conformances, properties }: Struct.Args) {
+    public constructor({ accessLevel, name, conformances, properties, nestedTypes }: Struct.Args) {
         super();
         this.name = name;
         this.accessLevel = accessLevel;
         this.conformances = conformances;
         this.properties = properties;
+        this.nestedTypes = nestedTypes;
     }
 
     public write(writer: Writer): void {
@@ -46,6 +50,16 @@ export class Struct extends AstNode {
             property.write(writer);
             writer.newLine();
         });
+        if (this.nestedTypes) {
+            writer.newLine();
+            this.nestedTypes.forEach((nestedType, nestedTypeIdx) => {
+                if (nestedTypeIdx > 0) {
+                    writer.newLine();
+                }
+                nestedType.write(writer);
+                writer.newLine();
+            });
+        }
         writer.dedent();
         writer.write("}");
     }

--- a/generators/swift/codegen/src/ast/__test__/snapshots/struct_with_1_nested_enum.swift
+++ b/generators/swift/codegen/src/ast/__test__/snapshots/struct_with_1_nested_enum.swift
@@ -1,0 +1,9 @@
+struct Order {
+    let id: Int64
+    let petId: String
+
+    enum Status: String, Codable, CaseIterable {
+        case available
+        case pending
+    }
+}

--- a/generators/swift/codegen/src/ast/__test__/snapshots/struct_with_2_nested_enums.swift
+++ b/generators/swift/codegen/src/ast/__test__/snapshots/struct_with_2_nested_enums.swift
@@ -1,0 +1,14 @@
+struct Pet {
+    let id: Int
+    let name: String
+
+    enum Status: String, Codable, CaseIterable {
+        case available
+        case pending
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+    }
+}

--- a/generators/swift/codegen/src/ast/__test__/struct.test.ts
+++ b/generators/swift/codegen/src/ast/__test__/struct.test.ts
@@ -191,7 +191,7 @@ describe("Struct", () => {
             `);
         });
 
-        it("should write struct with 1 nested enum", () => {
+        it("should write struct with 1 nested enum", async () => {
             const struct = swift.struct({
                 name: "Order",
                 properties: [
@@ -218,10 +218,10 @@ describe("Struct", () => {
                 ]
             });
 
-            expect(struct.toString()).toMatchFileSnapshot("snapshots/struct_with_1_nested_enum.swift");
+            await expect(struct.toString()).toMatchFileSnapshot("snapshots/struct_with_1_nested_enum.swift");
         });
 
-        it("should write struct with 2 nested enums", () => {
+        it("should write struct with 2 nested enums", async () => {
             const struct = swift.struct({
                 name: "Pet",
                 properties: [
@@ -256,7 +256,7 @@ describe("Struct", () => {
                 ]
             });
 
-            expect(struct.toString()).toMatchFileSnapshot("snapshots/struct_with_2_nested_enums.swift");
+            await expect(struct.toString()).toMatchFileSnapshot("snapshots/struct_with_2_nested_enums.swift");
         });
     });
 });

--- a/generators/swift/codegen/src/ast/__test__/struct.test.ts
+++ b/generators/swift/codegen/src/ast/__test__/struct.test.ts
@@ -190,5 +190,73 @@ describe("Struct", () => {
               }"
             `);
         });
+
+        it("should write struct with 1 nested enum", () => {
+            const struct = swift.struct({
+                name: "Order",
+                properties: [
+                    swift.property({
+                        unsafeName: "id",
+                        type: Type.int64(),
+                        declarationType: DeclarationType.Let
+                    }),
+                    swift.property({
+                        unsafeName: "petId",
+                        type: Type.string(),
+                        declarationType: DeclarationType.Let
+                    })
+                ],
+                nestedTypes: [
+                    swift.enumWithRawValues({
+                        name: "Status",
+                        conformances: ["String", "Codable", "CaseIterable"],
+                        cases: [
+                            { unsafeName: "available", rawValue: "available" },
+                            { unsafeName: "pending", rawValue: "pending" }
+                        ]
+                    })
+                ]
+            });
+
+            expect(struct.toString()).toMatchFileSnapshot("snapshots/struct_with_1_nested_enum.swift");
+        });
+
+        it("should write struct with 2 nested enums", () => {
+            const struct = swift.struct({
+                name: "Pet",
+                properties: [
+                    swift.property({
+                        unsafeName: "id",
+                        type: Type.int(),
+                        declarationType: DeclarationType.Let
+                    }),
+                    swift.property({
+                        unsafeName: "name",
+                        type: Type.string(),
+                        declarationType: DeclarationType.Let
+                    })
+                ],
+                nestedTypes: [
+                    swift.enumWithRawValues({
+                        name: "Status",
+                        conformances: ["String", "Codable", "CaseIterable"],
+                        cases: [
+                            { unsafeName: "available", rawValue: "available" },
+                            { unsafeName: "pending", rawValue: "pending" }
+                        ]
+                    }),
+                    swift.enumWithRawValues({
+                        name: "CodingKeys",
+                        conformances: ["String", "CodingKey"],
+                        cases: [
+                            { unsafeName: "id", rawValue: "id" },
+                            { unsafeName: "name", rawValue: "name" }
+                        ]
+                    })
+                ]
+            });
+
+            expect(struct.toString()).toMatchFileSnapshot("snapshots/struct_with_2_nested_enums.swift");
+        });
     });
 });

--- a/generators/swift/model/src/__test__/snapshots/basic-object/User.swift
+++ b/generators/swift/model/src/__test__/snapshots/basic-object/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: String
     public let name: String
     public let email: String

--- a/generators/swift/model/src/__test__/snapshots/linked-objects/Address.swift
+++ b/generators/swift/model/src/__test__/snapshots/linked-objects/Address.swift
@@ -1,4 +1,4 @@
-public struct Address {
+public struct Address: Codable, Hashable {
     public let street: String
     public let city: String
     public let state: String

--- a/generators/swift/model/src/__test__/snapshots/linked-objects/User.swift
+++ b/generators/swift/model/src/__test__/snapshots/linked-objects/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: String
     public let name: String
     public let address: Address

--- a/seed/swift-sdk/alias-extends/src/AliasExtends/Child.swift
+++ b/seed/swift-sdk/alias-extends/src/AliasExtends/Child.swift
@@ -1,3 +1,3 @@
-public struct Child {
+public struct Child: Codable, Hashable {
     public let child: String
 }

--- a/seed/swift-sdk/alias-extends/src/AliasExtends/Parent.swift
+++ b/seed/swift-sdk/alias-extends/src/AliasExtends/Parent.swift
@@ -1,3 +1,3 @@
-public struct Parent {
+public struct Parent: Codable, Hashable {
     public let parent: String
 }

--- a/seed/swift-sdk/alias/src/Alias/Type.swift
+++ b/seed/swift-sdk/alias/src/Alias/Type.swift
@@ -1,4 +1,4 @@
-public struct Type {
+public struct Type: Codable, Hashable {
     public let id: TypeId
     public let name: String
 }

--- a/seed/swift-sdk/any-auth/src/AnyAuth/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/any-auth/src/AnyAuth/Auth/TokenResponse.swift
@@ -1,5 +1,11 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
     public let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/seed/swift-sdk/any-auth/src/AnyAuth/User/User.swift
+++ b/seed/swift-sdk/any-auth/src/AnyAuth/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: String
     public let name: String
 }

--- a/seed/swift-sdk/audiences/src/Audiences/FolderA/Service/Response.swift
+++ b/seed/swift-sdk/audiences/src/Audiences/FolderA/Service/Response.swift
@@ -1,3 +1,3 @@
-public struct Response {
+public struct Response: Codable, Hashable {
     public let foo: Foo?
 }

--- a/seed/swift-sdk/audiences/src/Audiences/FolderB/Common/Foo.swift
+++ b/seed/swift-sdk/audiences/src/Audiences/FolderB/Common/Foo.swift
@@ -1,3 +1,3 @@
-public struct Foo {
+public struct Foo: Codable, Hashable {
     public let foo: FolderCFoo?
 }

--- a/seed/swift-sdk/audiences/src/Audiences/FolderC/Common/FolderCFoo.swift
+++ b/seed/swift-sdk/audiences/src/Audiences/FolderC/Common/FolderCFoo.swift
@@ -1,3 +1,7 @@
-public struct FolderCFoo {
+public struct FolderCFoo: Codable, Hashable {
     public let barProperty: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case barProperty = "bar_property"
+    }
 }

--- a/seed/swift-sdk/audiences/src/Audiences/FolderD/Service/Response.swift
+++ b/seed/swift-sdk/audiences/src/Audiences/FolderD/Service/Response.swift
@@ -1,3 +1,3 @@
-public struct Response {
+public struct Response: Codable, Hashable {
     public let foo: String
 }

--- a/seed/swift-sdk/audiences/src/Audiences/Foo/FilteredType.swift
+++ b/seed/swift-sdk/audiences/src/Audiences/Foo/FilteredType.swift
@@ -1,4 +1,9 @@
-public struct FilteredType {
+public struct FilteredType: Codable, Hashable {
     public let publicProperty: String?
     public let privateProperty: Int
+
+    enum CodingKeys: String, CodingKey {
+        case publicProperty = "public_property"
+        case privateProperty = "private_property"
+    }
 }

--- a/seed/swift-sdk/audiences/src/Audiences/Foo/ImportingType.swift
+++ b/seed/swift-sdk/audiences/src/Audiences/Foo/ImportingType.swift
@@ -1,3 +1,3 @@
-public struct ImportingType {
+public struct ImportingType: Codable, Hashable {
     public let imported: Imported
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/src/BasicAuthEnvironmentVariables/Errors/UnauthorizedRequestErrorBody.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/src/BasicAuthEnvironmentVariables/Errors/UnauthorizedRequestErrorBody.swift
@@ -1,3 +1,3 @@
-public struct UnauthorizedRequestErrorBody {
+public struct UnauthorizedRequestErrorBody: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/basic-auth/src/BasicAuth/Errors/UnauthorizedRequestErrorBody.swift
+++ b/seed/swift-sdk/basic-auth/src/BasicAuth/Errors/UnauthorizedRequestErrorBody.swift
@@ -1,3 +1,3 @@
-public struct UnauthorizedRequestErrorBody {
+public struct UnauthorizedRequestErrorBody: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/A/A.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/A/A.swift
@@ -1,2 +1,2 @@
-public struct A {
+public struct A: Codable, Hashable {
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Acai.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Acai.swift
@@ -1,2 +1,2 @@
-public struct Acai {
+public struct Acai: Codable, Hashable {
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Berry.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Berry.swift
@@ -1,3 +1,3 @@
-public struct Berry {
+public struct Berry: Codable, Hashable {
     public let animal: Animal
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/BranchNode.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/BranchNode.swift
@@ -1,3 +1,3 @@
-public struct BranchNode {
+public struct BranchNode: Codable, Hashable {
     public let children: [Node]
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Cat.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Cat.swift
@@ -1,3 +1,3 @@
-public struct Cat {
+public struct Cat: Codable, Hashable {
     public let fruit: Fruit
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Dog.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Dog.swift
@@ -1,3 +1,3 @@
-public struct Dog {
+public struct Dog: Codable, Hashable {
     public let fruit: Fruit
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Fig.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/Fig.swift
@@ -1,3 +1,3 @@
-public struct Fig {
+public struct Fig: Codable, Hashable {
     public let animal: Animal
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/LeafNode.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/LeafNode.swift
@@ -1,2 +1,2 @@
-public struct LeafNode {
+public struct LeafNode: Codable, Hashable {
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/NodesWrapper.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/NodesWrapper.swift
@@ -1,3 +1,3 @@
-public struct NodesWrapper {
+public struct NodesWrapper: Codable, Hashable {
     public let nodes: [[Node]]
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/ObjectFieldValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/ObjectFieldValue.swift
@@ -1,4 +1,4 @@
-public struct ObjectFieldValue {
+public struct ObjectFieldValue: Codable, Hashable {
     public let name: FieldName
     public let value: FieldValue
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/Ast/ObjectValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/Ast/ObjectValue.swift
@@ -1,2 +1,2 @@
-public struct ObjectValue {
+public struct ObjectValue: Codable, Hashable {
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/ImportingA.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/ImportingA.swift
@@ -1,3 +1,3 @@
-public struct ImportingA {
+public struct ImportingA: Codable, Hashable {
     public let a: A?
 }

--- a/seed/swift-sdk/circular-references-advanced/src/Api/RootType.swift
+++ b/seed/swift-sdk/circular-references-advanced/src/Api/RootType.swift
@@ -1,3 +1,3 @@
-public struct RootType {
+public struct RootType: Codable, Hashable {
     public let s: String
 }

--- a/seed/swift-sdk/circular-references/src/Api/A/A.swift
+++ b/seed/swift-sdk/circular-references/src/Api/A/A.swift
@@ -1,2 +1,2 @@
-public struct A {
+public struct A: Codable, Hashable {
 }

--- a/seed/swift-sdk/circular-references/src/Api/Ast/ObjectValue.swift
+++ b/seed/swift-sdk/circular-references/src/Api/Ast/ObjectValue.swift
@@ -1,2 +1,2 @@
-public struct ObjectValue {
+public struct ObjectValue: Codable, Hashable {
 }

--- a/seed/swift-sdk/circular-references/src/Api/Ast/T.swift
+++ b/seed/swift-sdk/circular-references/src/Api/Ast/T.swift
@@ -1,3 +1,3 @@
-public struct T {
+public struct T: Codable, Hashable {
     public let child: TorU
 }

--- a/seed/swift-sdk/circular-references/src/Api/Ast/U.swift
+++ b/seed/swift-sdk/circular-references/src/Api/Ast/U.swift
@@ -1,3 +1,3 @@
-public struct U {
+public struct U: Codable, Hashable {
     public let child: T
 }

--- a/seed/swift-sdk/circular-references/src/Api/ImportingA.swift
+++ b/seed/swift-sdk/circular-references/src/Api/ImportingA.swift
@@ -1,3 +1,3 @@
-public struct ImportingA {
+public struct ImportingA: Codable, Hashable {
     public let a: A?
 }

--- a/seed/swift-sdk/circular-references/src/Api/RootType.swift
+++ b/seed/swift-sdk/circular-references/src/Api/RootType.swift
@@ -1,3 +1,3 @@
-public struct RootType {
+public struct RootType: Codable, Hashable {
     public let s: String
 }

--- a/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderA/Service/Response.swift
+++ b/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderA/Service/Response.swift
@@ -1,3 +1,3 @@
-public struct Response {
+public struct Response: Codable, Hashable {
     public let foo: Foo?
 }

--- a/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderB/Common/Foo.swift
+++ b/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderB/Common/Foo.swift
@@ -1,3 +1,3 @@
-public struct Foo {
+public struct Foo: Codable, Hashable {
     public let foo: Foo?
 }

--- a/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderC/Common/Foo.swift
+++ b/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderC/Common/Foo.swift
@@ -1,3 +1,7 @@
-public struct Foo {
+public struct Foo: Codable, Hashable {
     public let barProperty: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case barProperty = "bar_property"
+    }
 }

--- a/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderD/Service/Response.swift
+++ b/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/FolderD/Service/Response.swift
@@ -1,3 +1,3 @@
-public struct Response {
+public struct Response: Codable, Hashable {
     public let foo: Foo?
 }

--- a/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/Foo/ImportingType.swift
+++ b/seed/swift-sdk/cross-package-type-names/src/CrossPackageTypeNames/Foo/ImportingType.swift
@@ -1,3 +1,3 @@
-public struct ImportingType {
+public struct ImportingType: Codable, Hashable {
     public let imported: Imported
 }

--- a/seed/swift-sdk/custom-auth/src/CustomAuth/Errors/UnauthorizedRequestErrorBody.swift
+++ b/seed/swift-sdk/custom-auth/src/CustomAuth/Errors/UnauthorizedRequestErrorBody.swift
@@ -1,3 +1,3 @@
-public struct UnauthorizedRequestErrorBody {
+public struct UnauthorizedRequestErrorBody: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/error-property/src/ErrorProperty/Errors/PropertyBasedErrorTestBody.swift
+++ b/seed/swift-sdk/error-property/src/ErrorProperty/Errors/PropertyBasedErrorTestBody.swift
@@ -1,3 +1,3 @@
-public struct PropertyBasedErrorTestBody {
+public struct PropertyBasedErrorTestBody: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/examples/src/Examples/Commons/Types/Metadata.swift
+++ b/seed/swift-sdk/examples/src/Examples/Commons/Types/Metadata.swift
@@ -1,4 +1,4 @@
-public struct Metadata {
+public struct Metadata: Codable, Hashable {
     public let id: String
     public let data: Any?
     public let jsonString: String?

--- a/seed/swift-sdk/examples/src/Examples/Identifier.swift
+++ b/seed/swift-sdk/examples/src/Examples/Identifier.swift
@@ -1,4 +1,4 @@
-public struct Identifier {
+public struct Identifier: Codable, Hashable {
     public let type: Type
     public let value: String
     public let label: String

--- a/seed/swift-sdk/examples/src/Examples/Types/Actor.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Actor.swift
@@ -1,4 +1,4 @@
-public struct Actor {
+public struct Actor: Codable, Hashable {
     public let name: String
     public let id: String
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/Actress.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Actress.swift
@@ -1,4 +1,4 @@
-public struct Actress {
+public struct Actress: Codable, Hashable {
     public let name: String
     public let id: String
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/BigEntity.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/BigEntity.swift
@@ -1,4 +1,4 @@
-public struct BigEntity {
+public struct BigEntity: Codable, Hashable {
     public let castMember: CastMember?
     public let extendedMovie: ExtendedMovie?
     public let entity: Entity?

--- a/seed/swift-sdk/examples/src/Examples/Types/Directory.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Directory.swift
@@ -1,4 +1,4 @@
-public struct Directory {
+public struct Directory: Codable, Hashable {
     public let name: String
     public let files: [File]?
     public let directories: [Directory]?

--- a/seed/swift-sdk/examples/src/Examples/Types/Entity.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Entity.swift
@@ -1,4 +1,4 @@
-public struct Entity {
+public struct Entity: Codable, Hashable {
     public let type: Type
     public let name: String
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/ExceptionInfo.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/ExceptionInfo.swift
@@ -1,4 +1,4 @@
-public struct ExceptionInfo {
+public struct ExceptionInfo: Codable, Hashable {
     public let exceptionType: String
     public let exceptionMessage: String
     public let exceptionStacktrace: String

--- a/seed/swift-sdk/examples/src/Examples/Types/ExtendedMovie.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/ExtendedMovie.swift
@@ -1,3 +1,3 @@
-public struct ExtendedMovie {
+public struct ExtendedMovie: Codable, Hashable {
     public let cast: [String]
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/File.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/File.swift
@@ -1,4 +1,4 @@
-public struct File {
+public struct File: Codable, Hashable {
     public let name: String
     public let contents: String
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/Migration.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Migration.swift
@@ -1,4 +1,4 @@
-public struct Migration {
+public struct Migration: Codable, Hashable {
     public let name: String
     public let status: MigrationStatus
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/Moment.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Moment.swift
@@ -1,4 +1,4 @@
-public struct Moment {
+public struct Moment: Codable, Hashable {
     public let id: UUID
     public let date: Date
     public let datetime: Date

--- a/seed/swift-sdk/examples/src/Examples/Types/Movie.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Movie.swift
@@ -1,4 +1,4 @@
-public struct Movie {
+public struct Movie: Codable, Hashable {
     public let id: MovieId
     public let prequel: MovieId?
     public let title: String

--- a/seed/swift-sdk/examples/src/Examples/Types/Node.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Node.swift
@@ -1,4 +1,4 @@
-public struct Node {
+public struct Node: Codable, Hashable {
     public let name: String
     public let nodes: [Node]?
     public let trees: [Tree]?

--- a/seed/swift-sdk/examples/src/Examples/Types/Request.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Request.swift
@@ -1,3 +1,3 @@
-public struct Request {
+public struct Request: Codable, Hashable {
     public let request: Any
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/Response.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Response.swift
@@ -1,4 +1,4 @@
-public struct Response {
+public struct Response: Codable, Hashable {
     public let response: Any
     public let identifiers: [Identifier]
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/ResponseType.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/ResponseType.swift
@@ -1,3 +1,3 @@
-public struct ResponseType {
+public struct ResponseType: Codable, Hashable {
     public let type: Type
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/StuntDouble.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/StuntDouble.swift
@@ -1,4 +1,4 @@
-public struct StuntDouble {
+public struct StuntDouble: Codable, Hashable {
     public let name: String
     public let actorOrActressId: String
 }

--- a/seed/swift-sdk/examples/src/Examples/Types/Tree.swift
+++ b/seed/swift-sdk/examples/src/Examples/Types/Tree.swift
@@ -1,3 +1,3 @@
-public struct Tree {
+public struct Tree: Codable, Hashable {
     public let nodes: [Node]?
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Endpoints/Put/Error.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Endpoints/Put/Error.swift
@@ -1,4 +1,4 @@
-public struct Error {
+public struct Error: Codable, Hashable {
     public let category: ErrorCategory
     public let code: ErrorCode
     public let detail: String?

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Endpoints/Put/PutResponse.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Endpoints/Put/PutResponse.swift
@@ -1,3 +1,3 @@
-public struct PutResponse {
+public struct PutResponse: Codable, Hashable {
     public let errors: [Error]?
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/GeneralErrors/BadObjectRequestInfo.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/GeneralErrors/BadObjectRequestInfo.swift
@@ -1,3 +1,3 @@
-public struct BadObjectRequestInfo {
+public struct BadObjectRequestInfo: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/DoubleOptional.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/DoubleOptional.swift
@@ -1,3 +1,3 @@
-public struct DoubleOptional {
+public struct DoubleOptional: Codable, Hashable {
     public let optionalAlias: OptionalAlias?
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/NestedObjectWithOptionalField.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/NestedObjectWithOptionalField.swift
@@ -1,4 +1,9 @@
-public struct NestedObjectWithOptionalField {
+public struct NestedObjectWithOptionalField: Codable, Hashable {
     public let string: String?
     public let nestedObject: ObjectWithOptionalField?
+
+    enum CodingKeys: String, CodingKey {
+        case string
+        case nestedObject = "NestedObject"
+    }
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/NestedObjectWithRequiredField.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/NestedObjectWithRequiredField.swift
@@ -1,4 +1,9 @@
-public struct NestedObjectWithRequiredField {
+public struct NestedObjectWithRequiredField: Codable, Hashable {
     public let string: String
     public let nestedObject: ObjectWithOptionalField
+
+    enum CodingKeys: String, CodingKey {
+        case string
+        case nestedObject = "NestedObject"
+    }
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/ObjectWithMapOfMap.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/ObjectWithMapOfMap.swift
@@ -1,3 +1,3 @@
-public struct ObjectWithMapOfMap {
+public struct ObjectWithMapOfMap: Codable, Hashable {
     public let map: Any
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/ObjectWithOptionalField.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/ObjectWithOptionalField.swift
@@ -1,4 +1,4 @@
-public struct ObjectWithOptionalField {
+public struct ObjectWithOptionalField: Codable, Hashable {
     public let string: String?
     public let integer: Int?
     public let long: Int64?

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/ObjectWithRequiredField.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Object/ObjectWithRequiredField.swift
@@ -1,3 +1,3 @@
-public struct ObjectWithRequiredField {
+public struct ObjectWithRequiredField: Codable, Hashable {
     public let string: String
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Union/Cat.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Union/Cat.swift
@@ -1,4 +1,4 @@
-public struct Cat {
+public struct Cat: Codable, Hashable {
     public let name: String
     public let likesToMeow: Bool
 }

--- a/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Union/Dog.swift
+++ b/seed/swift-sdk/exhaustive/src/Exhaustive/Types/Union/Dog.swift
@@ -1,4 +1,4 @@
-public struct Dog {
+public struct Dog: Codable, Hashable {
     public let name: String
     public let likesToWoof: Bool
 }

--- a/seed/swift-sdk/extends/src/Extends/Docs.swift
+++ b/seed/swift-sdk/extends/src/Extends/Docs.swift
@@ -1,3 +1,3 @@
-public struct Docs {
+public struct Docs: Codable, Hashable {
     public let docs: String
 }

--- a/seed/swift-sdk/extends/src/Extends/ExampleType.swift
+++ b/seed/swift-sdk/extends/src/Extends/ExampleType.swift
@@ -1,3 +1,3 @@
-public struct ExampleType {
+public struct ExampleType: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/extends/src/Extends/Json.swift
+++ b/seed/swift-sdk/extends/src/Extends/Json.swift
@@ -1,3 +1,3 @@
-public struct Json {
+public struct Json: Codable, Hashable {
     public let raw: String
 }

--- a/seed/swift-sdk/extends/src/Extends/NestedType.swift
+++ b/seed/swift-sdk/extends/src/Extends/NestedType.swift
@@ -1,3 +1,3 @@
-public struct NestedType {
+public struct NestedType: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/extra-properties/src/ExtraProperties/Failure.swift
+++ b/seed/swift-sdk/extra-properties/src/ExtraProperties/Failure.swift
@@ -1,3 +1,3 @@
-public struct Failure {
+public struct Failure: Codable, Hashable {
     public let status: Any
 }

--- a/seed/swift-sdk/extra-properties/src/ExtraProperties/User/User.swift
+++ b/seed/swift-sdk/extra-properties/src/ExtraProperties/User/User.swift
@@ -1,3 +1,3 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/file-upload/src/FileUpload/Service/MyObject.swift
+++ b/seed/swift-sdk/file-upload/src/FileUpload/Service/MyObject.swift
@@ -1,3 +1,3 @@
-public struct MyObject {
+public struct MyObject: Codable, Hashable {
     public let foo: String
 }

--- a/seed/swift-sdk/file-upload/src/FileUpload/Service/MyObjectWithOptional.swift
+++ b/seed/swift-sdk/file-upload/src/FileUpload/Service/MyObjectWithOptional.swift
@@ -1,4 +1,4 @@
-public struct MyObjectWithOptional {
+public struct MyObjectWithOptional: Codable, Hashable {
     public let prop: String
     public let optionalProp: String?
 }

--- a/seed/swift-sdk/http-head/src/HttpHead/User/User.swift
+++ b/seed/swift-sdk/http-head/src/HttpHead/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let tags: [String]
 }

--- a/seed/swift-sdk/imdb/src/Api/Imdb/CreateMovieRequest.swift
+++ b/seed/swift-sdk/imdb/src/Api/Imdb/CreateMovieRequest.swift
@@ -1,4 +1,4 @@
-public struct CreateMovieRequest {
+public struct CreateMovieRequest: Codable, Hashable {
     public let title: String
     public let rating: Double
 }

--- a/seed/swift-sdk/imdb/src/Api/Imdb/Movie.swift
+++ b/seed/swift-sdk/imdb/src/Api/Imdb/Movie.swift
@@ -1,4 +1,4 @@
-public struct Movie {
+public struct Movie: Codable, Hashable {
     public let id: MovieId
     public let title: String
     public let rating: Double

--- a/seed/swift-sdk/license/src/License/Type.swift
+++ b/seed/swift-sdk/license/src/License/Type.swift
@@ -1,3 +1,3 @@
-public struct Type {
+public struct Type: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/literal/src/Literal/Inlined/ANestedLiteral.swift
+++ b/seed/swift-sdk/literal/src/Literal/Inlined/ANestedLiteral.swift
@@ -1,3 +1,3 @@
-public struct ANestedLiteral {
+public struct ANestedLiteral: Codable, Hashable {
     public let myLiteral: Any
 }

--- a/seed/swift-sdk/literal/src/Literal/Inlined/ATopLevelLiteral.swift
+++ b/seed/swift-sdk/literal/src/Literal/Inlined/ATopLevelLiteral.swift
@@ -1,3 +1,3 @@
-public struct ATopLevelLiteral {
+public struct ATopLevelLiteral: Codable, Hashable {
     public let nestedLiteral: ANestedLiteral
 }

--- a/seed/swift-sdk/literal/src/Literal/Reference/ContainerObject.swift
+++ b/seed/swift-sdk/literal/src/Literal/Reference/ContainerObject.swift
@@ -1,3 +1,3 @@
-public struct ContainerObject {
+public struct ContainerObject: Codable, Hashable {
     public let nestedObjects: [NestedObjectWithLiterals]
 }

--- a/seed/swift-sdk/literal/src/Literal/Reference/NestedObjectWithLiterals.swift
+++ b/seed/swift-sdk/literal/src/Literal/Reference/NestedObjectWithLiterals.swift
@@ -1,4 +1,4 @@
-public struct NestedObjectWithLiterals {
+public struct NestedObjectWithLiterals: Codable, Hashable {
     public let literal1: Any
     public let literal2: Any
     public let strProp: String

--- a/seed/swift-sdk/literal/src/Literal/Reference/SendRequest.swift
+++ b/seed/swift-sdk/literal/src/Literal/Reference/SendRequest.swift
@@ -1,4 +1,4 @@
-public struct SendRequest {
+public struct SendRequest: Codable, Hashable {
     public let prompt: Any
     public let query: String
     public let stream: Any

--- a/seed/swift-sdk/literal/src/Literal/SendResponse.swift
+++ b/seed/swift-sdk/literal/src/Literal/SendResponse.swift
@@ -1,4 +1,4 @@
-public struct SendResponse {
+public struct SendResponse: Codable, Hashable {
     public let message: String
     public let status: Int
     public let success: Any

--- a/seed/swift-sdk/mixed-case/src/MixedCase/Service/NestedUser.swift
+++ b/seed/swift-sdk/mixed-case/src/MixedCase/Service/NestedUser.swift
@@ -1,4 +1,9 @@
-public struct NestedUser {
+public struct NestedUser: Codable, Hashable {
     public let name: String
     public let nestedUser: User
+
+    enum CodingKeys: String, CodingKey {
+        case name = "Name"
+        case nestedUser = "NestedUser"
+    }
 }

--- a/seed/swift-sdk/mixed-case/src/MixedCase/Service/Organization.swift
+++ b/seed/swift-sdk/mixed-case/src/MixedCase/Service/Organization.swift
@@ -1,3 +1,3 @@
-public struct Organization {
+public struct Organization: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/mixed-case/src/MixedCase/Service/User.swift
+++ b/seed/swift-sdk/mixed-case/src/MixedCase/Service/User.swift
@@ -1,5 +1,11 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let userName: String
     public let metadataTags: [String]
     public let extraProperties: Any
+
+    enum CodingKeys: String, CodingKey {
+        case userName
+        case metadataTags = "metadata_tags"
+        case extraProperties = "EXTRA_PROPERTIES"
+    }
 }

--- a/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/Organization/CreateOrganizationRequest.swift
+++ b/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/Organization/CreateOrganizationRequest.swift
@@ -1,3 +1,3 @@
-public struct CreateOrganizationRequest {
+public struct CreateOrganizationRequest: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/Organization/Organization.swift
+++ b/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/Organization/Organization.swift
@@ -1,4 +1,4 @@
-public struct Organization {
+public struct Organization: Codable, Hashable {
     public let id: Id
     public let name: String
     public let users: [User]

--- a/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/User/Events/Event.swift
+++ b/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/User/Events/Event.swift
@@ -1,4 +1,4 @@
-public struct Event {
+public struct Event: Codable, Hashable {
     public let id: Id
     public let name: String
 }

--- a/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/User/Events/Metadata/Metadata.swift
+++ b/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/User/Events/Metadata/Metadata.swift
@@ -1,4 +1,4 @@
-public struct Metadata {
+public struct Metadata: Codable, Hashable {
     public let id: Id
     public let value: Any
 }

--- a/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/User/User.swift
+++ b/seed/swift-sdk/mixed-file-directory/src/MixedFileDirectory/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: Id
     public let name: String
     public let age: Int

--- a/seed/swift-sdk/multi-line-docs/src/MultiLineDocs/User/User.swift
+++ b/seed/swift-sdk/multi-line-docs/src/MultiLineDocs/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: String
     public let name: String
     public let age: Int?

--- a/seed/swift-sdk/nullable/src/Nullable/Nullable/Metadata.swift
+++ b/seed/swift-sdk/nullable/src/Nullable/Nullable/Metadata.swift
@@ -1,4 +1,4 @@
-public struct Metadata {
+public struct Metadata: Codable, Hashable {
     public let createdAt: Date
     public let updatedAt: Date
     public let avatar: Any

--- a/seed/swift-sdk/nullable/src/Nullable/Nullable/User.swift
+++ b/seed/swift-sdk/nullable/src/Nullable/Nullable/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let id: UserId
     public let tags: Any
@@ -7,4 +7,15 @@ public struct User {
     public let favoriteNumber: WeirdNumber
     public let numbers: Any?
     public let strings: Any?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case id
+        case tags
+        case metadata
+        case email
+        case favoriteNumber = "favorite-number"
+        case numbers
+        case strings
+    }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/src/OauthClientCredentials/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/src/OauthClientCredentials/Auth/TokenResponse.swift
@@ -1,5 +1,11 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
     public let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/src/OauthClientCredentialsDefault/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/src/OauthClientCredentialsDefault/Auth/TokenResponse.swift
@@ -1,4 +1,9 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+    }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/src/OauthClientCredentialsEnvironmentVariables/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/src/OauthClientCredentialsEnvironmentVariables/Auth/TokenResponse.swift
@@ -1,5 +1,11 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
     public let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/src/OauthClientCredentials/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/src/OauthClientCredentials/Auth/TokenResponse.swift
@@ -1,5 +1,11 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
     public let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/src/OauthClientCredentialsWithVariables/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/src/OauthClientCredentialsWithVariables/Auth/TokenResponse.swift
@@ -1,5 +1,11 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
     public let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/seed/swift-sdk/oauth-client-credentials/src/OauthClientCredentials/Auth/TokenResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials/src/OauthClientCredentials/Auth/TokenResponse.swift
@@ -1,5 +1,11 @@
-public struct TokenResponse {
+public struct TokenResponse: Codable, Hashable {
     public let accessToken: String
     public let expiresIn: Int
     public let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/seed/swift-sdk/object/src/Object/Name.swift
+++ b/seed/swift-sdk/object/src/Object/Name.swift
@@ -1,4 +1,4 @@
-public struct Name {
+public struct Name: Codable, Hashable {
     public let id: String
     public let value: String
 }

--- a/seed/swift-sdk/object/src/Object/Type.swift
+++ b/seed/swift-sdk/object/src/Object/Type.swift
@@ -1,4 +1,4 @@
-public struct Type {
+public struct Type: Codable, Hashable {
     public let one: Int
     public let two: Double
     public let three: String

--- a/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/Commons/Metadata/Metadata.swift
+++ b/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/Commons/Metadata/Metadata.swift
@@ -1,4 +1,4 @@
-public struct Metadata {
+public struct Metadata: Codable, Hashable {
     public let id: String
     public let data: Any?
 }

--- a/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/File/Directory/Directory.swift
+++ b/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/File/Directory/Directory.swift
@@ -1,4 +1,4 @@
-public struct Directory {
+public struct Directory: Codable, Hashable {
     public let name: String
     public let files: [File]?
     public let directories: [Directory]?

--- a/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/File/File.swift
+++ b/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/File/File.swift
@@ -1,4 +1,4 @@
-public struct File {
+public struct File: Codable, Hashable {
     public let name: String
     public let contents: String
     public let info: FileInfo

--- a/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/Node.swift
+++ b/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/Node.swift
@@ -1,4 +1,4 @@
-public struct Node {
+public struct Node: Codable, Hashable {
     public let id: String
     public let label: String?
     public let metadata: Metadata?

--- a/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/Tree.swift
+++ b/seed/swift-sdk/objects-with-imports/src/ObjectsWithImports/Tree.swift
@@ -1,3 +1,3 @@
-public struct Tree {
+public struct Tree: Codable, Hashable {
     public let nodes: [Node]?
 }

--- a/seed/swift-sdk/package-yml/src/PackageYml/EchoRequest.swift
+++ b/seed/swift-sdk/package-yml/src/PackageYml/EchoRequest.swift
@@ -1,4 +1,4 @@
-public struct EchoRequest {
+public struct EchoRequest: Codable, Hashable {
     public let name: String
     public let size: Int
 }

--- a/seed/swift-sdk/pagination-custom/src/Pagination/UsernameCursor.swift
+++ b/seed/swift-sdk/pagination-custom/src/Pagination/UsernameCursor.swift
@@ -1,3 +1,3 @@
-public struct UsernameCursor {
+public struct UsernameCursor: Codable, Hashable {
     public let cursor: UsernamePage
 }

--- a/seed/swift-sdk/pagination-custom/src/Pagination/UsernamePage.swift
+++ b/seed/swift-sdk/pagination-custom/src/Pagination/UsernamePage.swift
@@ -1,4 +1,4 @@
-public struct UsernamePage {
+public struct UsernamePage: Codable, Hashable {
     public let after: String?
     public let data: [String]
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/Conversation.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/Conversation.swift
@@ -1,3 +1,3 @@
-public struct Conversation {
+public struct Conversation: Codable, Hashable {
     public let foo: String
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/CursorPages.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/CursorPages.swift
@@ -1,7 +1,15 @@
-public struct CursorPages {
+public struct CursorPages: Codable, Hashable {
     public let next: StartingAfterPaging?
     public let page: Int?
     public let perPage: Int?
     public let totalPages: Int?
     public let type: Any
+
+    enum CodingKeys: String, CodingKey {
+        case next
+        case page
+        case perPage = "per_page"
+        case totalPages = "total_pages"
+        case type
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/MultipleFilterSearchRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/MultipleFilterSearchRequest.swift
@@ -1,4 +1,4 @@
-public struct MultipleFilterSearchRequest {
+public struct MultipleFilterSearchRequest: Codable, Hashable {
     public let `operator`: MultipleFilterSearchRequestOperator?
     public let value: MultipleFilterSearchRequestValue?
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/PaginatedConversationResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/PaginatedConversationResponse.swift
@@ -1,6 +1,13 @@
-public struct PaginatedConversationResponse {
+public struct PaginatedConversationResponse: Codable, Hashable {
     public let conversations: [Conversation]
     public let pages: CursorPages?
     public let totalCount: Int
     public let type: Any
+
+    enum CodingKeys: String, CodingKey {
+        case conversations
+        case pages
+        case totalCount = "total_count"
+        case type
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/SearchRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/SearchRequest.swift
@@ -1,4 +1,4 @@
-public struct SearchRequest {
+public struct SearchRequest: Codable, Hashable {
     public let pagination: StartingAfterPaging?
     public let query: SearchRequestQuery
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/SingleFilterSearchRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/SingleFilterSearchRequest.swift
@@ -1,4 +1,4 @@
-public struct SingleFilterSearchRequest {
+public struct SingleFilterSearchRequest: Codable, Hashable {
     public let field: String?
     public let `operator`: SingleFilterSearchRequestOperator?
     public let value: String?

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/StartingAfterPaging.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Complex/StartingAfterPaging.swift
@@ -1,4 +1,9 @@
-public struct StartingAfterPaging {
+public struct StartingAfterPaging: Codable, Hashable {
     public let perPage: Int
     public let startingAfter: String?
+
+    enum CodingKeys: String, CodingKey {
+        case perPage = "per_page"
+        case startingAfter = "starting_after"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/UsernameCursor.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/UsernameCursor.swift
@@ -1,3 +1,3 @@
-public struct UsernameCursor {
+public struct UsernameCursor: Codable, Hashable {
     public let cursor: UsernamePage
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/UsernamePage.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/UsernamePage.swift
@@ -1,4 +1,4 @@
-public struct UsernamePage {
+public struct UsernamePage: Codable, Hashable {
     public let after: String?
     public let data: [String]
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersExtendedOptionalListResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersExtendedOptionalListResponse.swift
@@ -1,3 +1,7 @@
-public struct ListUsersExtendedOptionalListResponse {
+public struct ListUsersExtendedOptionalListResponse: Codable, Hashable {
     public let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersExtendedResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersExtendedResponse.swift
@@ -1,3 +1,7 @@
-public struct ListUsersExtendedResponse {
+public struct ListUsersExtendedResponse: Codable, Hashable {
     public let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersMixedTypePaginationResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersMixedTypePaginationResponse.swift
@@ -1,4 +1,4 @@
-public struct ListUsersMixedTypePaginationResponse {
+public struct ListUsersMixedTypePaginationResponse: Codable, Hashable {
     public let next: String
     public let data: [User]
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersPaginationResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/ListUsersPaginationResponse.swift
@@ -1,6 +1,13 @@
-public struct ListUsersPaginationResponse {
+public struct ListUsersPaginationResponse: Codable, Hashable {
     public let hasNextPage: Bool?
     public let page: Page?
     public let totalCount: Int
     public let data: [User]
+
+    enum CodingKeys: String, CodingKey {
+        case hasNextPage
+        case page
+        case totalCount = "total_count"
+        case data
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/NextPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/NextPage.swift
@@ -1,4 +1,9 @@
-public struct NextPage {
+public struct NextPage: Codable, Hashable {
     public let page: Int
     public let startingAfter: String
+
+    enum CodingKeys: String, CodingKey {
+        case page
+        case startingAfter = "starting_after"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/Page.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/Page.swift
@@ -1,6 +1,13 @@
-public struct Page {
+public struct Page: Codable, Hashable {
     public let page: Int
     public let next: NextPage?
     public let perPage: Int
     public let totalPage: Int
+
+    enum CodingKeys: String, CodingKey {
+        case page
+        case next
+        case perPage = "per_page"
+        case totalPage = "total_page"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/User.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let id: Int
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserListContainer.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserListContainer.swift
@@ -1,3 +1,3 @@
-public struct UserListContainer {
+public struct UserListContainer: Codable, Hashable {
     public let users: [User]
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserOptionalListContainer.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserOptionalListContainer.swift
@@ -1,3 +1,3 @@
-public struct UserOptionalListContainer {
+public struct UserOptionalListContainer: Codable, Hashable {
     public let users: [User]?
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserOptionalListPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserOptionalListPage.swift
@@ -1,4 +1,4 @@
-public struct UserOptionalListPage {
+public struct UserOptionalListPage: Codable, Hashable {
     public let data: UserOptionalListContainer
     public let next: UUID?
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UserPage.swift
@@ -1,4 +1,4 @@
-public struct UserPage {
+public struct UserPage: Codable, Hashable {
     public let data: UserListContainer
     public let next: UUID?
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UsernameContainer.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/UsernameContainer.swift
@@ -1,3 +1,3 @@
-public struct UsernameContainer {
+public struct UsernameContainer: Codable, Hashable {
     public let results: [String]
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/WithCursor.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/WithCursor.swift
@@ -1,3 +1,3 @@
-public struct WithCursor {
+public struct WithCursor: Codable, Hashable {
     public let cursor: String?
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/WithPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/src/Pagination/Users/WithPage.swift
@@ -1,3 +1,3 @@
-public struct WithPage {
+public struct WithPage: Codable, Hashable {
     public let page: Int?
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/Conversation.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/Conversation.swift
@@ -1,3 +1,3 @@
-public struct Conversation {
+public struct Conversation: Codable, Hashable {
     public let foo: String
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/CursorPages.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/CursorPages.swift
@@ -1,7 +1,15 @@
-public struct CursorPages {
+public struct CursorPages: Codable, Hashable {
     public let next: StartingAfterPaging?
     public let page: Int?
     public let perPage: Int?
     public let totalPages: Int?
     public let type: Any
+
+    enum CodingKeys: String, CodingKey {
+        case next
+        case page
+        case perPage = "per_page"
+        case totalPages = "total_pages"
+        case type
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/MultipleFilterSearchRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/MultipleFilterSearchRequest.swift
@@ -1,4 +1,4 @@
-public struct MultipleFilterSearchRequest {
+public struct MultipleFilterSearchRequest: Codable, Hashable {
     public let `operator`: MultipleFilterSearchRequestOperator?
     public let value: MultipleFilterSearchRequestValue?
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/PaginatedConversationResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/PaginatedConversationResponse.swift
@@ -1,6 +1,13 @@
-public struct PaginatedConversationResponse {
+public struct PaginatedConversationResponse: Codable, Hashable {
     public let conversations: [Conversation]
     public let pages: CursorPages?
     public let totalCount: Int
     public let type: Any
+
+    enum CodingKeys: String, CodingKey {
+        case conversations
+        case pages
+        case totalCount = "total_count"
+        case type
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/SearchRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/SearchRequest.swift
@@ -1,4 +1,4 @@
-public struct SearchRequest {
+public struct SearchRequest: Codable, Hashable {
     public let pagination: StartingAfterPaging?
     public let query: SearchRequestQuery
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/SingleFilterSearchRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/SingleFilterSearchRequest.swift
@@ -1,4 +1,4 @@
-public struct SingleFilterSearchRequest {
+public struct SingleFilterSearchRequest: Codable, Hashable {
     public let field: String?
     public let `operator`: SingleFilterSearchRequestOperator?
     public let value: String?

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/StartingAfterPaging.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Complex/StartingAfterPaging.swift
@@ -1,4 +1,9 @@
-public struct StartingAfterPaging {
+public struct StartingAfterPaging: Codable, Hashable {
     public let perPage: Int
     public let startingAfter: String?
+
+    enum CodingKeys: String, CodingKey {
+        case perPage = "per_page"
+        case startingAfter = "starting_after"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/UsernameCursor.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/UsernameCursor.swift
@@ -1,3 +1,3 @@
-public struct UsernameCursor {
+public struct UsernameCursor: Codable, Hashable {
     public let cursor: UsernamePage
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/UsernamePage.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/UsernamePage.swift
@@ -1,4 +1,4 @@
-public struct UsernamePage {
+public struct UsernamePage: Codable, Hashable {
     public let after: String?
     public let data: [String]
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersExtendedOptionalListResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersExtendedOptionalListResponse.swift
@@ -1,3 +1,7 @@
-public struct ListUsersExtendedOptionalListResponse {
+public struct ListUsersExtendedOptionalListResponse: Codable, Hashable {
     public let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersExtendedResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersExtendedResponse.swift
@@ -1,3 +1,7 @@
-public struct ListUsersExtendedResponse {
+public struct ListUsersExtendedResponse: Codable, Hashable {
     public let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersMixedTypePaginationResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersMixedTypePaginationResponse.swift
@@ -1,4 +1,4 @@
-public struct ListUsersMixedTypePaginationResponse {
+public struct ListUsersMixedTypePaginationResponse: Codable, Hashable {
     public let next: String
     public let data: [User]
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersPaginationResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/ListUsersPaginationResponse.swift
@@ -1,6 +1,13 @@
-public struct ListUsersPaginationResponse {
+public struct ListUsersPaginationResponse: Codable, Hashable {
     public let hasNextPage: Bool?
     public let page: Page?
     public let totalCount: Int
     public let data: [User]
+
+    enum CodingKeys: String, CodingKey {
+        case hasNextPage
+        case page
+        case totalCount = "total_count"
+        case data
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/NextPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/NextPage.swift
@@ -1,4 +1,9 @@
-public struct NextPage {
+public struct NextPage: Codable, Hashable {
     public let page: Int
     public let startingAfter: String
+
+    enum CodingKeys: String, CodingKey {
+        case page
+        case startingAfter = "starting_after"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/Page.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/Page.swift
@@ -1,6 +1,13 @@
-public struct Page {
+public struct Page: Codable, Hashable {
     public let page: Int
     public let next: NextPage?
     public let perPage: Int
     public let totalPage: Int
+
+    enum CodingKeys: String, CodingKey {
+        case page
+        case next
+        case perPage = "per_page"
+        case totalPage = "total_page"
+    }
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/User.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let id: Int
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserListContainer.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserListContainer.swift
@@ -1,3 +1,3 @@
-public struct UserListContainer {
+public struct UserListContainer: Codable, Hashable {
     public let users: [User]
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserOptionalListContainer.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserOptionalListContainer.swift
@@ -1,3 +1,3 @@
-public struct UserOptionalListContainer {
+public struct UserOptionalListContainer: Codable, Hashable {
     public let users: [User]?
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserOptionalListPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserOptionalListPage.swift
@@ -1,4 +1,4 @@
-public struct UserOptionalListPage {
+public struct UserOptionalListPage: Codable, Hashable {
     public let data: UserOptionalListContainer
     public let next: UUID?
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UserPage.swift
@@ -1,4 +1,4 @@
-public struct UserPage {
+public struct UserPage: Codable, Hashable {
     public let data: UserListContainer
     public let next: UUID?
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UsernameContainer.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/UsernameContainer.swift
@@ -1,3 +1,3 @@
-public struct UsernameContainer {
+public struct UsernameContainer: Codable, Hashable {
     public let results: [String]
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/WithCursor.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/WithCursor.swift
@@ -1,3 +1,3 @@
-public struct WithCursor {
+public struct WithCursor: Codable, Hashable {
     public let cursor: String?
 }

--- a/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/WithPage.swift
+++ b/seed/swift-sdk/pagination/custom-pager/src/Pagination/Users/WithPage.swift
@@ -1,3 +1,3 @@
-public struct WithPage {
+public struct WithPage: Codable, Hashable {
     public let page: Int?
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/Conversation.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/Conversation.swift
@@ -1,3 +1,3 @@
-public struct Conversation {
+public struct Conversation: Codable, Hashable {
     public let foo: String
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/CursorPages.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/CursorPages.swift
@@ -1,7 +1,15 @@
-public struct CursorPages {
+public struct CursorPages: Codable, Hashable {
     public let next: StartingAfterPaging?
     public let page: Int?
     public let perPage: Int?
     public let totalPages: Int?
     public let type: Any
+
+    enum CodingKeys: String, CodingKey {
+        case next
+        case page
+        case perPage = "per_page"
+        case totalPages = "total_pages"
+        case type
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/MultipleFilterSearchRequest.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/MultipleFilterSearchRequest.swift
@@ -1,4 +1,4 @@
-public struct MultipleFilterSearchRequest {
+public struct MultipleFilterSearchRequest: Codable, Hashable {
     public let `operator`: MultipleFilterSearchRequestOperator?
     public let value: MultipleFilterSearchRequestValue?
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/PaginatedConversationResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/PaginatedConversationResponse.swift
@@ -1,6 +1,13 @@
-public struct PaginatedConversationResponse {
+public struct PaginatedConversationResponse: Codable, Hashable {
     public let conversations: [Conversation]
     public let pages: CursorPages?
     public let totalCount: Int
     public let type: Any
+
+    enum CodingKeys: String, CodingKey {
+        case conversations
+        case pages
+        case totalCount = "total_count"
+        case type
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/SearchRequest.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/SearchRequest.swift
@@ -1,4 +1,4 @@
-public struct SearchRequest {
+public struct SearchRequest: Codable, Hashable {
     public let pagination: StartingAfterPaging?
     public let query: SearchRequestQuery
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/SingleFilterSearchRequest.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/SingleFilterSearchRequest.swift
@@ -1,4 +1,4 @@
-public struct SingleFilterSearchRequest {
+public struct SingleFilterSearchRequest: Codable, Hashable {
     public let field: String?
     public let `operator`: SingleFilterSearchRequestOperator?
     public let value: String?

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/StartingAfterPaging.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Complex/StartingAfterPaging.swift
@@ -1,4 +1,9 @@
-public struct StartingAfterPaging {
+public struct StartingAfterPaging: Codable, Hashable {
     public let perPage: Int
     public let startingAfter: String?
+
+    enum CodingKeys: String, CodingKey {
+        case perPage = "per_page"
+        case startingAfter = "starting_after"
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/UsernameCursor.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/UsernameCursor.swift
@@ -1,3 +1,3 @@
-public struct UsernameCursor {
+public struct UsernameCursor: Codable, Hashable {
     public let cursor: UsernamePage
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/UsernamePage.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/UsernamePage.swift
@@ -1,4 +1,4 @@
-public struct UsernamePage {
+public struct UsernamePage: Codable, Hashable {
     public let after: String?
     public let data: [String]
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersExtendedOptionalListResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersExtendedOptionalListResponse.swift
@@ -1,3 +1,7 @@
-public struct ListUsersExtendedOptionalListResponse {
+public struct ListUsersExtendedOptionalListResponse: Codable, Hashable {
     public let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersExtendedResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersExtendedResponse.swift
@@ -1,3 +1,7 @@
-public struct ListUsersExtendedResponse {
+public struct ListUsersExtendedResponse: Codable, Hashable {
     public let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersMixedTypePaginationResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersMixedTypePaginationResponse.swift
@@ -1,4 +1,4 @@
-public struct ListUsersMixedTypePaginationResponse {
+public struct ListUsersMixedTypePaginationResponse: Codable, Hashable {
     public let next: String
     public let data: [User]
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersPaginationResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/ListUsersPaginationResponse.swift
@@ -1,6 +1,13 @@
-public struct ListUsersPaginationResponse {
+public struct ListUsersPaginationResponse: Codable, Hashable {
     public let hasNextPage: Bool?
     public let page: Page?
     public let totalCount: Int
     public let data: [User]
+
+    enum CodingKeys: String, CodingKey {
+        case hasNextPage
+        case page
+        case totalCount = "total_count"
+        case data
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/NextPage.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/NextPage.swift
@@ -1,4 +1,9 @@
-public struct NextPage {
+public struct NextPage: Codable, Hashable {
     public let page: Int
     public let startingAfter: String
+
+    enum CodingKeys: String, CodingKey {
+        case page
+        case startingAfter = "starting_after"
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/Page.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/Page.swift
@@ -1,6 +1,13 @@
-public struct Page {
+public struct Page: Codable, Hashable {
     public let page: Int
     public let next: NextPage?
     public let perPage: Int
     public let totalPage: Int
+
+    enum CodingKeys: String, CodingKey {
+        case page
+        case next
+        case perPage = "per_page"
+        case totalPage = "total_page"
+    }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/User.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let id: Int
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserListContainer.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserListContainer.swift
@@ -1,3 +1,3 @@
-public struct UserListContainer {
+public struct UserListContainer: Codable, Hashable {
     public let users: [User]
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserOptionalListContainer.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserOptionalListContainer.swift
@@ -1,3 +1,3 @@
-public struct UserOptionalListContainer {
+public struct UserOptionalListContainer: Codable, Hashable {
     public let users: [User]?
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserOptionalListPage.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserOptionalListPage.swift
@@ -1,4 +1,4 @@
-public struct UserOptionalListPage {
+public struct UserOptionalListPage: Codable, Hashable {
     public let data: UserOptionalListContainer
     public let next: UUID?
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserPage.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UserPage.swift
@@ -1,4 +1,4 @@
-public struct UserPage {
+public struct UserPage: Codable, Hashable {
     public let data: UserListContainer
     public let next: UUID?
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UsernameContainer.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/UsernameContainer.swift
@@ -1,3 +1,3 @@
-public struct UsernameContainer {
+public struct UsernameContainer: Codable, Hashable {
     public let results: [String]
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/WithCursor.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/WithCursor.swift
@@ -1,3 +1,3 @@
-public struct WithCursor {
+public struct WithCursor: Codable, Hashable {
     public let cursor: String?
 }

--- a/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/WithPage.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/src/Pagination/Users/WithPage.swift
@@ -1,3 +1,3 @@
-public struct WithPage {
+public struct WithPage: Codable, Hashable {
     public let page: Int?
 }

--- a/seed/swift-sdk/path-parameters/src/PathParameters/Organizations/Organization.swift
+++ b/seed/swift-sdk/path-parameters/src/PathParameters/Organizations/Organization.swift
@@ -1,4 +1,4 @@
-public struct Organization {
+public struct Organization: Codable, Hashable {
     public let name: String
     public let tags: [String]
 }

--- a/seed/swift-sdk/path-parameters/src/PathParameters/User/User.swift
+++ b/seed/swift-sdk/path-parameters/src/PathParameters/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let tags: [String]
 }

--- a/seed/swift-sdk/query-parameters/src/QueryParameters/User/NestedUser.swift
+++ b/seed/swift-sdk/query-parameters/src/QueryParameters/User/NestedUser.swift
@@ -1,4 +1,4 @@
-public struct NestedUser {
+public struct NestedUser: Codable, Hashable {
     public let name: String
     public let user: User
 }

--- a/seed/swift-sdk/query-parameters/src/QueryParameters/User/User.swift
+++ b/seed/swift-sdk/query-parameters/src/QueryParameters/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let tags: [String]
 }

--- a/seed/swift-sdk/request-parameters/src/RequestParameters/User/NestedUser.swift
+++ b/seed/swift-sdk/request-parameters/src/RequestParameters/User/NestedUser.swift
@@ -1,4 +1,4 @@
-public struct NestedUser {
+public struct NestedUser: Codable, Hashable {
     public let name: String
     public let user: User
 }

--- a/seed/swift-sdk/request-parameters/src/RequestParameters/User/User.swift
+++ b/seed/swift-sdk/request-parameters/src/RequestParameters/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let name: String
     public let tags: [String]
 }

--- a/seed/swift-sdk/reserved-keywords/src/NurseryApi/Package/Package.swift
+++ b/seed/swift-sdk/reserved-keywords/src/NurseryApi/Package/Package.swift
@@ -1,3 +1,3 @@
-public struct Package {
+public struct Package: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/reserved-keywords/src/NurseryApi/Package/Record.swift
+++ b/seed/swift-sdk/reserved-keywords/src/NurseryApi/Package/Record.swift
@@ -1,4 +1,9 @@
-public struct Record {
+public struct Record: Codable, Hashable {
     public let foo: Any
     public let 3D: Int
+
+    enum CodingKeys: String, CodingKey {
+        case foo
+        case 3D = "3d"
+    }
 }

--- a/seed/swift-sdk/response-property/src/ResponseProperty/Service/Movie.swift
+++ b/seed/swift-sdk/response-property/src/ResponseProperty/Service/Movie.swift
@@ -1,4 +1,4 @@
-public struct Movie {
+public struct Movie: Codable, Hashable {
     public let id: String
     public let name: String
 }

--- a/seed/swift-sdk/response-property/src/ResponseProperty/Service/Response.swift
+++ b/seed/swift-sdk/response-property/src/ResponseProperty/Service/Response.swift
@@ -1,3 +1,3 @@
-public struct Response {
+public struct Response: Codable, Hashable {
     public let data: Movie
 }

--- a/seed/swift-sdk/response-property/src/ResponseProperty/Service/WithDocs.swift
+++ b/seed/swift-sdk/response-property/src/ResponseProperty/Service/WithDocs.swift
@@ -1,3 +1,3 @@
-public struct WithDocs {
+public struct WithDocs: Codable, Hashable {
     public let docs: String
 }

--- a/seed/swift-sdk/response-property/src/ResponseProperty/StringResponse.swift
+++ b/seed/swift-sdk/response-property/src/ResponseProperty/StringResponse.swift
@@ -1,3 +1,3 @@
-public struct StringResponse {
+public struct StringResponse: Codable, Hashable {
     public let data: String
 }

--- a/seed/swift-sdk/response-property/src/ResponseProperty/WithMetadata.swift
+++ b/seed/swift-sdk/response-property/src/ResponseProperty/WithMetadata.swift
@@ -1,3 +1,3 @@
-public struct WithMetadata {
+public struct WithMetadata: Codable, Hashable {
     public let metadata: Any
 }

--- a/seed/swift-sdk/server-sent-event-examples/src/ServerSentEvents/Completions/StreamedCompletion.swift
+++ b/seed/swift-sdk/server-sent-event-examples/src/ServerSentEvents/Completions/StreamedCompletion.swift
@@ -1,4 +1,4 @@
-public struct StreamedCompletion {
+public struct StreamedCompletion: Codable, Hashable {
     public let delta: String
     public let tokens: Int?
 }

--- a/seed/swift-sdk/server-sent-events/src/ServerSentEvents/Completions/StreamedCompletion.swift
+++ b/seed/swift-sdk/server-sent-events/src/ServerSentEvents/Completions/StreamedCompletion.swift
@@ -1,4 +1,4 @@
-public struct StreamedCompletion {
+public struct StreamedCompletion: Codable, Hashable {
     public let delta: String
     public let tokens: Int?
 }

--- a/seed/swift-sdk/simple-fhir/src/Api/Account.swift
+++ b/seed/swift-sdk/simple-fhir/src/Api/Account.swift
@@ -1,6 +1,13 @@
-public struct Account {
+public struct Account: Codable, Hashable {
     public let resourceType: Any
     public let name: String
     public let patient: Patient?
     public let practitioner: Practitioner?
+
+    enum CodingKeys: String, CodingKey {
+        case resourceType = "resource_type"
+        case name
+        case patient
+        case practitioner
+    }
 }

--- a/seed/swift-sdk/simple-fhir/src/Api/BaseResource.swift
+++ b/seed/swift-sdk/simple-fhir/src/Api/BaseResource.swift
@@ -1,5 +1,11 @@
-public struct BaseResource {
+public struct BaseResource: Codable, Hashable {
     public let id: String
     public let relatedResources: [ResourceList]
     public let memo: Memo
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case relatedResources = "related_resources"
+        case memo
+    }
 }

--- a/seed/swift-sdk/simple-fhir/src/Api/Memo.swift
+++ b/seed/swift-sdk/simple-fhir/src/Api/Memo.swift
@@ -1,4 +1,4 @@
-public struct Memo {
+public struct Memo: Codable, Hashable {
     public let description: String
     public let account: Account?
 }

--- a/seed/swift-sdk/simple-fhir/src/Api/Patient.swift
+++ b/seed/swift-sdk/simple-fhir/src/Api/Patient.swift
@@ -1,5 +1,11 @@
-public struct Patient {
+public struct Patient: Codable, Hashable {
     public let resourceType: Any
     public let name: String
     public let scripts: [Script]
+
+    enum CodingKeys: String, CodingKey {
+        case resourceType = "resource_type"
+        case name
+        case scripts
+    }
 }

--- a/seed/swift-sdk/simple-fhir/src/Api/Practitioner.swift
+++ b/seed/swift-sdk/simple-fhir/src/Api/Practitioner.swift
@@ -1,4 +1,9 @@
-public struct Practitioner {
+public struct Practitioner: Codable, Hashable {
     public let resourceType: Any
     public let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case resourceType = "resource_type"
+        case name
+    }
 }

--- a/seed/swift-sdk/simple-fhir/src/Api/Script.swift
+++ b/seed/swift-sdk/simple-fhir/src/Api/Script.swift
@@ -1,4 +1,9 @@
-public struct Script {
+public struct Script: Codable, Hashable {
     public let resourceType: Any
     public let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case resourceType = "resource_type"
+        case name
+    }
 }

--- a/seed/swift-sdk/streaming-parameter/src/Streaming/Dummy/RegularResponse.swift
+++ b/seed/swift-sdk/streaming-parameter/src/Streaming/Dummy/RegularResponse.swift
@@ -1,4 +1,4 @@
-public struct RegularResponse {
+public struct RegularResponse: Codable, Hashable {
     public let id: String
     public let name: String?
 }

--- a/seed/swift-sdk/streaming-parameter/src/Streaming/Dummy/StreamResponse.swift
+++ b/seed/swift-sdk/streaming-parameter/src/Streaming/Dummy/StreamResponse.swift
@@ -1,4 +1,4 @@
-public struct StreamResponse {
+public struct StreamResponse: Codable, Hashable {
     public let id: String
     public let name: String?
 }

--- a/seed/swift-sdk/streaming/src/Streaming/Dummy/StreamResponse.swift
+++ b/seed/swift-sdk/streaming/src/Streaming/Dummy/StreamResponse.swift
@@ -1,4 +1,4 @@
-public struct StreamResponse {
+public struct StreamResponse: Codable, Hashable {
     public let id: String
     public let name: String?
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/BinaryTreeNodeAndTreeValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/BinaryTreeNodeAndTreeValue.swift
@@ -1,4 +1,4 @@
-public struct BinaryTreeNodeAndTreeValue {
+public struct BinaryTreeNodeAndTreeValue: Codable, Hashable {
     public let nodeId: NodeId
     public let fullTree: BinaryTreeValue
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/BinaryTreeNodeValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/BinaryTreeNodeValue.swift
@@ -1,4 +1,4 @@
-public struct BinaryTreeNodeValue {
+public struct BinaryTreeNodeValue: Codable, Hashable {
     public let nodeId: NodeId
     public let val: Double
     public let right: NodeId?

--- a/seed/swift-sdk/trace/src/Trace/Commons/BinaryTreeValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/BinaryTreeValue.swift
@@ -1,4 +1,4 @@
-public struct BinaryTreeValue {
+public struct BinaryTreeValue: Codable, Hashable {
     public let root: NodeId?
     public let nodes: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/DebugKeyValuePairs.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/DebugKeyValuePairs.swift
@@ -1,4 +1,4 @@
-public struct DebugKeyValuePairs {
+public struct DebugKeyValuePairs: Codable, Hashable {
     public let key: DebugVariableValue
     public let value: DebugVariableValue
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/DebugMapValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/DebugMapValue.swift
@@ -1,3 +1,3 @@
-public struct DebugMapValue {
+public struct DebugMapValue: Codable, Hashable {
     public let keyValuePairs: [DebugKeyValuePairs]
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/DoublyLinkedListNodeAndListValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/DoublyLinkedListNodeAndListValue.swift
@@ -1,4 +1,4 @@
-public struct DoublyLinkedListNodeAndListValue {
+public struct DoublyLinkedListNodeAndListValue: Codable, Hashable {
     public let nodeId: NodeId
     public let fullList: DoublyLinkedListValue
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/DoublyLinkedListNodeValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/DoublyLinkedListNodeValue.swift
@@ -1,4 +1,4 @@
-public struct DoublyLinkedListNodeValue {
+public struct DoublyLinkedListNodeValue: Codable, Hashable {
     public let nodeId: NodeId
     public let val: Double
     public let next: NodeId?

--- a/seed/swift-sdk/trace/src/Trace/Commons/DoublyLinkedListValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/DoublyLinkedListValue.swift
@@ -1,4 +1,4 @@
-public struct DoublyLinkedListValue {
+public struct DoublyLinkedListValue: Codable, Hashable {
     public let head: NodeId?
     public let nodes: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/FileInfo.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/FileInfo.swift
@@ -1,4 +1,4 @@
-public struct FileInfo {
+public struct FileInfo: Codable, Hashable {
     public let filename: String
     public let contents: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/GenericValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/GenericValue.swift
@@ -1,4 +1,4 @@
-public struct GenericValue {
+public struct GenericValue: Codable, Hashable {
     public let stringifiedType: String?
     public let stringifiedValue: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/KeyValuePair.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/KeyValuePair.swift
@@ -1,4 +1,4 @@
-public struct KeyValuePair {
+public struct KeyValuePair: Codable, Hashable {
     public let key: VariableValue
     public let value: VariableValue
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/ListType.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/ListType.swift
@@ -1,4 +1,4 @@
-public struct ListType {
+public struct ListType: Codable, Hashable {
     public let valueType: VariableType
     public let isFixedLength: Bool?
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/MapType.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/MapType.swift
@@ -1,4 +1,4 @@
-public struct MapType {
+public struct MapType: Codable, Hashable {
     public let keyType: VariableType
     public let valueType: VariableType
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/MapValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/MapValue.swift
@@ -1,3 +1,3 @@
-public struct MapValue {
+public struct MapValue: Codable, Hashable {
     public let keyValuePairs: [KeyValuePair]
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/SinglyLinkedListNodeAndListValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/SinglyLinkedListNodeAndListValue.swift
@@ -1,4 +1,4 @@
-public struct SinglyLinkedListNodeAndListValue {
+public struct SinglyLinkedListNodeAndListValue: Codable, Hashable {
     public let nodeId: NodeId
     public let fullList: SinglyLinkedListValue
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/SinglyLinkedListNodeValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/SinglyLinkedListNodeValue.swift
@@ -1,4 +1,4 @@
-public struct SinglyLinkedListNodeValue {
+public struct SinglyLinkedListNodeValue: Codable, Hashable {
     public let nodeId: NodeId
     public let val: Double
     public let next: NodeId?

--- a/seed/swift-sdk/trace/src/Trace/Commons/SinglyLinkedListValue.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/SinglyLinkedListValue.swift
@@ -1,4 +1,4 @@
-public struct SinglyLinkedListValue {
+public struct SinglyLinkedListValue: Codable, Hashable {
     public let head: NodeId?
     public let nodes: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/TestCase.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/TestCase.swift
@@ -1,4 +1,4 @@
-public struct TestCase {
+public struct TestCase: Codable, Hashable {
     public let id: String
     public let params: [VariableValue]
 }

--- a/seed/swift-sdk/trace/src/Trace/Commons/TestCaseWithExpectedResult.swift
+++ b/seed/swift-sdk/trace/src/Trace/Commons/TestCaseWithExpectedResult.swift
@@ -1,4 +1,4 @@
-public struct TestCaseWithExpectedResult {
+public struct TestCaseWithExpectedResult: Codable, Hashable {
     public let testCase: TestCase
     public let expectedResult: VariableValue
 }

--- a/seed/swift-sdk/trace/src/Trace/LangServer/LangServerRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/LangServer/LangServerRequest.swift
@@ -1,3 +1,3 @@
-public struct LangServerRequest {
+public struct LangServerRequest: Codable, Hashable {
     public let request: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/LangServer/LangServerResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/LangServer/LangServerResponse.swift
@@ -1,3 +1,3 @@
-public struct LangServerResponse {
+public struct LangServerResponse: Codable, Hashable {
     public let response: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Migration/Migration.swift
+++ b/seed/swift-sdk/trace/src/Trace/Migration/Migration.swift
@@ -1,4 +1,4 @@
-public struct Migration {
+public struct Migration: Codable, Hashable {
     public let name: String
     public let status: MigrationStatus
 }

--- a/seed/swift-sdk/trace/src/Trace/Playlist/Playlist.swift
+++ b/seed/swift-sdk/trace/src/Trace/Playlist/Playlist.swift
@@ -1,4 +1,9 @@
-public struct Playlist {
+public struct Playlist: Codable, Hashable {
     public let playlistId: PlaylistId
     public let ownerId: UserId
+
+    enum CodingKeys: String, CodingKey {
+        case playlistId = "playlist_id"
+        case ownerId = "owner-id"
+    }
 }

--- a/seed/swift-sdk/trace/src/Trace/Playlist/PlaylistCreateRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Playlist/PlaylistCreateRequest.swift
@@ -1,4 +1,4 @@
-public struct PlaylistCreateRequest {
+public struct PlaylistCreateRequest: Codable, Hashable {
     public let name: String
     public let problems: [ProblemId]
 }

--- a/seed/swift-sdk/trace/src/Trace/Playlist/UpdatePlaylistRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Playlist/UpdatePlaylistRequest.swift
@@ -1,4 +1,4 @@
-public struct UpdatePlaylistRequest {
+public struct UpdatePlaylistRequest: Codable, Hashable {
     public let name: String
     public let problems: [ProblemId]
 }

--- a/seed/swift-sdk/trace/src/Trace/Problem/CreateProblemRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/CreateProblemRequest.swift
@@ -1,4 +1,4 @@
-public struct CreateProblemRequest {
+public struct CreateProblemRequest: Codable, Hashable {
     public let problemName: String
     public let problemDescription: ProblemDescription
     public let files: Any

--- a/seed/swift-sdk/trace/src/Trace/Problem/GenericCreateProblemError.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/GenericCreateProblemError.swift
@@ -1,4 +1,4 @@
-public struct GenericCreateProblemError {
+public struct GenericCreateProblemError: Codable, Hashable {
     public let message: String
     public let type: String
     public let stacktrace: String

--- a/seed/swift-sdk/trace/src/Trace/Problem/GetDefaultStarterFilesResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/GetDefaultStarterFilesResponse.swift
@@ -1,3 +1,3 @@
-public struct GetDefaultStarterFilesResponse {
+public struct GetDefaultStarterFilesResponse: Codable, Hashable {
     public let files: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Problem/ProblemDescription.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/ProblemDescription.swift
@@ -1,3 +1,3 @@
-public struct ProblemDescription {
+public struct ProblemDescription: Codable, Hashable {
     public let boards: [ProblemDescriptionBoard]
 }

--- a/seed/swift-sdk/trace/src/Trace/Problem/ProblemFiles.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/ProblemFiles.swift
@@ -1,4 +1,4 @@
-public struct ProblemFiles {
+public struct ProblemFiles: Codable, Hashable {
     public let solutionFile: FileInfo
     public let readOnlyFiles: [FileInfo]
 }

--- a/seed/swift-sdk/trace/src/Trace/Problem/ProblemInfo.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/ProblemInfo.swift
@@ -1,4 +1,4 @@
-public struct ProblemInfo {
+public struct ProblemInfo: Codable, Hashable {
     public let problemId: ProblemId
     public let problemDescription: ProblemDescription
     public let problemName: String

--- a/seed/swift-sdk/trace/src/Trace/Problem/UpdateProblemResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/UpdateProblemResponse.swift
@@ -1,3 +1,3 @@
-public struct UpdateProblemResponse {
+public struct UpdateProblemResponse: Codable, Hashable {
     public let problemVersion: Int
 }

--- a/seed/swift-sdk/trace/src/Trace/Problem/VariableTypeAndName.swift
+++ b/seed/swift-sdk/trace/src/Trace/Problem/VariableTypeAndName.swift
@@ -1,4 +1,4 @@
-public struct VariableTypeAndName {
+public struct VariableTypeAndName: Codable, Hashable {
     public let variableType: VariableType
     public let name: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/BuildingExecutorResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/BuildingExecutorResponse.swift
@@ -1,4 +1,4 @@
-public struct BuildingExecutorResponse {
+public struct BuildingExecutorResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let status: ExecutionSessionStatus
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/CompileError.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/CompileError.swift
@@ -1,3 +1,3 @@
-public struct CompileError {
+public struct CompileError: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/CustomTestCasesUnsupported.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/CustomTestCasesUnsupported.swift
@@ -1,4 +1,4 @@
-public struct CustomTestCasesUnsupported {
+public struct CustomTestCasesUnsupported: Codable, Hashable {
     public let problemId: ProblemId
     public let submissionId: SubmissionId
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/ErroredResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/ErroredResponse.swift
@@ -1,4 +1,4 @@
-public struct ErroredResponse {
+public struct ErroredResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let errorInfo: ErrorInfo
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/ExceptionInfo.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/ExceptionInfo.swift
@@ -1,4 +1,4 @@
-public struct ExceptionInfo {
+public struct ExceptionInfo: Codable, Hashable {
     public let exceptionType: String
     public let exceptionMessage: String
     public let exceptionStacktrace: String

--- a/seed/swift-sdk/trace/src/Trace/Submission/ExecutionSessionResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/ExecutionSessionResponse.swift
@@ -1,4 +1,4 @@
-public struct ExecutionSessionResponse {
+public struct ExecutionSessionResponse: Codable, Hashable {
     public let sessionId: String
     public let executionSessionUrl: String?
     public let language: Language

--- a/seed/swift-sdk/trace/src/Trace/Submission/ExecutionSessionState.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/ExecutionSessionState.swift
@@ -1,4 +1,4 @@
-public struct ExecutionSessionState {
+public struct ExecutionSessionState: Codable, Hashable {
     public let lastTimeContacted: String?
     public let sessionId: String
     public let isWarmInstance: Bool

--- a/seed/swift-sdk/trace/src/Trace/Submission/ExistingSubmissionExecuting.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/ExistingSubmissionExecuting.swift
@@ -1,3 +1,3 @@
-public struct ExistingSubmissionExecuting {
+public struct ExistingSubmissionExecuting: Codable, Hashable {
     public let submissionId: SubmissionId
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/ExpressionLocation.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/ExpressionLocation.swift
@@ -1,4 +1,4 @@
-public struct ExpressionLocation {
+public struct ExpressionLocation: Codable, Hashable {
     public let start: Int
     public let offset: Int
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/FinishedResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/FinishedResponse.swift
@@ -1,3 +1,3 @@
-public struct FinishedResponse {
+public struct FinishedResponse: Codable, Hashable {
     public let submissionId: SubmissionId
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/GetExecutionSessionStateResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/GetExecutionSessionStateResponse.swift
@@ -1,4 +1,4 @@
-public struct GetExecutionSessionStateResponse {
+public struct GetExecutionSessionStateResponse: Codable, Hashable {
     public let states: Any
     public let numWarmingInstances: Int?
     public let warmingSessionIds: [String]

--- a/seed/swift-sdk/trace/src/Trace/Submission/GetSubmissionStateResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/GetSubmissionStateResponse.swift
@@ -1,4 +1,4 @@
-public struct GetSubmissionStateResponse {
+public struct GetSubmissionStateResponse: Codable, Hashable {
     public let timeSubmitted: Date?
     public let submission: String
     public let language: Language

--- a/seed/swift-sdk/trace/src/Trace/Submission/GetTraceResponsesPageRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/GetTraceResponsesPageRequest.swift
@@ -1,3 +1,3 @@
-public struct GetTraceResponsesPageRequest {
+public struct GetTraceResponsesPageRequest: Codable, Hashable {
     public let offset: Int?
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/GradedResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/GradedResponse.swift
@@ -1,4 +1,4 @@
-public struct GradedResponse {
+public struct GradedResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let testCases: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/GradedResponseV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/GradedResponseV2.swift
@@ -1,4 +1,4 @@
-public struct GradedResponseV2 {
+public struct GradedResponseV2: Codable, Hashable {
     public let submissionId: SubmissionId
     public let testCases: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/GradedTestCaseUpdate.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/GradedTestCaseUpdate.swift
@@ -1,4 +1,4 @@
-public struct GradedTestCaseUpdate {
+public struct GradedTestCaseUpdate: Codable, Hashable {
     public let testCaseId: TestCaseId
     public let grade: TestCaseGrade
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/InitializeProblemRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/InitializeProblemRequest.swift
@@ -1,4 +1,4 @@
-public struct InitializeProblemRequest {
+public struct InitializeProblemRequest: Codable, Hashable {
     public let problemId: ProblemId
     public let problemVersion: Int?
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/InternalError.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/InternalError.swift
@@ -1,3 +1,3 @@
-public struct InternalError {
+public struct InternalError: Codable, Hashable {
     public let exceptionInfo: ExceptionInfo
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/InvalidRequestResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/InvalidRequestResponse.swift
@@ -1,4 +1,4 @@
-public struct InvalidRequestResponse {
+public struct InvalidRequestResponse: Codable, Hashable {
     public let request: SubmissionRequest
     public let cause: InvalidRequestCause
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/LightweightStackframeInformation.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/LightweightStackframeInformation.swift
@@ -1,4 +1,4 @@
-public struct LightweightStackframeInformation {
+public struct LightweightStackframeInformation: Codable, Hashable {
     public let numStackFrames: Int
     public let topStackFrameMethodName: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/RecordedResponseNotification.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/RecordedResponseNotification.swift
@@ -1,4 +1,4 @@
-public struct RecordedResponseNotification {
+public struct RecordedResponseNotification: Codable, Hashable {
     public let submissionId: SubmissionId
     public let traceResponsesSize: Int
     public let testCaseId: String?

--- a/seed/swift-sdk/trace/src/Trace/Submission/RecordedTestCaseUpdate.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/RecordedTestCaseUpdate.swift
@@ -1,4 +1,4 @@
-public struct RecordedTestCaseUpdate {
+public struct RecordedTestCaseUpdate: Codable, Hashable {
     public let testCaseId: TestCaseId
     public let traceResponsesSize: Int
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/RecordingResponseNotification.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/RecordingResponseNotification.swift
@@ -1,4 +1,4 @@
-public struct RecordingResponseNotification {
+public struct RecordingResponseNotification: Codable, Hashable {
     public let submissionId: SubmissionId
     public let testCaseId: String?
     public let lineNumber: Int

--- a/seed/swift-sdk/trace/src/Trace/Submission/RunningResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/RunningResponse.swift
@@ -1,4 +1,4 @@
-public struct RunningResponse {
+public struct RunningResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let state: RunningSubmissionState
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/RuntimeError.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/RuntimeError.swift
@@ -1,3 +1,3 @@
-public struct RuntimeError {
+public struct RuntimeError: Codable, Hashable {
     public let message: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/Scope.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/Scope.swift
@@ -1,3 +1,3 @@
-public struct Scope {
+public struct Scope: Codable, Hashable {
     public let variables: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/StackFrame.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/StackFrame.swift
@@ -1,4 +1,4 @@
-public struct StackFrame {
+public struct StackFrame: Codable, Hashable {
     public let methodName: String
     public let lineNumber: Int
     public let scopes: [Scope]

--- a/seed/swift-sdk/trace/src/Trace/Submission/StackInformation.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/StackInformation.swift
@@ -1,4 +1,4 @@
-public struct StackInformation {
+public struct StackInformation: Codable, Hashable {
     public let numStackFrames: Int
     public let topStackFrame: StackFrame?
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/StderrResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/StderrResponse.swift
@@ -1,4 +1,4 @@
-public struct StderrResponse {
+public struct StderrResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let stderr: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/StdoutResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/StdoutResponse.swift
@@ -1,4 +1,4 @@
-public struct StdoutResponse {
+public struct StdoutResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let stdout: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/StopRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/StopRequest.swift
@@ -1,3 +1,3 @@
-public struct StopRequest {
+public struct StopRequest: Codable, Hashable {
     public let submissionId: SubmissionId
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/StoppedResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/StoppedResponse.swift
@@ -1,3 +1,3 @@
-public struct StoppedResponse {
+public struct StoppedResponse: Codable, Hashable {
     public let submissionId: SubmissionId
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/SubmissionFileInfo.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/SubmissionFileInfo.swift
@@ -1,4 +1,4 @@
-public struct SubmissionFileInfo {
+public struct SubmissionFileInfo: Codable, Hashable {
     public let directory: String
     public let filename: String
     public let contents: String

--- a/seed/swift-sdk/trace/src/Trace/Submission/SubmissionIdNotFound.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/SubmissionIdNotFound.swift
@@ -1,3 +1,3 @@
-public struct SubmissionIdNotFound {
+public struct SubmissionIdNotFound: Codable, Hashable {
     public let missingSubmissionId: SubmissionId
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/SubmitRequestV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/SubmitRequestV2.swift
@@ -1,4 +1,4 @@
-public struct SubmitRequestV2 {
+public struct SubmitRequestV2: Codable, Hashable {
     public let submissionId: SubmissionId
     public let language: Language
     public let submissionFiles: [SubmissionFileInfo]

--- a/seed/swift-sdk/trace/src/Trace/Submission/TerminatedResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TerminatedResponse.swift
@@ -1,2 +1,2 @@
-public struct TerminatedResponse {
+public struct TerminatedResponse: Codable, Hashable {
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestCaseHiddenGrade.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestCaseHiddenGrade.swift
@@ -1,3 +1,3 @@
-public struct TestCaseHiddenGrade {
+public struct TestCaseHiddenGrade: Codable, Hashable {
     public let passed: Bool
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestCaseNonHiddenGrade.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestCaseNonHiddenGrade.swift
@@ -1,4 +1,4 @@
-public struct TestCaseNonHiddenGrade {
+public struct TestCaseNonHiddenGrade: Codable, Hashable {
     public let passed: Bool
     public let actualResult: VariableValue?
     public let exception: ExceptionV2?

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestCaseResult.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestCaseResult.swift
@@ -1,4 +1,4 @@
-public struct TestCaseResult {
+public struct TestCaseResult: Codable, Hashable {
     public let expectedResult: VariableValue
     public let actualResult: ActualResult
     public let passed: Bool

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestCaseResultWithStdout.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestCaseResultWithStdout.swift
@@ -1,4 +1,4 @@
-public struct TestCaseResultWithStdout {
+public struct TestCaseResultWithStdout: Codable, Hashable {
     public let result: TestCaseResult
     public let stdout: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestSubmissionState.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestSubmissionState.swift
@@ -1,4 +1,4 @@
-public struct TestSubmissionState {
+public struct TestSubmissionState: Codable, Hashable {
     public let problemId: ProblemId
     public let defaultTestCases: [TestCase]
     public let customTestCases: [TestCase]

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestSubmissionStatusV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestSubmissionStatusV2.swift
@@ -1,4 +1,4 @@
-public struct TestSubmissionStatusV2 {
+public struct TestSubmissionStatusV2: Codable, Hashable {
     public let updates: [TestSubmissionUpdate]
     public let problemId: ProblemId
     public let problemVersion: Int

--- a/seed/swift-sdk/trace/src/Trace/Submission/TestSubmissionUpdate.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TestSubmissionUpdate.swift
@@ -1,4 +1,4 @@
-public struct TestSubmissionUpdate {
+public struct TestSubmissionUpdate: Codable, Hashable {
     public let updateTime: Date
     public let updateInfo: TestSubmissionUpdateInfo
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TraceResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TraceResponse.swift
@@ -1,4 +1,4 @@
-public struct TraceResponse {
+public struct TraceResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let lineNumber: Int
     public let returnValue: DebugVariableValue?

--- a/seed/swift-sdk/trace/src/Trace/Submission/TraceResponseV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TraceResponseV2.swift
@@ -1,4 +1,4 @@
-public struct TraceResponseV2 {
+public struct TraceResponseV2: Codable, Hashable {
     public let submissionId: SubmissionId
     public let lineNumber: Int
     public let file: TracedFile

--- a/seed/swift-sdk/trace/src/Trace/Submission/TraceResponsesPage.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TraceResponsesPage.swift
@@ -1,4 +1,4 @@
-public struct TraceResponsesPage {
+public struct TraceResponsesPage: Codable, Hashable {
     public let offset: Int?
     public let traceResponses: [TraceResponse]
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TraceResponsesPageV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TraceResponsesPageV2.swift
@@ -1,4 +1,4 @@
-public struct TraceResponsesPageV2 {
+public struct TraceResponsesPageV2: Codable, Hashable {
     public let offset: Int?
     public let traceResponses: [TraceResponseV2]
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TracedFile.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TracedFile.swift
@@ -1,4 +1,4 @@
-public struct TracedFile {
+public struct TracedFile: Codable, Hashable {
     public let filename: String
     public let directory: String
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/TracedTestCase.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/TracedTestCase.swift
@@ -1,4 +1,4 @@
-public struct TracedTestCase {
+public struct TracedTestCase: Codable, Hashable {
     public let result: TestCaseResultWithStdout
     public let traceResponsesSize: Int
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/UnexpectedLanguageError.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/UnexpectedLanguageError.swift
@@ -1,4 +1,4 @@
-public struct UnexpectedLanguageError {
+public struct UnexpectedLanguageError: Codable, Hashable {
     public let expectedLanguage: Language
     public let actualLanguage: Language
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceFiles.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceFiles.swift
@@ -1,4 +1,4 @@
-public struct WorkspaceFiles {
+public struct WorkspaceFiles: Codable, Hashable {
     public let mainFile: FileInfo
     public let readOnlyFiles: [FileInfo]
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceRanResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceRanResponse.swift
@@ -1,4 +1,4 @@
-public struct WorkspaceRanResponse {
+public struct WorkspaceRanResponse: Codable, Hashable {
     public let submissionId: SubmissionId
     public let runDetails: WorkspaceRunDetails
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceRunDetails.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceRunDetails.swift
@@ -1,4 +1,4 @@
-public struct WorkspaceRunDetails {
+public struct WorkspaceRunDetails: Codable, Hashable {
     public let exceptionV2: ExceptionV2?
     public let exception: ExceptionInfo?
     public let stdout: String

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceStarterFilesResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceStarterFilesResponse.swift
@@ -1,3 +1,3 @@
-public struct WorkspaceStarterFilesResponse {
+public struct WorkspaceStarterFilesResponse: Codable, Hashable {
     public let files: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceStarterFilesResponseV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceStarterFilesResponseV2.swift
@@ -1,3 +1,3 @@
-public struct WorkspaceStarterFilesResponseV2 {
+public struct WorkspaceStarterFilesResponseV2: Codable, Hashable {
     public let filesByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmissionState.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmissionState.swift
@@ -1,3 +1,3 @@
-public struct WorkspaceSubmissionState {
+public struct WorkspaceSubmissionState: Codable, Hashable {
     public let status: WorkspaceSubmissionStatus
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmissionStatusV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmissionStatusV2.swift
@@ -1,3 +1,3 @@
-public struct WorkspaceSubmissionStatusV2 {
+public struct WorkspaceSubmissionStatusV2: Codable, Hashable {
     public let updates: [WorkspaceSubmissionUpdate]
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmissionUpdate.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmissionUpdate.swift
@@ -1,4 +1,4 @@
-public struct WorkspaceSubmissionUpdate {
+public struct WorkspaceSubmissionUpdate: Codable, Hashable {
     public let updateTime: Date
     public let updateInfo: WorkspaceSubmissionUpdateInfo
 }

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmitRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceSubmitRequest.swift
@@ -1,4 +1,4 @@
-public struct WorkspaceSubmitRequest {
+public struct WorkspaceSubmitRequest: Codable, Hashable {
     public let submissionId: SubmissionId
     public let language: Language
     public let submissionFiles: [SubmissionFileInfo]

--- a/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceTracedUpdate.swift
+++ b/seed/swift-sdk/trace/src/Trace/Submission/WorkspaceTracedUpdate.swift
@@ -1,3 +1,3 @@
-public struct WorkspaceTracedUpdate {
+public struct WorkspaceTracedUpdate: Codable, Hashable {
     public let traceResponsesSize: Int
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/BasicCustomFiles.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/BasicCustomFiles.swift
@@ -1,4 +1,4 @@
-public struct BasicCustomFiles {
+public struct BasicCustomFiles: Codable, Hashable {
     public let methodName: String
     public let signature: NonVoidFunctionSignature
     public let additionalFiles: Any

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/BasicTestCaseTemplate.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/BasicTestCaseTemplate.swift
@@ -1,4 +1,4 @@
-public struct BasicTestCaseTemplate {
+public struct BasicTestCaseTemplate: Codable, Hashable {
     public let templateId: TestCaseTemplateId
     public let name: String
     public let description: TestCaseImplementationDescription

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/CreateProblemRequestV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/CreateProblemRequestV2.swift
@@ -1,4 +1,4 @@
-public struct CreateProblemRequestV2 {
+public struct CreateProblemRequestV2: Codable, Hashable {
     public let problemName: String
     public let problemDescription: ProblemDescription
     public let customFiles: CustomFiles

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/DeepEqualityCorrectnessCheck.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/DeepEqualityCorrectnessCheck.swift
@@ -1,3 +1,3 @@
-public struct DeepEqualityCorrectnessCheck {
+public struct DeepEqualityCorrectnessCheck: Codable, Hashable {
     public let expectedValueParameterId: ParameterId
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/DefaultProvidedFile.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/DefaultProvidedFile.swift
@@ -1,4 +1,4 @@
-public struct DefaultProvidedFile {
+public struct DefaultProvidedFile: Codable, Hashable {
     public let file: FileInfoV2
     public let relatedTypes: [VariableType]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/FileInfoV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/FileInfoV2.swift
@@ -1,4 +1,4 @@
-public struct FileInfoV2 {
+public struct FileInfoV2: Codable, Hashable {
     public let filename: String
     public let directory: String
     public let contents: String

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/Files.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/Files.swift
@@ -1,3 +1,3 @@
-public struct Files {
+public struct Files: Codable, Hashable {
     public let files: [FileInfoV2]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/FunctionImplementation.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/FunctionImplementation.swift
@@ -1,4 +1,4 @@
-public struct FunctionImplementation {
+public struct FunctionImplementation: Codable, Hashable {
     public let impl: String
     public let imports: String?
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/FunctionImplementationForMultipleLanguages.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/FunctionImplementationForMultipleLanguages.swift
@@ -1,3 +1,3 @@
-public struct FunctionImplementationForMultipleLanguages {
+public struct FunctionImplementationForMultipleLanguages: Codable, Hashable {
     public let codeByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GeneratedFiles.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GeneratedFiles.swift
@@ -1,4 +1,4 @@
-public struct GeneratedFiles {
+public struct GeneratedFiles: Codable, Hashable {
     public let generatedTestCaseFiles: Any
     public let generatedTemplateFiles: Any
     public let other: Any

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GetBasicSolutionFileRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GetBasicSolutionFileRequest.swift
@@ -1,4 +1,4 @@
-public struct GetBasicSolutionFileRequest {
+public struct GetBasicSolutionFileRequest: Codable, Hashable {
     public let methodName: String
     public let signature: NonVoidFunctionSignature
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GetBasicSolutionFileResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GetBasicSolutionFileResponse.swift
@@ -1,3 +1,3 @@
-public struct GetBasicSolutionFileResponse {
+public struct GetBasicSolutionFileResponse: Codable, Hashable {
     public let solutionFileByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GetFunctionSignatureRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GetFunctionSignatureRequest.swift
@@ -1,3 +1,3 @@
-public struct GetFunctionSignatureRequest {
+public struct GetFunctionSignatureRequest: Codable, Hashable {
     public let functionSignature: FunctionSignature
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GetFunctionSignatureResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GetFunctionSignatureResponse.swift
@@ -1,3 +1,3 @@
-public struct GetFunctionSignatureResponse {
+public struct GetFunctionSignatureResponse: Codable, Hashable {
     public let functionByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GetGeneratedTestCaseFileRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GetGeneratedTestCaseFileRequest.swift
@@ -1,4 +1,4 @@
-public struct GetGeneratedTestCaseFileRequest {
+public struct GetGeneratedTestCaseFileRequest: Codable, Hashable {
     public let template: TestCaseTemplate?
     public let testCase: TestCaseV2
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/GetGeneratedTestCaseTemplateFileRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/GetGeneratedTestCaseTemplateFileRequest.swift
@@ -1,3 +1,3 @@
-public struct GetGeneratedTestCaseTemplateFileRequest {
+public struct GetGeneratedTestCaseTemplateFileRequest: Codable, Hashable {
     public let template: TestCaseTemplate
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/LightweightProblemInfoV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/LightweightProblemInfoV2.swift
@@ -1,4 +1,4 @@
-public struct LightweightProblemInfoV2 {
+public struct LightweightProblemInfoV2: Codable, Hashable {
     public let problemId: ProblemId
     public let problemName: String
     public let problemVersion: Int

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/NonVoidFunctionDefinition.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/NonVoidFunctionDefinition.swift
@@ -1,4 +1,4 @@
-public struct NonVoidFunctionDefinition {
+public struct NonVoidFunctionDefinition: Codable, Hashable {
     public let signature: NonVoidFunctionSignature
     public let code: FunctionImplementationForMultipleLanguages
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/NonVoidFunctionSignature.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/NonVoidFunctionSignature.swift
@@ -1,4 +1,4 @@
-public struct NonVoidFunctionSignature {
+public struct NonVoidFunctionSignature: Codable, Hashable {
     public let parameters: [Parameter]
     public let returnType: VariableType
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/Parameter.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/Parameter.swift
@@ -1,4 +1,4 @@
-public struct Parameter {
+public struct Parameter: Codable, Hashable {
     public let parameterId: ParameterId
     public let name: String
     public let variableType: VariableType

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/ProblemInfoV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/ProblemInfoV2.swift
@@ -1,4 +1,4 @@
-public struct ProblemInfoV2 {
+public struct ProblemInfoV2: Codable, Hashable {
     public let problemId: ProblemId
     public let problemDescription: ProblemDescription
     public let problemName: String

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseExpects.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseExpects.swift
@@ -1,3 +1,3 @@
-public struct TestCaseExpects {
+public struct TestCaseExpects: Codable, Hashable {
     public let expectedStdout: String?
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseImplementation.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseImplementation.swift
@@ -1,4 +1,4 @@
-public struct TestCaseImplementation {
+public struct TestCaseImplementation: Codable, Hashable {
     public let description: TestCaseImplementationDescription
     public let function: TestCaseFunction
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseImplementationDescription.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseImplementationDescription.swift
@@ -1,3 +1,3 @@
-public struct TestCaseImplementationDescription {
+public struct TestCaseImplementationDescription: Codable, Hashable {
     public let boards: [TestCaseImplementationDescriptionBoard]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseMetadata.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseMetadata.swift
@@ -1,4 +1,4 @@
-public struct TestCaseMetadata {
+public struct TestCaseMetadata: Codable, Hashable {
     public let id: TestCaseId
     public let name: String
     public let hidden: Bool

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseTemplate.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseTemplate.swift
@@ -1,4 +1,4 @@
-public struct TestCaseTemplate {
+public struct TestCaseTemplate: Codable, Hashable {
     public let templateId: TestCaseTemplateId
     public let name: String
     public let implementation: TestCaseImplementation

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseV2.swift
@@ -1,4 +1,4 @@
-public struct TestCaseV2 {
+public struct TestCaseV2: Codable, Hashable {
     public let metadata: TestCaseMetadata
     public let implementation: TestCaseImplementationReference
     public let arguments: Any

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseWithActualResultImplementation.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/TestCaseWithActualResultImplementation.swift
@@ -1,4 +1,4 @@
-public struct TestCaseWithActualResultImplementation {
+public struct TestCaseWithActualResultImplementation: Codable, Hashable {
     public let getActualResult: NonVoidFunctionDefinition
     public let assertCorrectnessCheck: AssertCorrectnessCheck
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionDefinition.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionDefinition.swift
@@ -1,4 +1,4 @@
-public struct VoidFunctionDefinition {
+public struct VoidFunctionDefinition: Codable, Hashable {
     public let parameters: [Parameter]
     public let code: FunctionImplementationForMultipleLanguages
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionDefinitionThatTakesActualResult.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionDefinitionThatTakesActualResult.swift
@@ -1,4 +1,4 @@
-public struct VoidFunctionDefinitionThatTakesActualResult {
+public struct VoidFunctionDefinitionThatTakesActualResult: Codable, Hashable {
     public let additionalParameters: [Parameter]
     public let code: FunctionImplementationForMultipleLanguages
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionSignature.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionSignature.swift
@@ -1,3 +1,3 @@
-public struct VoidFunctionSignature {
+public struct VoidFunctionSignature: Codable, Hashable {
     public let parameters: [Parameter]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionSignatureThatTakesActualResult.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/Problem/VoidFunctionSignatureThatTakesActualResult.swift
@@ -1,4 +1,4 @@
-public struct VoidFunctionSignatureThatTakesActualResult {
+public struct VoidFunctionSignatureThatTakesActualResult: Codable, Hashable {
     public let parameters: [Parameter]
     public let actualResultType: VariableType
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/BasicCustomFiles.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/BasicCustomFiles.swift
@@ -1,4 +1,4 @@
-public struct BasicCustomFiles {
+public struct BasicCustomFiles: Codable, Hashable {
     public let methodName: String
     public let signature: NonVoidFunctionSignature
     public let additionalFiles: Any

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/BasicTestCaseTemplate.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/BasicTestCaseTemplate.swift
@@ -1,4 +1,4 @@
-public struct BasicTestCaseTemplate {
+public struct BasicTestCaseTemplate: Codable, Hashable {
     public let templateId: TestCaseTemplateId
     public let name: String
     public let description: TestCaseImplementationDescription

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/CreateProblemRequestV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/CreateProblemRequestV2.swift
@@ -1,4 +1,4 @@
-public struct CreateProblemRequestV2 {
+public struct CreateProblemRequestV2: Codable, Hashable {
     public let problemName: String
     public let problemDescription: ProblemDescription
     public let customFiles: CustomFiles

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/DeepEqualityCorrectnessCheck.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/DeepEqualityCorrectnessCheck.swift
@@ -1,3 +1,3 @@
-public struct DeepEqualityCorrectnessCheck {
+public struct DeepEqualityCorrectnessCheck: Codable, Hashable {
     public let expectedValueParameterId: ParameterId
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/DefaultProvidedFile.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/DefaultProvidedFile.swift
@@ -1,4 +1,4 @@
-public struct DefaultProvidedFile {
+public struct DefaultProvidedFile: Codable, Hashable {
     public let file: FileInfoV2
     public let relatedTypes: [VariableType]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/FileInfoV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/FileInfoV2.swift
@@ -1,4 +1,4 @@
-public struct FileInfoV2 {
+public struct FileInfoV2: Codable, Hashable {
     public let filename: String
     public let directory: String
     public let contents: String

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/Files.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/Files.swift
@@ -1,3 +1,3 @@
-public struct Files {
+public struct Files: Codable, Hashable {
     public let files: [FileInfoV2]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/FunctionImplementation.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/FunctionImplementation.swift
@@ -1,4 +1,4 @@
-public struct FunctionImplementation {
+public struct FunctionImplementation: Codable, Hashable {
     public let impl: String
     public let imports: String?
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/FunctionImplementationForMultipleLanguages.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/FunctionImplementationForMultipleLanguages.swift
@@ -1,3 +1,3 @@
-public struct FunctionImplementationForMultipleLanguages {
+public struct FunctionImplementationForMultipleLanguages: Codable, Hashable {
     public let codeByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GeneratedFiles.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GeneratedFiles.swift
@@ -1,4 +1,4 @@
-public struct GeneratedFiles {
+public struct GeneratedFiles: Codable, Hashable {
     public let generatedTestCaseFiles: Any
     public let generatedTemplateFiles: Any
     public let other: Any

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetBasicSolutionFileRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetBasicSolutionFileRequest.swift
@@ -1,4 +1,4 @@
-public struct GetBasicSolutionFileRequest {
+public struct GetBasicSolutionFileRequest: Codable, Hashable {
     public let methodName: String
     public let signature: NonVoidFunctionSignature
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetBasicSolutionFileResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetBasicSolutionFileResponse.swift
@@ -1,3 +1,3 @@
-public struct GetBasicSolutionFileResponse {
+public struct GetBasicSolutionFileResponse: Codable, Hashable {
     public let solutionFileByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetFunctionSignatureRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetFunctionSignatureRequest.swift
@@ -1,3 +1,3 @@
-public struct GetFunctionSignatureRequest {
+public struct GetFunctionSignatureRequest: Codable, Hashable {
     public let functionSignature: FunctionSignature
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetFunctionSignatureResponse.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetFunctionSignatureResponse.swift
@@ -1,3 +1,3 @@
-public struct GetFunctionSignatureResponse {
+public struct GetFunctionSignatureResponse: Codable, Hashable {
     public let functionByLanguage: Any
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetGeneratedTestCaseFileRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetGeneratedTestCaseFileRequest.swift
@@ -1,4 +1,4 @@
-public struct GetGeneratedTestCaseFileRequest {
+public struct GetGeneratedTestCaseFileRequest: Codable, Hashable {
     public let template: TestCaseTemplate?
     public let testCase: TestCaseV2
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetGeneratedTestCaseTemplateFileRequest.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/GetGeneratedTestCaseTemplateFileRequest.swift
@@ -1,3 +1,3 @@
-public struct GetGeneratedTestCaseTemplateFileRequest {
+public struct GetGeneratedTestCaseTemplateFileRequest: Codable, Hashable {
     public let template: TestCaseTemplate
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/LightweightProblemInfoV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/LightweightProblemInfoV2.swift
@@ -1,4 +1,4 @@
-public struct LightweightProblemInfoV2 {
+public struct LightweightProblemInfoV2: Codable, Hashable {
     public let problemId: ProblemId
     public let problemName: String
     public let problemVersion: Int

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/NonVoidFunctionDefinition.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/NonVoidFunctionDefinition.swift
@@ -1,4 +1,4 @@
-public struct NonVoidFunctionDefinition {
+public struct NonVoidFunctionDefinition: Codable, Hashable {
     public let signature: NonVoidFunctionSignature
     public let code: FunctionImplementationForMultipleLanguages
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/NonVoidFunctionSignature.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/NonVoidFunctionSignature.swift
@@ -1,4 +1,4 @@
-public struct NonVoidFunctionSignature {
+public struct NonVoidFunctionSignature: Codable, Hashable {
     public let parameters: [Parameter]
     public let returnType: VariableType
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/Parameter.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/Parameter.swift
@@ -1,4 +1,4 @@
-public struct Parameter {
+public struct Parameter: Codable, Hashable {
     public let parameterId: ParameterId
     public let name: String
     public let variableType: VariableType

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/ProblemInfoV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/ProblemInfoV2.swift
@@ -1,4 +1,4 @@
-public struct ProblemInfoV2 {
+public struct ProblemInfoV2: Codable, Hashable {
     public let problemId: ProblemId
     public let problemDescription: ProblemDescription
     public let problemName: String

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseExpects.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseExpects.swift
@@ -1,3 +1,3 @@
-public struct TestCaseExpects {
+public struct TestCaseExpects: Codable, Hashable {
     public let expectedStdout: String?
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseImplementation.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseImplementation.swift
@@ -1,4 +1,4 @@
-public struct TestCaseImplementation {
+public struct TestCaseImplementation: Codable, Hashable {
     public let description: TestCaseImplementationDescription
     public let function: TestCaseFunction
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseImplementationDescription.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseImplementationDescription.swift
@@ -1,3 +1,3 @@
-public struct TestCaseImplementationDescription {
+public struct TestCaseImplementationDescription: Codable, Hashable {
     public let boards: [TestCaseImplementationDescriptionBoard]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseMetadata.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseMetadata.swift
@@ -1,4 +1,4 @@
-public struct TestCaseMetadata {
+public struct TestCaseMetadata: Codable, Hashable {
     public let id: TestCaseId
     public let name: String
     public let hidden: Bool

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseTemplate.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseTemplate.swift
@@ -1,4 +1,4 @@
-public struct TestCaseTemplate {
+public struct TestCaseTemplate: Codable, Hashable {
     public let templateId: TestCaseTemplateId
     public let name: String
     public let implementation: TestCaseImplementation

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseV2.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseV2.swift
@@ -1,4 +1,4 @@
-public struct TestCaseV2 {
+public struct TestCaseV2: Codable, Hashable {
     public let metadata: TestCaseMetadata
     public let implementation: TestCaseImplementationReference
     public let arguments: Any

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseWithActualResultImplementation.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/TestCaseWithActualResultImplementation.swift
@@ -1,4 +1,4 @@
-public struct TestCaseWithActualResultImplementation {
+public struct TestCaseWithActualResultImplementation: Codable, Hashable {
     public let getActualResult: NonVoidFunctionDefinition
     public let assertCorrectnessCheck: AssertCorrectnessCheck
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionDefinition.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionDefinition.swift
@@ -1,4 +1,4 @@
-public struct VoidFunctionDefinition {
+public struct VoidFunctionDefinition: Codable, Hashable {
     public let parameters: [Parameter]
     public let code: FunctionImplementationForMultipleLanguages
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionDefinitionThatTakesActualResult.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionDefinitionThatTakesActualResult.swift
@@ -1,4 +1,4 @@
-public struct VoidFunctionDefinitionThatTakesActualResult {
+public struct VoidFunctionDefinitionThatTakesActualResult: Codable, Hashable {
     public let additionalParameters: [Parameter]
     public let code: FunctionImplementationForMultipleLanguages
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionSignature.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionSignature.swift
@@ -1,3 +1,3 @@
-public struct VoidFunctionSignature {
+public struct VoidFunctionSignature: Codable, Hashable {
     public let parameters: [Parameter]
 }

--- a/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionSignatureThatTakesActualResult.swift
+++ b/seed/swift-sdk/trace/src/Trace/V2/V3/Problem/VoidFunctionSignatureThatTakesActualResult.swift
@@ -1,4 +1,4 @@
-public struct VoidFunctionSignatureThatTakesActualResult {
+public struct VoidFunctionSignatureThatTakesActualResult: Codable, Hashable {
     public let parameters: [Parameter]
     public let actualResultType: VariableType
 }

--- a/seed/swift-sdk/undiscriminated-unions/src/UndiscriminatedUnions/Union/NamedMetadata.swift
+++ b/seed/swift-sdk/undiscriminated-unions/src/UndiscriminatedUnions/Union/NamedMetadata.swift
@@ -1,4 +1,4 @@
-public struct NamedMetadata {
+public struct NamedMetadata: Codable, Hashable {
     public let name: String
     public let value: Any
 }

--- a/seed/swift-sdk/undiscriminated-unions/src/UndiscriminatedUnions/Union/Request.swift
+++ b/seed/swift-sdk/undiscriminated-unions/src/UndiscriminatedUnions/Union/Request.swift
@@ -1,3 +1,3 @@
-public struct Request {
+public struct Request: Codable, Hashable {
     public let union: MetadataUnion?
 }

--- a/seed/swift-sdk/undiscriminated-unions/src/UndiscriminatedUnions/Union/TypeWithOptionalUnion.swift
+++ b/seed/swift-sdk/undiscriminated-unions/src/UndiscriminatedUnions/Union/TypeWithOptionalUnion.swift
@@ -1,3 +1,3 @@
-public struct TypeWithOptionalUnion {
+public struct TypeWithOptionalUnion: Codable, Hashable {
     public let myUnion: MyUnion?
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/ActiveDiamond.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/ActiveDiamond.swift
@@ -1,3 +1,3 @@
-public struct ActiveDiamond {
+public struct ActiveDiamond: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/AttractiveScript.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/AttractiveScript.swift
@@ -1,3 +1,3 @@
-public struct AttractiveScript {
+public struct AttractiveScript: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/CircularCard.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/CircularCard.swift
@@ -1,3 +1,3 @@
-public struct CircularCard {
+public struct CircularCard: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/ColorfulCover.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/ColorfulCover.swift
@@ -1,3 +1,3 @@
-public struct ColorfulCover {
+public struct ColorfulCover: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/DiligentDeal.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/DiligentDeal.swift
@@ -1,3 +1,3 @@
-public struct DiligentDeal {
+public struct DiligentDeal: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/DisloyalValue.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/DisloyalValue.swift
@@ -1,3 +1,3 @@
-public struct DisloyalValue {
+public struct DisloyalValue: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/DistinctFailure.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/DistinctFailure.swift
@@ -1,3 +1,3 @@
-public struct DistinctFailure {
+public struct DistinctFailure: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/FalseMirror.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/FalseMirror.swift
@@ -1,3 +1,3 @@
-public struct FalseMirror {
+public struct FalseMirror: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/FrozenSleep.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/FrozenSleep.swift
@@ -1,3 +1,3 @@
-public struct FrozenSleep {
+public struct FrozenSleep: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/GaseousRoad.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/GaseousRoad.swift
@@ -1,3 +1,3 @@
-public struct GaseousRoad {
+public struct GaseousRoad: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/GruesomeCoach.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/GruesomeCoach.swift
@@ -1,3 +1,3 @@
-public struct GruesomeCoach {
+public struct GruesomeCoach: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/HarmoniousPlay.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/HarmoniousPlay.swift
@@ -1,3 +1,3 @@
-public struct HarmoniousPlay {
+public struct HarmoniousPlay: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/HastyPain.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/HastyPain.swift
@@ -1,3 +1,3 @@
-public struct HastyPain {
+public struct HastyPain: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/HoarseMouse.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/HoarseMouse.swift
@@ -1,3 +1,3 @@
-public struct HoarseMouse {
+public struct HoarseMouse: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/JumboEnd.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/JumboEnd.swift
@@ -1,3 +1,3 @@
-public struct JumboEnd {
+public struct JumboEnd: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/LimpingStep.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/LimpingStep.swift
@@ -1,3 +1,3 @@
-public struct LimpingStep {
+public struct LimpingStep: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/MistySnow.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/MistySnow.swift
@@ -1,3 +1,3 @@
-public struct MistySnow {
+public struct MistySnow: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/NormalSweet.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/NormalSweet.swift
@@ -1,3 +1,3 @@
-public struct NormalSweet {
+public struct NormalSweet: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/PopularLimit.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/PopularLimit.swift
@@ -1,3 +1,3 @@
-public struct PopularLimit {
+public struct PopularLimit: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/PotableBad.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/PotableBad.swift
@@ -1,3 +1,3 @@
-public struct PotableBad {
+public struct PotableBad: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/PracticalPrinciple.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/PracticalPrinciple.swift
@@ -1,3 +1,3 @@
-public struct PracticalPrinciple {
+public struct PracticalPrinciple: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/PrimaryBlock.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/PrimaryBlock.swift
@@ -1,3 +1,3 @@
-public struct PrimaryBlock {
+public struct PrimaryBlock: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/RotatingRatio.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/RotatingRatio.swift
@@ -1,3 +1,3 @@
-public struct RotatingRatio {
+public struct RotatingRatio: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/ThankfulFactor.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/ThankfulFactor.swift
@@ -1,3 +1,3 @@
-public struct ThankfulFactor {
+public struct ThankfulFactor: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/TotalWork.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/TotalWork.swift
@@ -1,3 +1,3 @@
-public struct TotalWork {
+public struct TotalWork: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/TriangularRepair.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/TriangularRepair.swift
@@ -1,3 +1,3 @@
-public struct TriangularRepair {
+public struct TriangularRepair: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/UniqueStress.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/UniqueStress.swift
@@ -1,3 +1,3 @@
-public struct UniqueStress {
+public struct UniqueStress: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/UnwillingSmoke.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/UnwillingSmoke.swift
@@ -1,3 +1,3 @@
-public struct UnwillingSmoke {
+public struct UnwillingSmoke: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Bigunion/VibrantExcitement.swift
+++ b/seed/swift-sdk/unions/src/Unions/Bigunion/VibrantExcitement.swift
@@ -1,3 +1,3 @@
-public struct VibrantExcitement {
+public struct VibrantExcitement: Codable, Hashable {
     public let value: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Types/Bar.swift
+++ b/seed/swift-sdk/unions/src/Unions/Types/Bar.swift
@@ -1,3 +1,3 @@
-public struct Bar {
+public struct Bar: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Types/Foo.swift
+++ b/seed/swift-sdk/unions/src/Unions/Types/Foo.swift
@@ -1,3 +1,3 @@
-public struct Foo {
+public struct Foo: Codable, Hashable {
     public let name: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Types/FooExtended.swift
+++ b/seed/swift-sdk/unions/src/Unions/Types/FooExtended.swift
@@ -1,3 +1,3 @@
-public struct FooExtended {
+public struct FooExtended: Codable, Hashable {
     public let age: Int
 }

--- a/seed/swift-sdk/unions/src/Unions/Union/Circle.swift
+++ b/seed/swift-sdk/unions/src/Unions/Union/Circle.swift
@@ -1,3 +1,3 @@
-public struct Circle {
+public struct Circle: Codable, Hashable {
     public let radius: Double
 }

--- a/seed/swift-sdk/unions/src/Unions/Union/GetShapeRequest.swift
+++ b/seed/swift-sdk/unions/src/Unions/Union/GetShapeRequest.swift
@@ -1,3 +1,3 @@
-public struct GetShapeRequest {
+public struct GetShapeRequest: Codable, Hashable {
     public let id: String
 }

--- a/seed/swift-sdk/unions/src/Unions/Union/Square.swift
+++ b/seed/swift-sdk/unions/src/Unions/Union/Square.swift
@@ -1,3 +1,3 @@
-public struct Square {
+public struct Square: Codable, Hashable {
     public let length: Double
 }

--- a/seed/swift-sdk/unknown/src/UnknownAsAny/Unknown/MyObject.swift
+++ b/seed/swift-sdk/unknown/src/UnknownAsAny/Unknown/MyObject.swift
@@ -1,3 +1,3 @@
-public struct MyObject {
+public struct MyObject: Codable, Hashable {
     public let unknown: Any
 }

--- a/seed/swift-sdk/validation/src/Validation/Type.swift
+++ b/seed/swift-sdk/validation/src/Validation/Type.swift
@@ -1,4 +1,4 @@
-public struct Type {
+public struct Type: Codable, Hashable {
     public let decimal: Double
     public let even: Int
     public let name: String

--- a/seed/swift-sdk/version-no-default/src/Version/User/User.swift
+++ b/seed/swift-sdk/version-no-default/src/Version/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: UserId
     public let name: String
 }

--- a/seed/swift-sdk/version/src/Version/User/User.swift
+++ b/seed/swift-sdk/version/src/Version/User/User.swift
@@ -1,4 +1,4 @@
-public struct User {
+public struct User: Codable, Hashable {
     public let id: UserId
     public let name: String
 }

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveEvent.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveEvent.swift
@@ -1,4 +1,4 @@
-public struct ReceiveEvent {
+public struct ReceiveEvent: Codable, Hashable {
     public let alpha: String
     public let beta: Int
 }

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveEvent2.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveEvent2.swift
@@ -1,4 +1,4 @@
-public struct ReceiveEvent2 {
+public struct ReceiveEvent2: Codable, Hashable {
     public let gamma: String
     public let delta: Int
     public let epsilon: Bool

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveEvent3.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveEvent3.swift
@@ -1,3 +1,3 @@
-public struct ReceiveEvent3 {
+public struct ReceiveEvent3: Codable, Hashable {
     public let receiveText3: String
 }

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveSnakeCase.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/ReceiveSnakeCase.swift
@@ -1,4 +1,9 @@
-public struct ReceiveSnakeCase {
+public struct ReceiveSnakeCase: Codable, Hashable {
     public let receiveText: String
     public let receiveInt: Int
+
+    enum CodingKeys: String, CodingKey {
+        case receiveText = "receive_text"
+        case receiveInt = "receive_int"
+    }
 }

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/SendEvent.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/SendEvent.swift
@@ -1,4 +1,4 @@
-public struct SendEvent {
+public struct SendEvent: Codable, Hashable {
     public let sendText: String
     public let sendParam: Int
 }

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/SendEvent2.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/SendEvent2.swift
@@ -1,4 +1,4 @@
-public struct SendEvent2 {
+public struct SendEvent2: Codable, Hashable {
     public let sendText2: String
     public let sendParam2: Bool
 }

--- a/seed/swift-sdk/websocket/src/Websocket/Realtime/SendSnakeCase.swift
+++ b/seed/swift-sdk/websocket/src/Websocket/Realtime/SendSnakeCase.swift
@@ -1,4 +1,9 @@
-public struct SendSnakeCase {
+public struct SendSnakeCase: Codable, Hashable {
     public let sendText: String
     public let sendParam: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sendText = "send_text"
+        case sendParam = "send_param"
+    }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Implements the changes that allow us to inject CodingKeys into the structs that need it. See [example](https://github.com/fern-api/fern/blob/da255b5275b99bcee5aee85dab450e2cb004434d/seed/swift-sdk/nullable/src/Nullable/Nullable/User.swift).

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added `nestedTypes` to `Struct.Args` in `codegen`
- Changed `ObjectGenerator` to inject `CodingKeys` when the object has non-camelcase properties
- Updated Seed test output

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

