### PR TITLE
fix(docs): Update 2025-07-10.mdx to use backslash to escape tags

### DIFF
--- a/fern/pages/changelogs/php-sdk/2025-07-10.mdx
+++ b/fern/pages/changelogs/php-sdk/2025-07-10.mdx
@@ -1,6 +1,6 @@
 ## 1.16.5
 **`(fix):`** Fix duplicate array types in undiscriminated union properties. Previously, nested unions 
-containing different array types (e.g., array<string, mixed> and array<Recipient>) would 
+containing different array types (e.g., `array<string, mixed>` and `array<Recipient>`) would 
 generate duplicate array annotations in PHP union types (array|array|null). The fix implements 
 recursive union flattening with proper deduplication during type generation.
 


### PR DESCRIPTION
## Description
Latest changelog did not escape < and > tags with backslashes

## Changes Made
```
[docs]:            Failed to parse pages/changelogs/php-sdk/2025-07-10.mdx: Unexpected character `,` (U+002C) in name, expected a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag
[docs]:            Failed to read docs configuration. Rendering blank page.
[docs]:            Unexpected character `,` (U+002C) in name, expected a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag
```
Running `fern docs dev` locally would produce the error above, so I added 
```
`array<string, mixed>` and `array<Recipient>`
```
to wrap the brackets with backslashes.


## Testing
Ran `fern docs dev` and `fern check`

