### PR TITLE
fix(docs): reintroduced launch callout

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "fern",
-  "version": "0.64.12"
+  "version": "0.65.13"
 }

--- a/fern/pages/docs/components/callouts.mdx
+++ b/fern/pages/docs/components/callouts.mdx
@@ -51,12 +51,12 @@ This Callout uses a title and a custom icon.
 
 ## Callout varieties
 
-### Note callouts
+### Info callouts
 
-<Note>This adds a note in the content</Note>
+<Info>This draws attention to important information</Info>
 
 ```jsx
-<Note>This adds a note in the content</Note>
+<Info>This draws attention to important information</Info>
 ```
 
 ### Warning callouts
@@ -83,12 +83,20 @@ This Callout uses a title and a custom icon.
 <Error>This indicates a potential error</Error>
 ```
 
-### Info callouts
+### Note callouts
 
-<Info>This draws attention to important information</Info>
+<Note>This adds a note in the content</Note>
 
 ```jsx
-<Info>This draws attention to important information</Info>
+<Note>This adds a note in the content</Note>
+```
+
+### Launch callouts
+
+<Launch>This indicates a launch or new feature announcement</Launch>
+
+```jsx
+<Launch>This indicates a launch or new feature announcement</Launch>
 ```
 
 ### Tip callouts


### PR DESCRIPTION
## Description
The Launch Callout was not documented, this PR documents this and reorganizes the callouts in the order that they are mentioned in the docs

## Changes Made
Added an example of a launch callout and reordered the callouts mentioned in the docs

## Testing
Ran `fern docs dev`

