### PR TITLE
feat(internal): allow specifying output path for seed run

### DIFF
--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -190,6 +190,12 @@ function addRunCommand(cli: Argv) {
                     demandOption: true,
                     description: "Path to the fern definition"
                 })
+                .option("output-path", {
+                    type: "string",
+                    string: true,
+                    demandOption: false,
+                    description: "Path to output the generated files (defaults to tmp dir)"
+                })
                 .option("log-level", {
                     default: LogLevel.Info,
                     choices: LOG_LEVELS
@@ -221,7 +227,12 @@ function addRunCommand(cli: Argv) {
                 workspace: generator,
                 logLevel: argv["log-level"],
                 audience: argv.audience,
-                skipScripts: argv.skipScripts
+                skipScripts: argv.skipScripts,
+                outputPath: argv["output-path"] 
+                    ? argv["output-path"].startsWith("/")
+                        ? AbsoluteFilePath.of(argv["output-path"])
+                        : join(AbsoluteFilePath.of(process.cwd()), RelativeFilePath.of(argv["output-path"]))
+                    : undefined
             });
         }
     );

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -22,17 +22,19 @@ export async function runWithCustomFixture({
     workspace,
     logLevel,
     audience,
-    skipScripts
+    skipScripts,
+    outputPath
 }: {
     pathToFixture: AbsoluteFilePath;
     workspace: GeneratorWorkspace;
     logLevel: LogLevel;
     audience: string | undefined;
     skipScripts: boolean | undefined;
+    outputPath?: AbsoluteFilePath;
 }): Promise<void> {
     const lock = new Semaphore(1);
-    const outputDir = await tmp.dir();
-    const absolutePathToOutput = AbsoluteFilePath.of(outputDir.path);
+    const absolutePathToOutput = outputPath ?? AbsoluteFilePath.of((await tmp.dir()).path);
+
     const taskContextFactory = new TaskContextFactory(logLevel);
     const customFixtureConfig = workspace.workspaceConfig.customFixtureConfig;
 


### PR DESCRIPTION
## Description
`seed run` writes to a generated tmp dir.

Allow the user to specify an output dir, for repeatability.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Add `--output-path` option to seed run

## Testing
<!-- Describe how you tested these changes -->

- [x] Manual testing completed

