### PR TITLE
docs: Fix formatting and whitespace in REST API documentation

### DIFF
--- a/fern/pages/api-definition/openapi/endpoints/rest.mdx
+++ b/fern/pages/api-definition/openapi/endpoints/rest.mdx
@@ -3,8 +3,8 @@ title: HTTP JSON Endpoints
 subtitle: Document HTTP JSON APIs with the `application/json` content type
 ---
 
-Endpoints in OpenAPI are defined underneath the `paths` key. Below is an example of defining 
-a single endpoint: 
+Endpoints in OpenAPI are defined underneath the `paths` key. Below is an example of defining
+a single endpoint:
 
 ```yml title="openapi.yml" maxLines=0 {2-18}
 paths:
@@ -29,7 +29,9 @@ paths:
 
 ## Examples
 
-You can provide examples of requests and responses by using the `examples` key.   
+
+
+You can provide examples of requests and responses by using the `examples` key.
 
 ```yaml title="openapi.yml" {12-17,25-30}
 paths:


### PR DESCRIPTION

This PR makes minor formatting improvements to the REST API documentation by:
- Removing trailing whitespace
- Fixing line spacing consistency
- Cleaning up empty lines in the Examples section

The changes are purely cosmetic and do not modify any technical content.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)