### PR TITLE
fix(python): handle non-multipleBaseUrls in WebsocketConnectMethodGenerator

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.25.3
+  changelogEntry:
+    - summary: |
+        Fix websocket connect method generation for single base URL environments.
+      type: fix
+  createdAt: '2025-07-14'
+  irVersion: 58
+
 - version: 4.25.2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/websocket_connect_method_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/websocket_connect_method_generator.py
@@ -261,7 +261,7 @@ class WebsocketConnectMethodGenerator:
         parameters: List[AST.NamedFunctionParameter],
     ) -> AST.CodeWriter:
         def write(writer: AST.NodeWriter) -> None:
-            environment_url = self._get_environment_as_str(websocket=websocket)
+            environment_url = self._get_multiple_base_url_environment_as_string(websocket=websocket)
             url_prefix = (
                 environment_url
                 if environment_url
@@ -619,7 +619,7 @@ class WebsocketConnectMethodGenerator:
             context=self._context, object_=reference, type_reference=query_parameter.value_type
         )
 
-    def _get_environment_as_str(self, *, websocket: ir_types.WebSocketChannel) -> Optional[str]:
+    def _get_multiple_base_url_environment_as_string(self, *, websocket: ir_types.WebSocketChannel) -> Optional[str]:
         if self._context.ir.environments is not None:
             environments_as_union = self._context.ir.environments.environments.get_as_union()
             if environments_as_union.type == "multipleBaseUrls":

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
@@ -58,7 +58,7 @@ class RealtimeClient:
         -------
         RealtimeSocketClient
         """
-        ws_url = +"/realtime/"
+        ws_url = self._raw_client._client_wrapper.get_base_url() + "/realtime/"
         query_params = httpx.QueryParams()
         if model is not None:
             query_params = query_params.add("model", model)
@@ -126,7 +126,7 @@ class AsyncRealtimeClient:
         -------
         AsyncRealtimeSocketClient
         """
-        ws_url = +"/realtime/"
+        ws_url = self._raw_client._client_wrapper.get_base_url() + "/realtime/"
         query_params = httpx.QueryParams()
         if model is not None:
             query_params = query_params.add("model", model)

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
@@ -46,7 +46,7 @@ class RawRealtimeClient:
         -------
         RealtimeSocketClient
         """
-        ws_url = +"/realtime/"
+        ws_url = self._client_wrapper.get_base_url() + "/realtime/"
         query_params = httpx.QueryParams()
         if model is not None:
             query_params = query_params.add("model", model)
@@ -103,7 +103,7 @@ class AsyncRawRealtimeClient:
         -------
         AsyncRealtimeSocketClient
         """
-        ws_url = +"/realtime/"
+        ws_url = self._client_wrapper.get_base_url() + "/realtime/"
         query_params = httpx.QueryParams()
         if model is not None:
             query_params = query_params.add("model", model)


### PR DESCRIPTION
Unless the environment type is "multipleBaseUrls", a websocket connect method is generated as 

```python
class RealtimeClient:
    ...

    @contextmanager
    def connect(...
    ) -> typing.Iterator[RealtimeSocketClient]:
        ...
        ws_url = +"/realtime/"
```

Note the invalid `ws_url`.

It should default instead to using the base URL, i.e. `ws_url = <BASE URL> + "/realtime/"`


## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- If no environment URL, use the base URL as the prefix of the websocket connection URL.

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed

## Release
- [x] Set version
