### PR TITLE
docs: Clarify API definition formats and improve readability

### DIFF
--- a/fern/pages/api-definition/introduction/what-is-an-api-definition.mdx
+++ b/fern/pages/api-definition/introduction/what-is-an-api-definition.mdx
@@ -8,7 +8,7 @@ An API Definition is a document that defines the structure of the API. It includ
 **request and response schemas**, and **authentication** requirements.
 </Info>
 
-Fern integrates with several API definition formats: 
+Fern integrates with several API definition formats. Those API Definition formats are called OpenAPI, AsyncAPI and gRPC.
 
 <AccordionGroup>
   <Accordion
@@ -257,11 +257,9 @@ Fern integrates with several API definition formats:
   </Accordion>
 </AccordionGroup>
 
-## Why create an API Definition ? 
+## Why create an API Definition ?
 
-Once you have an API definition, Fern will use it as an input to generate artifacts 
-like SDKs and API Reference documentation. Every time you update the API definition,
-you can regenerate these artifacts and ensure they are always up-to-date.
+Once you have an API definition, Fern will use it as an input to generate artifacts like SDKs and API Reference documentation. Every time you update the API definition, you can regenerate these artifacts and ensure they are always up-to-date.
 
 <CardGroup cols={2}>
   <Card


### PR DESCRIPTION

This PR enhances the documentation around API definitions by explicitly naming the supported formats (OpenAPI, AsyncAPI, and gRPC) and improves readability through text formatting adjustments. The changes make it clearer for users to understand what API definition formats are supported by Fern right from the start. Additionally, some text formatting has been cleaned up to ensure consistent line breaks and spacing throughout the document.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)