### PR TITLE
fix(cli): create a tmp config for buf export, ignore buf.yaml and buf.gen.yaml from source

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        Ignore buf.yaml and buf.gen.yaml when copying/exporting protobuf files.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-07-15"
+  version: 0.65.14
+
+- changelogEntry:
+    - summary: |  
         Add support for specifying target protobuf files for gRPC docs generation.
       type: feat
   irVersion: 58

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
@@ -144,7 +144,10 @@ export class ProtobufIRGenerator {
         // Copy the entire protobuf root, excluding buf.yaml and buf.gen.yaml, to a temp directory
         await cp(absoluteFilepathToProtobufRoot, protobufGeneratorConfigPath, {
             recursive: true,
-            filter: (src) => !src.includes("buf.yaml") && !src.includes("buf.gen.yaml")
+            filter: (src) => {
+              const basename = path.basename(src)
+              return basename !== "buf.yaml" && basename !== "buf.gen.yaml"
+            }
         });
     }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
@@ -6,6 +6,7 @@ import { createLoggingExecutable, runExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
 
 import {
+    PROTOBUF_EXPORT_CONFIG,
     PROTOBUF_GENERATOR_CONFIG_FILENAME,
     PROTOBUF_GENERATOR_OUTPUT_FILEPATH,
     PROTOBUF_GEN_CONFIG,
@@ -108,15 +109,29 @@ export class ProtobufIRGenerator {
             );
         }
 
+        // Create a temporary buf config file to prevent conflicts
+        const tmpBufConfigFile = await tmp.file({ postfix: ".yaml" });
+        await writeFile(tmpBufConfigFile.path, PROTOBUF_EXPORT_CONFIG, "utf8");
+
         await runExeca(
             this.context.logger,
             "buf",
-            ["export", "--path", absoluteFilepathToProtobufTarget, "--output", protobufGeneratorConfigPath],
+            [
+                "export",
+                "--path",
+                absoluteFilepathToProtobufTarget,
+                "--config",
+                AbsoluteFilePath.of(tmpBufConfigFile.path),
+                "--output",
+                protobufGeneratorConfigPath
+            ],
             {
                 cwd: absoluteFilepathToProtobufRoot,
                 stdio: "ignore"
             }
         );
+
+        await tmpBufConfigFile.cleanup();
     }
 
     private async copyProtobufFilesFromRoot({
@@ -126,8 +141,11 @@ export class ProtobufIRGenerator {
         protobufGeneratorConfigPath: AbsoluteFilePath;
         absoluteFilepathToProtobufRoot: AbsoluteFilePath;
     }): Promise<void> {
-        // Copy the entire protobuf root to a temp directory
-        await cp(absoluteFilepathToProtobufRoot, protobufGeneratorConfigPath, { recursive: true });
+        // Copy the entire protobuf root, excluding buf.yaml and buf.gen.yaml, to a temp directory
+        await cp(absoluteFilepathToProtobufRoot, protobufGeneratorConfigPath, {
+            recursive: true,
+            filter: (src) => !src.includes("buf.yaml") && !src.includes("buf.gen.yaml")
+        });
     }
 
     private async setupRemainingProtobufConfig({

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
@@ -1,4 +1,5 @@
 import { chmod, cp, writeFile } from "fs/promises";
+import path from "path";
 import tmp from "tmp-promise";
 
 import { AbsoluteFilePath, RelativeFilePath, join } from "@fern-api/fs-utils";
@@ -145,8 +146,8 @@ export class ProtobufIRGenerator {
         await cp(absoluteFilepathToProtobufRoot, protobufGeneratorConfigPath, {
             recursive: true,
             filter: (src) => {
-              const basename = path.basename(src)
-              return basename !== "buf.yaml" && basename !== "buf.gen.yaml"
+                const basename = path.basename(src);
+                return basename !== "buf.yaml" && basename !== "buf.gen.yaml";
             }
         });
     }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
@@ -4,7 +4,8 @@ export const PROTOBUF_GENERATOR_CONFIG_FILENAME = "buf.gen.yaml";
 export const PROTOBUF_GENERATOR_OUTPUT_PATH = "output";
 export const PROTOBUF_GENERATOR_OUTPUT_FILEPATH = `${PROTOBUF_GENERATOR_OUTPUT_PATH}/ir.json`;
 export const PROTOBUF_SHELL_PROXY_FILENAME = "protoc-gen-fern";
-
+export const PROTOBUF_EXPORT_CONFIG = `version: v2
+`;
 export const PROTOBUF_GEN_CONFIG = `version: v2
 plugins:
   - local: ["bash", "./protoc-gen-fern"]


### PR DESCRIPTION
## Description
- create a tmp `buf.yaml` config for buf export
- ignore `buf.yaml` and `buf.gen.yaml` files when copying root from source

## Testing
- [X] Unit tests added/updated
- [X] Manual testing completed

