### PR TITLE
feat(cli): use convertGrpcReferenceToTypeReference for message fields that are enums

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |  
+        Fix enum type reference conversions for protobuf docs generation.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-07-15"
+  version: 0.65.15
+
+- changelogEntry:
+    - summary: |  
         Ignore buf.yaml and buf.gen.yaml when copying/exporting protobuf files.
       type: fix
   irVersion: 58

--- a/packages/cli/generation/protoc-gen-fern/src/converters/message/FieldConverter.ts
+++ b/packages/cli/generation/protoc-gen-fern/src/converters/message/FieldConverter.ts
@@ -74,7 +74,7 @@ export class FieldConverter extends AbstractConverter<ProtofileConverterContext,
             }
         }
 
-        if (this.field.type === 11 && this.field.typeName != null) {
+        if ((this.field.type === 11 || this.field.type === 14) && this.field.typeName != null) {
             const typeReference = this.context.convertGrpcReferenceToTypeReference({
                 typeName: this.field.typeName,
                 displayNameOverride: this.field.name

--- a/packages/cli/generation/protoc-gen-fern/src/converters/message/FieldConverter.ts
+++ b/packages/cli/generation/protoc-gen-fern/src/converters/message/FieldConverter.ts
@@ -1,4 +1,4 @@
-import { FieldDescriptorProto } from "@bufbuild/protobuf/wkt";
+import { FieldDescriptorProto, FieldDescriptorProto_Type } from "@bufbuild/protobuf/wkt";
 
 import { Availability, ContainerType, TypeReference } from "@fern-api/ir-sdk";
 import { AbstractConverter } from "@fern-api/v2-importer-commons";
@@ -74,7 +74,11 @@ export class FieldConverter extends AbstractConverter<ProtofileConverterContext,
             }
         }
 
-        if ((this.field.type === 11 || this.field.type === 14) && this.field.typeName != null) {
+        if (
+            (this.field.type === FieldDescriptorProto_Type.MESSAGE ||
+                this.field.type === FieldDescriptorProto_Type.ENUM) &&
+            this.field.typeName != null
+        ) {
             const typeReference = this.context.convertGrpcReferenceToTypeReference({
                 typeName: this.field.typeName,
                 displayNameOverride: this.field.name

--- a/packages/cli/generation/protoc-gen-fern/tests/simple/output/ir.json
+++ b/packages/cli/generation/protoc-gen-fern/tests/simple/output/ir.json
@@ -618,6 +618,71 @@
           {
             "name": {
               "name": {
+                "originalName": "level",
+                "camelCase": {
+                  "unsafeName": "level",
+                  "safeName": "level"
+                },
+                "snakeCase": {
+                  "unsafeName": "level",
+                  "safeName": "level"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "LEVEL",
+                  "safeName": "LEVEL"
+                },
+                "pascalCase": {
+                  "unsafeName": "Level",
+                  "safeName": "Level"
+                }
+              },
+              "wireValue": "level"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.ClassificationLevels",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1ClassificationLevels",
+                      "safeName": "andurilEntitymanagerV1ClassificationLevels"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_classification_levels",
+                      "safeName": "anduril_entitymanager_v_1_classification_levels"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_CLASSIFICATION_LEVELS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_CLASSIFICATION_LEVELS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1ClassificationLevels",
+                      "safeName": "AndurilEntitymanagerV1ClassificationLevels"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.ClassificationLevels",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "level"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Classification level to be applied to the information in question."
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "caveats",
                 "camelCase": {
                   "unsafeName": "caveats",
@@ -1360,6 +1425,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "[default=false] indicates that altitude is either unset or so uncertain that it is meaningless"
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "altitude_reference",
+                "camelCase": {
+                  "unsafeName": "altitudeReference",
+                  "safeName": "altitudeReference"
+                },
+                "snakeCase": {
+                  "unsafeName": "altitude_reference",
+                  "safeName": "altitude_reference"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "ALTITUDE_REFERENCE",
+                  "safeName": "ALTITUDE_REFERENCE"
+                },
+                "pascalCase": {
+                  "unsafeName": "AltitudeReference",
+                  "safeName": "AltitudeReference"
+                }
+              },
+              "wireValue": "altitude_reference"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.type.LLA.AltitudeReference",
+                    "camelCase": {
+                      "unsafeName": "andurilTypeLlaAltitudeReference",
+                      "safeName": "andurilTypeLlaAltitudeReference"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_type_lla_altitude_reference",
+                      "safeName": "anduril_type_lla_altitude_reference"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TYPE_LLA_ALTITUDE_REFERENCE",
+                      "safeName": "ANDURIL_TYPE_LLA_ALTITUDE_REFERENCE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTypeLlaAltitudeReference",
+                      "safeName": "AndurilTypeLlaAltitudeReference"
+                    }
+                  },
+                  "typeId": "anduril.type.LLA.AltitudeReference",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "altitude_reference"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Meaning of alt.\n altitude in meters above either WGS84 or EGM96, use altitude_reference to\n determine what zero means."
           }
         ],
         "extends": [],
@@ -8090,7 +8220,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "type",
+                "camelCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "snakeCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TYPE",
+                  "safeName": "TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Type",
+                  "safeName": "Type"
+                }
+              },
+              "wireValue": "type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.GeoType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1GeoType",
+                      "safeName": "andurilEntitymanagerV1GeoType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_geo_type",
+                      "safeName": "anduril_entitymanager_v_1_geo_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_GEO_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_GEO_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1GeoType",
+                      "safeName": "AndurilEntitymanagerV1GeoType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.GeoType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -10344,7 +10540,42 @@
       },
       "shape": {
         "_type": "undiscriminatedUnion",
-        "members": []
+        "members": [
+          {
+            "type": {
+              "_type": "named",
+              "fernFilepath": {
+                "allParts": [],
+                "packagePath": [],
+                "file": null
+              },
+              "name": {
+                "originalName": "anduril.entitymanager.v1.ArmyEchelon",
+                "camelCase": {
+                  "unsafeName": "andurilEntitymanagerV1ArmyEchelon",
+                  "safeName": "andurilEntitymanagerV1ArmyEchelon"
+                },
+                "snakeCase": {
+                  "unsafeName": "anduril_entitymanager_v_1_army_echelon",
+                  "safeName": "anduril_entitymanager_v_1_army_echelon"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_ARMY_ECHELON",
+                  "safeName": "ANDURIL_ENTITYMANAGER_V_1_ARMY_ECHELON"
+                },
+                "pascalCase": {
+                  "unsafeName": "AndurilEntitymanagerV1ArmyEchelon",
+                  "safeName": "AndurilEntitymanagerV1ArmyEchelon"
+                }
+              },
+              "typeId": "anduril.entitymanager.v1.ArmyEchelon",
+              "default": null,
+              "inline": false,
+              "displayName": "army_echelon"
+            },
+            "docs": null
+          }
+        ]
       },
       "autogeneratedExamples": [],
       "userProvidedExamples": [],
@@ -11115,6 +11346,71 @@
           {
             "name": {
               "name": {
+                "originalName": "status",
+                "camelCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "snakeCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "STATUS",
+                  "safeName": "STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "Status",
+                  "safeName": "Status"
+                }
+              },
+              "wireValue": "status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.HealthStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1HealthStatus",
+                      "safeName": "andurilEntitymanagerV1HealthStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_health_status",
+                      "safeName": "anduril_entitymanager_v_1_health_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_HEALTH_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_HEALTH_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1HealthStatus",
+                      "safeName": "AndurilEntitymanagerV1HealthStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.HealthStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The status associated with this message."
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "message",
                 "camelCase": {
                   "unsafeName": "message",
@@ -11296,6 +11592,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Display name for this component."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "health",
+                "camelCase": {
+                  "unsafeName": "health",
+                  "safeName": "health"
+                },
+                "snakeCase": {
+                  "unsafeName": "health",
+                  "safeName": "health"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "HEALTH",
+                  "safeName": "HEALTH"
+                },
+                "pascalCase": {
+                  "unsafeName": "Health",
+                  "safeName": "Health"
+                }
+              },
+              "wireValue": "health"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.HealthStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1HealthStatus",
+                      "safeName": "andurilEntitymanagerV1HealthStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_health_status",
+                      "safeName": "anduril_entitymanager_v_1_health_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_HEALTH_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_HEALTH_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1HealthStatus",
+                      "safeName": "AndurilEntitymanagerV1HealthStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.HealthStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "health"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Health for this component."
           },
           {
             "name": {
@@ -11489,6 +11850,136 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "connection_status",
+                "camelCase": {
+                  "unsafeName": "connectionStatus",
+                  "safeName": "connectionStatus"
+                },
+                "snakeCase": {
+                  "unsafeName": "connection_status",
+                  "safeName": "connection_status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "CONNECTION_STATUS",
+                  "safeName": "CONNECTION_STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "ConnectionStatus",
+                  "safeName": "ConnectionStatus"
+                }
+              },
+              "wireValue": "connection_status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.ConnectionStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1ConnectionStatus",
+                      "safeName": "andurilEntitymanagerV1ConnectionStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_connection_status",
+                      "safeName": "anduril_entitymanager_v_1_connection_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_CONNECTION_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_CONNECTION_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1ConnectionStatus",
+                      "safeName": "AndurilEntitymanagerV1ConnectionStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.ConnectionStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "connection_status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Status indicating whether the entity is able to communicate with Entity Manager."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "health_status",
+                "camelCase": {
+                  "unsafeName": "healthStatus",
+                  "safeName": "healthStatus"
+                },
+                "snakeCase": {
+                  "unsafeName": "health_status",
+                  "safeName": "health_status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "HEALTH_STATUS",
+                  "safeName": "HEALTH_STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "HealthStatus",
+                  "safeName": "HealthStatus"
+                }
+              },
+              "wireValue": "health_status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.HealthStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1HealthStatus",
+                      "safeName": "andurilEntitymanagerV1HealthStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_health_status",
+                      "safeName": "anduril_entitymanager_v_1_health_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_HEALTH_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_HEALTH_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1HealthStatus",
+                      "safeName": "AndurilEntitymanagerV1HealthStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.HealthStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "health_status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Top-level health status; typically a roll-up of individual component healths."
+          },
           {
             "name": {
               "name": {
@@ -11847,6 +12338,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Human-readable description of this alert. The description is intended for display in the UI for human\n understanding and should not be used for machine processing. If the description is fixed and the vehicle controller\n provides no dynamic substitutions, then prefer lookup based on alert_code."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "level",
+                "camelCase": {
+                  "unsafeName": "level",
+                  "safeName": "level"
+                },
+                "snakeCase": {
+                  "unsafeName": "level",
+                  "safeName": "level"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "LEVEL",
+                  "safeName": "LEVEL"
+                },
+                "pascalCase": {
+                  "unsafeName": "Level",
+                  "safeName": "Level"
+                }
+              },
+              "wireValue": "level"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.AlertLevel",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1AlertLevel",
+                      "safeName": "andurilEntitymanagerV1AlertLevel"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_alert_level",
+                      "safeName": "anduril_entitymanager_v_1_alert_level"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_ALERT_LEVEL",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_ALERT_LEVEL"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1AlertLevel",
+                      "safeName": "AndurilEntitymanagerV1AlertLevel"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.AlertLevel",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "level"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Alert level (Warning, Caution, or Advisory)."
           },
           {
             "name": {
@@ -13400,6 +13956,71 @@
                       "validation": null
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "edition",
+                "camelCase": {
+                  "unsafeName": "edition",
+                  "safeName": "edition"
+                },
+                "snakeCase": {
+                  "unsafeName": "edition",
+                  "safeName": "edition"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EDITION",
+                  "safeName": "EDITION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Edition",
+                  "safeName": "Edition"
+                }
+              },
+              "wireValue": "edition"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "edition"
                 }
               }
             },
@@ -15147,6 +15768,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "verification",
+                "camelCase": {
+                  "unsafeName": "verification",
+                  "safeName": "verification"
+                },
+                "snakeCase": {
+                  "unsafeName": "verification",
+                  "safeName": "verification"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "VERIFICATION",
+                  "safeName": "VERIFICATION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Verification",
+                  "safeName": "Verification"
+                }
+              },
+              "wireValue": "verification"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.ExtensionRangeOptions.VerificationState",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufExtensionRangeOptionsVerificationState",
+                      "safeName": "googleProtobufExtensionRangeOptionsVerificationState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_extension_range_options_verification_state",
+                      "safeName": "google_protobuf_extension_range_options_verification_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EXTENSION_RANGE_OPTIONS_VERIFICATION_STATE",
+                      "safeName": "GOOGLE_PROTOBUF_EXTENSION_RANGE_OPTIONS_VERIFICATION_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufExtensionRangeOptionsVerificationState",
+                      "safeName": "GoogleProtobufExtensionRangeOptionsVerificationState"
+                    }
+                  },
+                  "typeId": "google.protobuf.ExtensionRangeOptions.VerificationState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "verification"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
           }
         ],
         "extends": [],
@@ -15916,6 +16602,136 @@
                       "validation": null
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "label",
+                "camelCase": {
+                  "unsafeName": "label",
+                  "safeName": "label"
+                },
+                "snakeCase": {
+                  "unsafeName": "label",
+                  "safeName": "label"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "LABEL",
+                  "safeName": "LABEL"
+                },
+                "pascalCase": {
+                  "unsafeName": "Label",
+                  "safeName": "Label"
+                }
+              },
+              "wireValue": "label"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FieldDescriptorProto.Label",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFieldDescriptorProtoLabel",
+                      "safeName": "googleProtobufFieldDescriptorProtoLabel"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_field_descriptor_proto_label",
+                      "safeName": "google_protobuf_field_descriptor_proto_label"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FIELD_DESCRIPTOR_PROTO_LABEL",
+                      "safeName": "GOOGLE_PROTOBUF_FIELD_DESCRIPTOR_PROTO_LABEL"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFieldDescriptorProtoLabel",
+                      "safeName": "GoogleProtobufFieldDescriptorProtoLabel"
+                    }
+                  },
+                  "typeId": "google.protobuf.FieldDescriptorProto.Label",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "label"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "type",
+                "camelCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "snakeCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TYPE",
+                  "safeName": "TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Type",
+                  "safeName": "Type"
+                }
+              },
+              "wireValue": "type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FieldDescriptorProto.Type",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFieldDescriptorProtoType",
+                      "safeName": "googleProtobufFieldDescriptorProtoType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_field_descriptor_proto_type",
+                      "safeName": "google_protobuf_field_descriptor_proto_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FIELD_DESCRIPTOR_PROTO_TYPE",
+                      "safeName": "GOOGLE_PROTOBUF_FIELD_DESCRIPTOR_PROTO_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFieldDescriptorProtoType",
+                      "safeName": "GoogleProtobufFieldDescriptorProtoType"
+                    }
+                  },
+                  "typeId": "google.protobuf.FieldDescriptorProto.Type",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "type"
                 }
               }
             },
@@ -18107,6 +18923,71 @@
           {
             "name": {
               "name": {
+                "originalName": "optimize_for",
+                "camelCase": {
+                  "unsafeName": "optimizeFor",
+                  "safeName": "optimizeFor"
+                },
+                "snakeCase": {
+                  "unsafeName": "optimize_for",
+                  "safeName": "optimize_for"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "OPTIMIZE_FOR",
+                  "safeName": "OPTIMIZE_FOR"
+                },
+                "pascalCase": {
+                  "unsafeName": "OptimizeFor",
+                  "safeName": "OptimizeFor"
+                }
+              },
+              "wireValue": "optimize_for"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FileOptions.OptimizeMode",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFileOptionsOptimizeMode",
+                      "safeName": "googleProtobufFileOptionsOptimizeMode"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_file_options_optimize_mode",
+                      "safeName": "google_protobuf_file_options_optimize_mode"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FILE_OPTIONS_OPTIMIZE_MODE",
+                      "safeName": "GOOGLE_PROTOBUF_FILE_OPTIONS_OPTIMIZE_MODE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFileOptionsOptimizeMode",
+                      "safeName": "GoogleProtobufFileOptionsOptimizeMode"
+                    }
+                  },
+                  "typeId": "google.protobuf.FileOptions.OptimizeMode",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "optimize_for"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "go_package",
                 "camelCase": {
                   "unsafeName": "goPackage",
@@ -19291,6 +20172,71 @@
           {
             "name": {
               "name": {
+                "originalName": "edition",
+                "camelCase": {
+                  "unsafeName": "edition",
+                  "safeName": "edition"
+                },
+                "snakeCase": {
+                  "unsafeName": "edition",
+                  "safeName": "edition"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EDITION",
+                  "safeName": "EDITION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Edition",
+                  "safeName": "Edition"
+                }
+              },
+              "wireValue": "edition"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "edition"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "value",
                 "camelCase": {
                   "unsafeName": "value",
@@ -19386,6 +20332,136 @@
           {
             "name": {
               "name": {
+                "originalName": "edition_introduced",
+                "camelCase": {
+                  "unsafeName": "editionIntroduced",
+                  "safeName": "editionIntroduced"
+                },
+                "snakeCase": {
+                  "unsafeName": "edition_introduced",
+                  "safeName": "edition_introduced"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EDITION_INTRODUCED",
+                  "safeName": "EDITION_INTRODUCED"
+                },
+                "pascalCase": {
+                  "unsafeName": "EditionIntroduced",
+                  "safeName": "EditionIntroduced"
+                }
+              },
+              "wireValue": "edition_introduced"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "edition_introduced"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "edition_deprecated",
+                "camelCase": {
+                  "unsafeName": "editionDeprecated",
+                  "safeName": "editionDeprecated"
+                },
+                "snakeCase": {
+                  "unsafeName": "edition_deprecated",
+                  "safeName": "edition_deprecated"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EDITION_DEPRECATED",
+                  "safeName": "EDITION_DEPRECATED"
+                },
+                "pascalCase": {
+                  "unsafeName": "EditionDeprecated",
+                  "safeName": "EditionDeprecated"
+                }
+              },
+              "wireValue": "edition_deprecated"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "edition_deprecated"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "deprecation_warning",
                 "camelCase": {
                   "unsafeName": "deprecationWarning",
@@ -19420,6 +20496,71 @@
                       "validation": null
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "edition_removed",
+                "camelCase": {
+                  "unsafeName": "editionRemoved",
+                  "safeName": "editionRemoved"
+                },
+                "snakeCase": {
+                  "unsafeName": "edition_removed",
+                  "safeName": "edition_removed"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EDITION_REMOVED",
+                  "safeName": "EDITION_REMOVED"
+                },
+                "pascalCase": {
+                  "unsafeName": "EditionRemoved",
+                  "safeName": "EditionRemoved"
+                }
+              },
+              "wireValue": "edition_removed"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "edition_removed"
                 }
               }
             },
@@ -20155,6 +21296,71 @@
           {
             "name": {
               "name": {
+                "originalName": "ctype",
+                "camelCase": {
+                  "unsafeName": "ctype",
+                  "safeName": "ctype"
+                },
+                "snakeCase": {
+                  "unsafeName": "ctype",
+                  "safeName": "ctype"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "CTYPE",
+                  "safeName": "CTYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Ctype",
+                  "safeName": "Ctype"
+                }
+              },
+              "wireValue": "ctype"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FieldOptions.CType",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFieldOptionsCType",
+                      "safeName": "googleProtobufFieldOptionsCType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_field_options_c_type",
+                      "safeName": "google_protobuf_field_options_c_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_C_TYPE",
+                      "safeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_C_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFieldOptionsCType",
+                      "safeName": "GoogleProtobufFieldOptionsCType"
+                    }
+                  },
+                  "typeId": "google.protobuf.FieldOptions.CType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "ctype"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "packed",
                 "camelCase": {
                   "unsafeName": "packed",
@@ -20188,6 +21394,71 @@
                       "default": null
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "jstype",
+                "camelCase": {
+                  "unsafeName": "jstype",
+                  "safeName": "jstype"
+                },
+                "snakeCase": {
+                  "unsafeName": "jstype",
+                  "safeName": "jstype"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "JSTYPE",
+                  "safeName": "JSTYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Jstype",
+                  "safeName": "Jstype"
+                }
+              },
+              "wireValue": "jstype"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FieldOptions.JSType",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFieldOptionsJsType",
+                      "safeName": "googleProtobufFieldOptionsJsType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_field_options_js_type",
+                      "safeName": "google_protobuf_field_options_js_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_JS_TYPE",
+                      "safeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_JS_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFieldOptionsJsType",
+                      "safeName": "GoogleProtobufFieldOptionsJsType"
+                    }
+                  },
+                  "typeId": "google.protobuf.FieldOptions.JSType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "jstype"
                 }
               }
             },
@@ -20419,6 +21690,71 @@
           {
             "name": {
               "name": {
+                "originalName": "retention",
+                "camelCase": {
+                  "unsafeName": "retention",
+                  "safeName": "retention"
+                },
+                "snakeCase": {
+                  "unsafeName": "retention",
+                  "safeName": "retention"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "RETENTION",
+                  "safeName": "RETENTION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Retention",
+                  "safeName": "Retention"
+                }
+              },
+              "wireValue": "retention"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FieldOptions.OptionRetention",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFieldOptionsOptionRetention",
+                      "safeName": "googleProtobufFieldOptionsOptionRetention"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_field_options_option_retention",
+                      "safeName": "google_protobuf_field_options_option_retention"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_OPTION_RETENTION",
+                      "safeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_OPTION_RETENTION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFieldOptionsOptionRetention",
+                      "safeName": "GoogleProtobufFieldOptionsOptionRetention"
+                    }
+                  },
+                  "typeId": "google.protobuf.FieldOptions.OptionRetention",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "retention"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "targets",
                 "camelCase": {
                   "unsafeName": "targets",
@@ -20448,7 +21784,41 @@
                   "container": {
                     "_type": "list",
                     "list": {
-                      "_type": "unknown"
+                      "_type": "container",
+                      "container": {
+                        "_type": "optional",
+                        "optional": {
+                          "_type": "named",
+                          "fernFilepath": {
+                            "allParts": [],
+                            "packagePath": [],
+                            "file": null
+                          },
+                          "name": {
+                            "originalName": "google.protobuf.FieldOptions.OptionTargetType",
+                            "camelCase": {
+                              "unsafeName": "googleProtobufFieldOptionsOptionTargetType",
+                              "safeName": "googleProtobufFieldOptionsOptionTargetType"
+                            },
+                            "snakeCase": {
+                              "unsafeName": "google_protobuf_field_options_option_target_type",
+                              "safeName": "google_protobuf_field_options_option_target_type"
+                            },
+                            "screamingSnakeCase": {
+                              "unsafeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_OPTION_TARGET_TYPE",
+                              "safeName": "GOOGLE_PROTOBUF_FIELD_OPTIONS_OPTION_TARGET_TYPE"
+                            },
+                            "pascalCase": {
+                              "unsafeName": "GoogleProtobufFieldOptionsOptionTargetType",
+                              "safeName": "GoogleProtobufFieldOptionsOptionTargetType"
+                            }
+                          },
+                          "typeId": "google.protobuf.FieldOptions.OptionTargetType",
+                          "default": null,
+                          "inline": false,
+                          "displayName": "targets"
+                        }
+                      }
                     }
                   }
                 }
@@ -22060,6 +23430,71 @@
           {
             "name": {
               "name": {
+                "originalName": "idempotency_level",
+                "camelCase": {
+                  "unsafeName": "idempotencyLevel",
+                  "safeName": "idempotencyLevel"
+                },
+                "snakeCase": {
+                  "unsafeName": "idempotency_level",
+                  "safeName": "idempotency_level"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "IDEMPOTENCY_LEVEL",
+                  "safeName": "IDEMPOTENCY_LEVEL"
+                },
+                "pascalCase": {
+                  "unsafeName": "IdempotencyLevel",
+                  "safeName": "IdempotencyLevel"
+                }
+              },
+              "wireValue": "idempotency_level"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.MethodOptions.IdempotencyLevel",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufMethodOptionsIdempotencyLevel",
+                      "safeName": "googleProtobufMethodOptionsIdempotencyLevel"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_method_options_idempotency_level",
+                      "safeName": "google_protobuf_method_options_idempotency_level"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_METHOD_OPTIONS_IDEMPOTENCY_LEVEL",
+                      "safeName": "GOOGLE_PROTOBUF_METHOD_OPTIONS_IDEMPOTENCY_LEVEL"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufMethodOptionsIdempotencyLevel",
+                      "safeName": "GoogleProtobufMethodOptionsIdempotencyLevel"
+                    }
+                  },
+                  "typeId": "google.protobuf.MethodOptions.IdempotencyLevel",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "idempotency_level"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "features",
                 "camelCase": {
                   "unsafeName": "features",
@@ -23660,7 +25095,463 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "field_presence",
+                "camelCase": {
+                  "unsafeName": "fieldPresence",
+                  "safeName": "fieldPresence"
+                },
+                "snakeCase": {
+                  "unsafeName": "field_presence",
+                  "safeName": "field_presence"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "FIELD_PRESENCE",
+                  "safeName": "FIELD_PRESENCE"
+                },
+                "pascalCase": {
+                  "unsafeName": "FieldPresence",
+                  "safeName": "FieldPresence"
+                }
+              },
+              "wireValue": "field_presence"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.FieldPresence",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetFieldPresence",
+                      "safeName": "googleProtobufFeatureSetFieldPresence"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_field_presence",
+                      "safeName": "google_protobuf_feature_set_field_presence"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_FIELD_PRESENCE",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_FIELD_PRESENCE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetFieldPresence",
+                      "safeName": "GoogleProtobufFeatureSetFieldPresence"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.FieldPresence",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "field_presence"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "enum_type",
+                "camelCase": {
+                  "unsafeName": "enumType",
+                  "safeName": "enumType"
+                },
+                "snakeCase": {
+                  "unsafeName": "enum_type",
+                  "safeName": "enum_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "ENUM_TYPE",
+                  "safeName": "ENUM_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "EnumType",
+                  "safeName": "EnumType"
+                }
+              },
+              "wireValue": "enum_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.EnumType",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetEnumType",
+                      "safeName": "googleProtobufFeatureSetEnumType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_enum_type",
+                      "safeName": "google_protobuf_feature_set_enum_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_ENUM_TYPE",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_ENUM_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetEnumType",
+                      "safeName": "GoogleProtobufFeatureSetEnumType"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.EnumType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "enum_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "repeated_field_encoding",
+                "camelCase": {
+                  "unsafeName": "repeatedFieldEncoding",
+                  "safeName": "repeatedFieldEncoding"
+                },
+                "snakeCase": {
+                  "unsafeName": "repeated_field_encoding",
+                  "safeName": "repeated_field_encoding"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "REPEATED_FIELD_ENCODING",
+                  "safeName": "REPEATED_FIELD_ENCODING"
+                },
+                "pascalCase": {
+                  "unsafeName": "RepeatedFieldEncoding",
+                  "safeName": "RepeatedFieldEncoding"
+                }
+              },
+              "wireValue": "repeated_field_encoding"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.RepeatedFieldEncoding",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetRepeatedFieldEncoding",
+                      "safeName": "googleProtobufFeatureSetRepeatedFieldEncoding"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_repeated_field_encoding",
+                      "safeName": "google_protobuf_feature_set_repeated_field_encoding"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_REPEATED_FIELD_ENCODING",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_REPEATED_FIELD_ENCODING"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetRepeatedFieldEncoding",
+                      "safeName": "GoogleProtobufFeatureSetRepeatedFieldEncoding"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.RepeatedFieldEncoding",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "repeated_field_encoding"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "utf8_validation",
+                "camelCase": {
+                  "unsafeName": "utf8Validation",
+                  "safeName": "utf8Validation"
+                },
+                "snakeCase": {
+                  "unsafeName": "utf_8_validation",
+                  "safeName": "utf_8_validation"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "UTF_8_VALIDATION",
+                  "safeName": "UTF_8_VALIDATION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Utf8Validation",
+                  "safeName": "Utf8Validation"
+                }
+              },
+              "wireValue": "utf8_validation"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.Utf8Validation",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetUtf8Validation",
+                      "safeName": "googleProtobufFeatureSetUtf8Validation"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_utf_8_validation",
+                      "safeName": "google_protobuf_feature_set_utf_8_validation"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_UTF_8_VALIDATION",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_UTF_8_VALIDATION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetUtf8Validation",
+                      "safeName": "GoogleProtobufFeatureSetUtf8Validation"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.Utf8Validation",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "utf8_validation"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "message_encoding",
+                "camelCase": {
+                  "unsafeName": "messageEncoding",
+                  "safeName": "messageEncoding"
+                },
+                "snakeCase": {
+                  "unsafeName": "message_encoding",
+                  "safeName": "message_encoding"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MESSAGE_ENCODING",
+                  "safeName": "MESSAGE_ENCODING"
+                },
+                "pascalCase": {
+                  "unsafeName": "MessageEncoding",
+                  "safeName": "MessageEncoding"
+                }
+              },
+              "wireValue": "message_encoding"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.MessageEncoding",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetMessageEncoding",
+                      "safeName": "googleProtobufFeatureSetMessageEncoding"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_message_encoding",
+                      "safeName": "google_protobuf_feature_set_message_encoding"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_MESSAGE_ENCODING",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_MESSAGE_ENCODING"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetMessageEncoding",
+                      "safeName": "GoogleProtobufFeatureSetMessageEncoding"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.MessageEncoding",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "message_encoding"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "json_format",
+                "camelCase": {
+                  "unsafeName": "jsonFormat",
+                  "safeName": "jsonFormat"
+                },
+                "snakeCase": {
+                  "unsafeName": "json_format",
+                  "safeName": "json_format"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "JSON_FORMAT",
+                  "safeName": "JSON_FORMAT"
+                },
+                "pascalCase": {
+                  "unsafeName": "JsonFormat",
+                  "safeName": "JsonFormat"
+                }
+              },
+              "wireValue": "json_format"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.JsonFormat",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetJsonFormat",
+                      "safeName": "googleProtobufFeatureSetJsonFormat"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_json_format",
+                      "safeName": "google_protobuf_feature_set_json_format"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_JSON_FORMAT",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_JSON_FORMAT"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetJsonFormat",
+                      "safeName": "GoogleProtobufFeatureSetJsonFormat"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.JsonFormat",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "json_format"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "enforce_naming_style",
+                "camelCase": {
+                  "unsafeName": "enforceNamingStyle",
+                  "safeName": "enforceNamingStyle"
+                },
+                "snakeCase": {
+                  "unsafeName": "enforce_naming_style",
+                  "safeName": "enforce_naming_style"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "ENFORCE_NAMING_STYLE",
+                  "safeName": "ENFORCE_NAMING_STYLE"
+                },
+                "pascalCase": {
+                  "unsafeName": "EnforceNamingStyle",
+                  "safeName": "EnforceNamingStyle"
+                }
+              },
+              "wireValue": "enforce_naming_style"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.FeatureSet.EnforceNamingStyle",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufFeatureSetEnforceNamingStyle",
+                      "safeName": "googleProtobufFeatureSetEnforceNamingStyle"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_feature_set_enforce_naming_style",
+                      "safeName": "google_protobuf_feature_set_enforce_naming_style"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_FEATURE_SET_ENFORCE_NAMING_STYLE",
+                      "safeName": "GOOGLE_PROTOBUF_FEATURE_SET_ENFORCE_NAMING_STYLE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufFeatureSetEnforceNamingStyle",
+                      "safeName": "GoogleProtobufFeatureSetEnforceNamingStyle"
+                    }
+                  },
+                  "typeId": "google.protobuf.FeatureSet.EnforceNamingStyle",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "enforce_naming_style"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -23710,6 +25601,71 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "edition",
+                "camelCase": {
+                  "unsafeName": "edition",
+                  "safeName": "edition"
+                },
+                "snakeCase": {
+                  "unsafeName": "edition",
+                  "safeName": "edition"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EDITION",
+                  "safeName": "EDITION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Edition",
+                  "safeName": "Edition"
+                }
+              },
+              "wireValue": "edition"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "edition"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
           {
             "name": {
               "name": {
@@ -23959,6 +25915,136 @@
                       }
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "minimum_edition",
+                "camelCase": {
+                  "unsafeName": "minimumEdition",
+                  "safeName": "minimumEdition"
+                },
+                "snakeCase": {
+                  "unsafeName": "minimum_edition",
+                  "safeName": "minimum_edition"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MINIMUM_EDITION",
+                  "safeName": "MINIMUM_EDITION"
+                },
+                "pascalCase": {
+                  "unsafeName": "MinimumEdition",
+                  "safeName": "MinimumEdition"
+                }
+              },
+              "wireValue": "minimum_edition"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "minimum_edition"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "maximum_edition",
+                "camelCase": {
+                  "unsafeName": "maximumEdition",
+                  "safeName": "maximumEdition"
+                },
+                "snakeCase": {
+                  "unsafeName": "maximum_edition",
+                  "safeName": "maximum_edition"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MAXIMUM_EDITION",
+                  "safeName": "MAXIMUM_EDITION"
+                },
+                "pascalCase": {
+                  "unsafeName": "MaximumEdition",
+                  "safeName": "MaximumEdition"
+                }
+              },
+              "wireValue": "maximum_edition"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.Edition",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufEdition",
+                      "safeName": "googleProtobufEdition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_edition",
+                      "safeName": "google_protobuf_edition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_EDITION",
+                      "safeName": "GOOGLE_PROTOBUF_EDITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufEdition",
+                      "safeName": "GoogleProtobufEdition"
+                    }
+                  },
+                  "typeId": "google.protobuf.Edition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "maximum_edition"
                 }
               }
             },
@@ -24762,6 +26848,71 @@
                       "validation": null
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "semantic",
+                "camelCase": {
+                  "unsafeName": "semantic",
+                  "safeName": "semantic"
+                },
+                "snakeCase": {
+                  "unsafeName": "semantic",
+                  "safeName": "semantic"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "SEMANTIC",
+                  "safeName": "SEMANTIC"
+                },
+                "pascalCase": {
+                  "unsafeName": "Semantic",
+                  "safeName": "Semantic"
+                }
+              },
+              "wireValue": "semantic"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "google.protobuf.GeneratedCodeInfo.Annotation.Semantic",
+                    "camelCase": {
+                      "unsafeName": "googleProtobufGeneratedCodeInfoAnnotationSemantic",
+                      "safeName": "googleProtobufGeneratedCodeInfoAnnotationSemantic"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "google_protobuf_generated_code_info_annotation_semantic",
+                      "safeName": "google_protobuf_generated_code_info_annotation_semantic"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "GOOGLE_PROTOBUF_GENERATED_CODE_INFO_ANNOTATION_SEMANTIC",
+                      "safeName": "GOOGLE_PROTOBUF_GENERATED_CODE_INFO_ANNOTATION_SEMANTIC"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "GoogleProtobufGeneratedCodeInfoAnnotationSemantic",
+                      "safeName": "GoogleProtobufGeneratedCodeInfoAnnotationSemantic"
+                    }
+                  },
+                  "typeId": "google.protobuf.GeneratedCodeInfo.Annotation.Semantic",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "semantic"
                 }
               }
             },
@@ -29823,7 +31974,203 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "disposition",
+                "camelCase": {
+                  "unsafeName": "disposition",
+                  "safeName": "disposition"
+                },
+                "snakeCase": {
+                  "unsafeName": "disposition",
+                  "safeName": "disposition"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "DISPOSITION",
+                  "safeName": "DISPOSITION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Disposition",
+                  "safeName": "Disposition"
+                }
+              },
+              "wireValue": "disposition"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.ontology.v1.Disposition",
+                    "camelCase": {
+                      "unsafeName": "andurilOntologyV1Disposition",
+                      "safeName": "andurilOntologyV1Disposition"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_ontology_v_1_disposition",
+                      "safeName": "anduril_ontology_v_1_disposition"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ONTOLOGY_V_1_DISPOSITION",
+                      "safeName": "ANDURIL_ONTOLOGY_V_1_DISPOSITION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilOntologyV1Disposition",
+                      "safeName": "AndurilOntologyV1Disposition"
+                    }
+                  },
+                  "typeId": "anduril.ontology.v1.Disposition",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "disposition"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "environment",
+                "camelCase": {
+                  "unsafeName": "environment",
+                  "safeName": "environment"
+                },
+                "snakeCase": {
+                  "unsafeName": "environment",
+                  "safeName": "environment"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "ENVIRONMENT",
+                  "safeName": "ENVIRONMENT"
+                },
+                "pascalCase": {
+                  "unsafeName": "Environment",
+                  "safeName": "Environment"
+                }
+              },
+              "wireValue": "environment"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.ontology.v1.Environment",
+                    "camelCase": {
+                      "unsafeName": "andurilOntologyV1Environment",
+                      "safeName": "andurilOntologyV1Environment"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_ontology_v_1_environment",
+                      "safeName": "anduril_ontology_v_1_environment"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ONTOLOGY_V_1_ENVIRONMENT",
+                      "safeName": "ANDURIL_ONTOLOGY_V_1_ENVIRONMENT"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilOntologyV1Environment",
+                      "safeName": "AndurilOntologyV1Environment"
+                    }
+                  },
+                  "typeId": "anduril.ontology.v1.Environment",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "environment"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "nationality",
+                "camelCase": {
+                  "unsafeName": "nationality",
+                  "safeName": "nationality"
+                },
+                "snakeCase": {
+                  "unsafeName": "nationality",
+                  "safeName": "nationality"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "NATIONALITY",
+                  "safeName": "NATIONALITY"
+                },
+                "pascalCase": {
+                  "unsafeName": "Nationality",
+                  "safeName": "Nationality"
+                }
+              },
+              "wireValue": "nationality"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.ontology.v1.Nationality",
+                    "camelCase": {
+                      "unsafeName": "andurilOntologyV1Nationality",
+                      "safeName": "andurilOntologyV1Nationality"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_ontology_v_1_nationality",
+                      "safeName": "anduril_ontology_v_1_nationality"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ONTOLOGY_V_1_NATIONALITY",
+                      "safeName": "ANDURIL_ONTOLOGY_V_1_NATIONALITY"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilOntologyV1Nationality",
+                      "safeName": "AndurilOntologyV1Nationality"
+                    }
+                  },
+                  "typeId": "anduril.ontology.v1.Nationality",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "nationality"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -29962,6 +32309,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "A string that describes the entity's exact model or type."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "template",
+                "camelCase": {
+                  "unsafeName": "template",
+                  "safeName": "template"
+                },
+                "snakeCase": {
+                  "unsafeName": "template",
+                  "safeName": "template"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TEMPLATE",
+                  "safeName": "TEMPLATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Template",
+                  "safeName": "Template"
+                }
+              },
+              "wireValue": "template"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.Template",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1Template",
+                      "safeName": "andurilEntitymanagerV1Template"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_template",
+                      "safeName": "anduril_entitymanager_v_1_template"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_TEMPLATE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_TEMPLATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1Template",
+                      "safeName": "AndurilEntitymanagerV1Template"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.Template",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "template"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The template used when creating this entity. Specifies minimum required components."
           }
         ],
         "extends": [],
@@ -30650,6 +33062,71 @@
           {
             "name": {
               "name": {
+                "originalName": "ref_frame",
+                "camelCase": {
+                  "unsafeName": "refFrame",
+                  "safeName": "refFrame"
+                },
+                "snakeCase": {
+                  "unsafeName": "ref_frame",
+                  "safeName": "ref_frame"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "REF_FRAME",
+                  "safeName": "REF_FRAME"
+                },
+                "pascalCase": {
+                  "unsafeName": "RefFrame",
+                  "safeName": "RefFrame"
+                }
+              },
+              "wireValue": "ref_frame"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.type.EciReferenceFrame",
+                    "camelCase": {
+                      "unsafeName": "andurilTypeEciReferenceFrame",
+                      "safeName": "andurilTypeEciReferenceFrame"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_type_eci_reference_frame",
+                      "safeName": "anduril_type_eci_reference_frame"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TYPE_ECI_REFERENCE_FRAME",
+                      "safeName": "ANDURIL_TYPE_ECI_REFERENCE_FRAME"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTypeEciReferenceFrame",
+                      "safeName": "AndurilTypeEciReferenceFrame"
+                    }
+                  },
+                  "typeId": "anduril.type.EciReferenceFrame",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "ref_frame"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Reference frame, assumed to be Earth-centered"
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "ref_frame_epoch",
                 "camelCase": {
                   "unsafeName": "refFrameEpoch",
@@ -30711,6 +33188,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Reference frame epoch in UTC - mandatory only if not intrinsic to frame definition"
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "mean_element_theory",
+                "camelCase": {
+                  "unsafeName": "meanElementTheory",
+                  "safeName": "meanElementTheory"
+                },
+                "snakeCase": {
+                  "unsafeName": "mean_element_theory",
+                  "safeName": "mean_element_theory"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MEAN_ELEMENT_THEORY",
+                  "safeName": "MEAN_ELEMENT_THEORY"
+                },
+                "pascalCase": {
+                  "unsafeName": "MeanElementTheory",
+                  "safeName": "MeanElementTheory"
+                }
+              },
+              "wireValue": "mean_element_theory"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.type.MeanElementTheory",
+                    "camelCase": {
+                      "unsafeName": "andurilTypeMeanElementTheory",
+                      "safeName": "andurilTypeMeanElementTheory"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_type_mean_element_theory",
+                      "safeName": "anduril_type_mean_element_theory"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TYPE_MEAN_ELEMENT_THEORY",
+                      "safeName": "ANDURIL_TYPE_MEAN_ELEMENT_THEORY"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTypeMeanElementTheory",
+                      "safeName": "AndurilTypeMeanElementTheory"
+                    }
+                  },
+                  "typeId": "anduril.type.MeanElementTheory",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "mean_element_theory"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
           }
         ],
         "extends": [],
@@ -32713,7 +35255,41 @@
                   "container": {
                     "_type": "list",
                     "list": {
-                      "_type": "unknown"
+                      "_type": "container",
+                      "container": {
+                        "_type": "optional",
+                        "optional": {
+                          "_type": "named",
+                          "fernFilepath": {
+                            "allParts": [],
+                            "packagePath": [],
+                            "file": null
+                          },
+                          "name": {
+                            "originalName": "anduril.ontology.v1.Environment",
+                            "camelCase": {
+                              "unsafeName": "andurilOntologyV1Environment",
+                              "safeName": "andurilOntologyV1Environment"
+                            },
+                            "snakeCase": {
+                              "unsafeName": "anduril_ontology_v_1_environment",
+                              "safeName": "anduril_ontology_v_1_environment"
+                            },
+                            "screamingSnakeCase": {
+                              "unsafeName": "ANDURIL_ONTOLOGY_V_1_ENVIRONMENT",
+                              "safeName": "ANDURIL_ONTOLOGY_V_1_ENVIRONMENT"
+                            },
+                            "pascalCase": {
+                              "unsafeName": "AndurilOntologyV1Environment",
+                              "safeName": "AndurilOntologyV1Environment"
+                            }
+                          },
+                          "typeId": "anduril.ontology.v1.Environment",
+                          "default": null,
+                          "inline": false,
+                          "displayName": "effective_environment"
+                        }
+                      }
                     }
                   }
                 }
@@ -32723,6 +35299,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "The target environments the configuration is effective against."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "payload_operational_state",
+                "camelCase": {
+                  "unsafeName": "payloadOperationalState",
+                  "safeName": "payloadOperationalState"
+                },
+                "snakeCase": {
+                  "unsafeName": "payload_operational_state",
+                  "safeName": "payload_operational_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "PAYLOAD_OPERATIONAL_STATE",
+                  "safeName": "PAYLOAD_OPERATIONAL_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "PayloadOperationalState",
+                  "safeName": "PayloadOperationalState"
+                }
+              },
+              "wireValue": "payload_operational_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.PayloadOperationalState",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1PayloadOperationalState",
+                      "safeName": "andurilEntitymanagerV1PayloadOperationalState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_payload_operational_state",
+                      "safeName": "anduril_entitymanager_v_1_payload_operational_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_PAYLOAD_OPERATIONAL_STATE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_PAYLOAD_OPERATIONAL_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1PayloadOperationalState",
+                      "safeName": "AndurilEntitymanagerV1PayloadOperationalState"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.PayloadOperationalState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "payload_operational_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The operational state of this payload."
           },
           {
             "name": {
@@ -33456,6 +36097,136 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "power_status",
+                "camelCase": {
+                  "unsafeName": "powerStatus",
+                  "safeName": "powerStatus"
+                },
+                "snakeCase": {
+                  "unsafeName": "power_status",
+                  "safeName": "power_status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "POWER_STATUS",
+                  "safeName": "POWER_STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "PowerStatus",
+                  "safeName": "PowerStatus"
+                }
+              },
+              "wireValue": "power_status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.PowerStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1PowerStatus",
+                      "safeName": "andurilEntitymanagerV1PowerStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_power_status",
+                      "safeName": "anduril_entitymanager_v_1_power_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_POWER_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_POWER_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1PowerStatus",
+                      "safeName": "AndurilEntitymanagerV1PowerStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.PowerStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "power_status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Status of the power source."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "power_type",
+                "camelCase": {
+                  "unsafeName": "powerType",
+                  "safeName": "powerType"
+                },
+                "snakeCase": {
+                  "unsafeName": "power_type",
+                  "safeName": "power_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "POWER_TYPE",
+                  "safeName": "POWER_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "PowerType",
+                  "safeName": "PowerType"
+                }
+              },
+              "wireValue": "power_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.PowerType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1PowerType",
+                      "safeName": "andurilEntitymanagerV1PowerType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_power_type",
+                      "safeName": "anduril_entitymanager_v_1_power_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_POWER_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_POWER_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1PowerType",
+                      "safeName": "AndurilEntitymanagerV1PowerType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.PowerType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "power_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Used to determine the type of power source."
+          },
           {
             "name": {
               "name": {
@@ -36690,6 +39461,71 @@
           {
             "name": {
               "name": {
+                "originalName": "scan_type",
+                "camelCase": {
+                  "unsafeName": "scanType",
+                  "safeName": "scanType"
+                },
+                "snakeCase": {
+                  "unsafeName": "scan_type",
+                  "safeName": "scan_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "SCAN_TYPE",
+                  "safeName": "SCAN_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "ScanType",
+                  "safeName": "ScanType"
+                }
+              },
+              "wireValue": "scan_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.ScanType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1ScanType",
+                      "safeName": "andurilEntitymanagerV1ScanType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_scan_type",
+                      "safeName": "anduril_entitymanager_v_1_scan_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_SCAN_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_SCAN_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1ScanType",
+                      "safeName": "AndurilEntitymanagerV1ScanType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.ScanType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "scan_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "scan_period_s",
                 "camelCase": {
                   "unsafeName": "scanPeriodS",
@@ -37658,6 +40494,136 @@
           {
             "name": {
               "name": {
+                "originalName": "operational_state",
+                "camelCase": {
+                  "unsafeName": "operationalState",
+                  "safeName": "operationalState"
+                },
+                "snakeCase": {
+                  "unsafeName": "operational_state",
+                  "safeName": "operational_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "OPERATIONAL_STATE",
+                  "safeName": "OPERATIONAL_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "OperationalState",
+                  "safeName": "OperationalState"
+                }
+              },
+              "wireValue": "operational_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.OperationalState",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1OperationalState",
+                      "safeName": "andurilEntitymanagerV1OperationalState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_operational_state",
+                      "safeName": "anduril_entitymanager_v_1_operational_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_OPERATIONAL_STATE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_OPERATIONAL_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1OperationalState",
+                      "safeName": "AndurilEntitymanagerV1OperationalState"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.OperationalState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "operational_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "sensor_type",
+                "camelCase": {
+                  "unsafeName": "sensorType",
+                  "safeName": "sensorType"
+                },
+                "snakeCase": {
+                  "unsafeName": "sensor_type",
+                  "safeName": "sensor_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "SENSOR_TYPE",
+                  "safeName": "SENSOR_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "SensorType",
+                  "safeName": "SensorType"
+                }
+              },
+              "wireValue": "sensor_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.SensorType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1SensorType",
+                      "safeName": "andurilEntitymanagerV1SensorType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_sensor_type",
+                      "safeName": "anduril_entitymanager_v_1_sensor_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_SENSOR_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_SENSOR_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1SensorType",
+                      "safeName": "AndurilEntitymanagerV1SensorType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.SensorType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "sensor_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The type of sensor"
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "sensor_description",
                 "camelCase": {
                   "unsafeName": "sensorDescription",
@@ -38392,6 +41358,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Sensor range in meters."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "mode",
+                "camelCase": {
+                  "unsafeName": "mode",
+                  "safeName": "mode"
+                },
+                "snakeCase": {
+                  "unsafeName": "mode",
+                  "safeName": "mode"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MODE",
+                  "safeName": "MODE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Mode",
+                  "safeName": "Mode"
+                }
+              },
+              "wireValue": "mode"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.SensorMode",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1SensorMode",
+                      "safeName": "andurilEntitymanagerV1SensorMode"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_sensor_mode",
+                      "safeName": "anduril_entitymanager_v_1_sensor_mode"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_SENSOR_MODE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_SENSOR_MODE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1SensorMode",
+                      "safeName": "AndurilEntitymanagerV1SensorMode"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.SensorMode",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "mode"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The mode that this sensor is currently in, used to display for context in the UI. Some sensors can emit multiple\n sensor field of views with different modes, for example a radar can simultaneously search broadly and perform\n tighter bounded tracking."
           }
         ],
         "extends": [],
@@ -40817,6 +43848,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "A unique identifier for this schedule."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "schedule_type",
+                "camelCase": {
+                  "unsafeName": "scheduleType",
+                  "safeName": "scheduleType"
+                },
+                "snakeCase": {
+                  "unsafeName": "schedule_type",
+                  "safeName": "schedule_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "SCHEDULE_TYPE",
+                  "safeName": "SCHEDULE_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "ScheduleType",
+                  "safeName": "ScheduleType"
+                }
+              },
+              "wireValue": "schedule_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.ScheduleType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1ScheduleType",
+                      "safeName": "andurilEntitymanagerV1ScheduleType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_schedule_type",
+                      "safeName": "anduril_entitymanager_v_1_schedule_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_SCHEDULE_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_SCHEDULE_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1ScheduleType",
+                      "safeName": "AndurilEntitymanagerV1ScheduleType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.ScheduleType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "schedule_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The schedule type"
           }
         ],
         "extends": [],
@@ -42530,6 +45626,71 @@
           {
             "name": {
               "name": {
+                "originalName": "mode4_interrogation_response",
+                "camelCase": {
+                  "unsafeName": "mode4InterrogationResponse",
+                  "safeName": "mode4InterrogationResponse"
+                },
+                "snakeCase": {
+                  "unsafeName": "mode_4_interrogation_response",
+                  "safeName": "mode_4_interrogation_response"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MODE_4_INTERROGATION_RESPONSE",
+                  "safeName": "MODE_4_INTERROGATION_RESPONSE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Mode4InterrogationResponse",
+                  "safeName": "Mode4InterrogationResponse"
+                }
+              },
+              "wireValue": "mode4_interrogation_response"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.InterrogationResponse",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1InterrogationResponse",
+                      "safeName": "andurilEntitymanagerV1InterrogationResponse"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_interrogation_response",
+                      "safeName": "anduril_entitymanager_v_1_interrogation_response"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_INTERROGATION_RESPONSE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_INTERROGATION_RESPONSE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1InterrogationResponse",
+                      "safeName": "AndurilEntitymanagerV1InterrogationResponse"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.InterrogationResponse",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "mode4_interrogation_response"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The validity of the response from the Mode 4 interrogation."
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "mode5",
                 "camelCase": {
                   "unsafeName": "mode5",
@@ -42707,6 +45868,71 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "mode5_interrogation_response",
+                "camelCase": {
+                  "unsafeName": "mode5InterrogationResponse",
+                  "safeName": "mode5InterrogationResponse"
+                },
+                "snakeCase": {
+                  "unsafeName": "mode_5_interrogation_response",
+                  "safeName": "mode_5_interrogation_response"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "MODE_5_INTERROGATION_RESPONSE",
+                  "safeName": "MODE_5_INTERROGATION_RESPONSE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Mode5InterrogationResponse",
+                  "safeName": "Mode5InterrogationResponse"
+                }
+              },
+              "wireValue": "mode5_interrogation_response"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.InterrogationResponse",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1InterrogationResponse",
+                      "safeName": "andurilEntitymanagerV1InterrogationResponse"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_interrogation_response",
+                      "safeName": "anduril_entitymanager_v_1_interrogation_response"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_INTERROGATION_RESPONSE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_INTERROGATION_RESPONSE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1InterrogationResponse",
+                      "safeName": "AndurilEntitymanagerV1InterrogationResponse"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.InterrogationResponse",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "mode5_interrogation_response"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The validity of the response from the Mode 5 interrogation."
+          },
           {
             "name": {
               "name": {
@@ -47729,6 +50955,71 @@
           {
             "name": {
               "name": {
+                "originalName": "status",
+                "camelCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "snakeCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "STATUS",
+                  "safeName": "STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "Status",
+                  "safeName": "Status"
+                }
+              },
+              "wireValue": "status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.OverrideStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1OverrideStatus",
+                      "safeName": "andurilEntitymanagerV1OverrideStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_override_status",
+                      "safeName": "anduril_entitymanager_v_1_override_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_OVERRIDE_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_OVERRIDE_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1OverrideStatus",
+                      "safeName": "AndurilEntitymanagerV1OverrideStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.OverrideStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "status of the override"
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "provenance",
                 "camelCase": {
                   "unsafeName": "provenance",
@@ -47790,6 +51081,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "type",
+                "camelCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "snakeCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TYPE",
+                  "safeName": "TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Type",
+                  "safeName": "Type"
+                }
+              },
+              "wireValue": "type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.OverrideType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1OverrideType",
+                      "safeName": "andurilEntitymanagerV1OverrideType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_override_type",
+                      "safeName": "anduril_entitymanager_v_1_override_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_OVERRIDE_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_OVERRIDE_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1OverrideType",
+                      "safeName": "AndurilEntitymanagerV1OverrideType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.OverrideType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The type of the override, defined by the stage of the entity lifecycle that the entity was in when the override\n was requested."
           },
           {
             "name": {
@@ -47943,6 +51299,71 @@
                       "validation": null
                     }
                   }
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "type",
+                "camelCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "snakeCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TYPE",
+                  "safeName": "TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Type",
+                  "safeName": "Type"
+                }
+              },
+              "wireValue": "type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.AltIdType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1AltIdType",
+                      "safeName": "andurilEntitymanagerV1AltIdType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_alt_id_type",
+                      "safeName": "anduril_entitymanager_v_1_alt_id_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_ALT_ID_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_ALT_ID_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1AltIdType",
+                      "safeName": "AndurilEntitymanagerV1AltIdType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.AltIdType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "type"
                 }
               }
             },
@@ -49988,6 +53409,136 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Who or what added this entity to the (de)correlation."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "replication_mode",
+                "camelCase": {
+                  "unsafeName": "replicationMode",
+                  "safeName": "replicationMode"
+                },
+                "snakeCase": {
+                  "unsafeName": "replication_mode",
+                  "safeName": "replication_mode"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "REPLICATION_MODE",
+                  "safeName": "REPLICATION_MODE"
+                },
+                "pascalCase": {
+                  "unsafeName": "ReplicationMode",
+                  "safeName": "ReplicationMode"
+                }
+              },
+              "wireValue": "replication_mode"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.CorrelationReplicationMode",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1CorrelationReplicationMode",
+                      "safeName": "andurilEntitymanagerV1CorrelationReplicationMode"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_correlation_replication_mode",
+                      "safeName": "anduril_entitymanager_v_1_correlation_replication_mode"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_CORRELATION_REPLICATION_MODE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_CORRELATION_REPLICATION_MODE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1CorrelationReplicationMode",
+                      "safeName": "AndurilEntitymanagerV1CorrelationReplicationMode"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.CorrelationReplicationMode",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "replication_mode"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Indicates how the correlation will be distributed. Because a correlation is composed of\n multiple secondaries, each of which may have been correlated with different replication\n modes, the distribution of the correlation is composed of distributions of the individual\n entities within the correlation set.\n For example, if there are two secondary entities A and B correlated against a primary C,\n with A having been correlated globally and B having been correlated locally, then the\n correlation set that is distributed globally than what is known locally in the node."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "type",
+                "camelCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "snakeCase": {
+                  "unsafeName": "type",
+                  "safeName": "type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TYPE",
+                  "safeName": "TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Type",
+                  "safeName": "Type"
+                }
+              },
+              "wireValue": "type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.CorrelationType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1CorrelationType",
+                      "safeName": "andurilEntitymanagerV1CorrelationType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_correlation_type",
+                      "safeName": "anduril_entitymanager_v_1_correlation_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_CORRELATION_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_CORRELATION_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1CorrelationType",
+                      "safeName": "AndurilEntitymanagerV1CorrelationType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.CorrelationType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "What type of (de)correlation was this entity added with."
           }
         ],
         "extends": [],
@@ -51565,6 +55116,71 @@
           {
             "name": {
               "name": {
+                "originalName": "list_comparator",
+                "camelCase": {
+                  "unsafeName": "listComparator",
+                  "safeName": "listComparator"
+                },
+                "snakeCase": {
+                  "unsafeName": "list_comparator",
+                  "safeName": "list_comparator"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "LIST_COMPARATOR",
+                  "safeName": "LIST_COMPARATOR"
+                },
+                "pascalCase": {
+                  "unsafeName": "ListComparator",
+                  "safeName": "ListComparator"
+                }
+              },
+              "wireValue": "list_comparator"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.ListComparator",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1ListComparator",
+                      "safeName": "andurilEntitymanagerV1ListComparator"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_list_comparator",
+                      "safeName": "anduril_entitymanager_v_1_list_comparator"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_LIST_COMPARATOR",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_LIST_COMPARATOR"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1ListComparator",
+                      "safeName": "AndurilEntitymanagerV1ListComparator"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.ListComparator",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "list_comparator"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The list_comparator specifies how to compose the boolean results from the child statement\n for each member of the specified list."
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "statement",
                 "camelCase": {
                   "unsafeName": "statement",
@@ -52040,6 +55656,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "The value determines the fixed value against which the entity field is to be compared.\n In the case of COMPARATOR_MATCH_ALL, the value contents do not matter as long as the Value is a supported\n type."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "comparator",
+                "camelCase": {
+                  "unsafeName": "comparator",
+                  "safeName": "comparator"
+                },
+                "snakeCase": {
+                  "unsafeName": "comparator",
+                  "safeName": "comparator"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "COMPARATOR",
+                  "safeName": "COMPARATOR"
+                },
+                "pascalCase": {
+                  "unsafeName": "Comparator",
+                  "safeName": "Comparator"
+                }
+              },
+              "wireValue": "comparator"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.Comparator",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1Comparator",
+                      "safeName": "andurilEntitymanagerV1Comparator"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_comparator",
+                      "safeName": "anduril_entitymanager_v_1_comparator"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_COMPARATOR",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_COMPARATOR"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1Comparator",
+                      "safeName": "AndurilEntitymanagerV1Comparator"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.Comparator",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "comparator"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The comparator determines the manner in which the entity field and static value are compared.\n Comparators may only be applied to certain values. For example, the WITHIN comparator cannot\n be used for a boolean value comparison."
           }
         ],
         "extends": [],
@@ -54994,7 +58675,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "status",
+                "camelCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "snakeCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "STATUS",
+                  "safeName": "STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "Status",
+                  "safeName": "Status"
+                }
+              },
+              "wireValue": "status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.OverrideStatus",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1OverrideStatus",
+                      "safeName": "andurilEntitymanagerV1OverrideStatus"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_override_status",
+                      "safeName": "anduril_entitymanager_v_1_override_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_OVERRIDE_STATUS",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_OVERRIDE_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1OverrideStatus",
+                      "safeName": "AndurilEntitymanagerV1OverrideStatus"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.OverrideStatus",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The status of the override request."
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -55793,6 +59540,71 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "event_type",
+                "camelCase": {
+                  "unsafeName": "eventType",
+                  "safeName": "eventType"
+                },
+                "snakeCase": {
+                  "unsafeName": "event_type",
+                  "safeName": "event_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EVENT_TYPE",
+                  "safeName": "EVENT_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "EventType",
+                  "safeName": "EventType"
+                }
+              },
+              "wireValue": "event_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.entitymanager.v1.EventType",
+                    "camelCase": {
+                      "unsafeName": "andurilEntitymanagerV1EventType",
+                      "safeName": "andurilEntitymanagerV1EventType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_entitymanager_v_1_event_type",
+                      "safeName": "anduril_entitymanager_v_1_event_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_ENTITYMANAGER_V_1_EVENT_TYPE",
+                      "safeName": "ANDURIL_ENTITYMANAGER_V_1_EVENT_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilEntitymanagerV1EventType",
+                      "safeName": "AndurilEntitymanagerV1EventType"
+                    }
+                  },
+                  "typeId": "anduril.entitymanager.v1.EventType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "event_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
           {
             "name": {
               "name": {
@@ -58565,6 +62377,71 @@
           {
             "name": {
               "name": {
+                "originalName": "status",
+                "camelCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "snakeCase": {
+                  "unsafeName": "status",
+                  "safeName": "status"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "STATUS",
+                  "safeName": "STATUS"
+                },
+                "pascalCase": {
+                  "unsafeName": "Status",
+                  "safeName": "Status"
+                }
+              },
+              "wireValue": "status"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.Status",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1Status",
+                      "safeName": "andurilTaskmanagerV1Status"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_status",
+                      "safeName": "anduril_taskmanager_v_1_status"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_STATUS",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_STATUS"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1Status",
+                      "safeName": "AndurilTaskmanagerV1Status"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.Status",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "status"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Status of the Task."
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "task_error",
                 "camelCase": {
                   "unsafeName": "taskError",
@@ -59002,6 +62879,71 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "code",
+                "camelCase": {
+                  "unsafeName": "code",
+                  "safeName": "code"
+                },
+                "snakeCase": {
+                  "unsafeName": "code",
+                  "safeName": "code"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "CODE",
+                  "safeName": "CODE"
+                },
+                "pascalCase": {
+                  "unsafeName": "Code",
+                  "safeName": "Code"
+                }
+              },
+              "wireValue": "code"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.ErrorCode",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1ErrorCode",
+                      "safeName": "andurilTaskmanagerV1ErrorCode"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_error_code",
+                      "safeName": "anduril_taskmanager_v_1_error_code"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_ERROR_CODE",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_ERROR_CODE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1ErrorCode",
+                      "safeName": "AndurilTaskmanagerV1ErrorCode"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.ErrorCode",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "code"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Error code for Task error."
+          },
           {
             "name": {
               "name": {
@@ -59927,6 +63869,71 @@
           {
             "name": {
               "name": {
+                "originalName": "event_type",
+                "camelCase": {
+                  "unsafeName": "eventType",
+                  "safeName": "eventType"
+                },
+                "snakeCase": {
+                  "unsafeName": "event_type",
+                  "safeName": "event_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EVENT_TYPE",
+                  "safeName": "EVENT_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "EventType",
+                  "safeName": "EventType"
+                }
+              },
+              "wireValue": "event_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.EventType",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1EventType",
+                      "safeName": "andurilTaskmanagerV1EventType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_event_type",
+                      "safeName": "anduril_taskmanager_v_1_event_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_EVENT_TYPE",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_EVENT_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1EventType",
+                      "safeName": "AndurilTaskmanagerV1EventType"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.EventType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "event_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Type of Event."
+          },
+          {
+            "name": {
+              "name": {
                 "originalName": "task",
                 "camelCase": {
                   "unsafeName": "task",
@@ -59988,6 +63995,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Task associated with this TaskEvent."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "task_view",
+                "camelCase": {
+                  "unsafeName": "taskView",
+                  "safeName": "taskView"
+                },
+                "snakeCase": {
+                  "unsafeName": "task_view",
+                  "safeName": "task_view"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TASK_VIEW",
+                  "safeName": "TASK_VIEW"
+                },
+                "pascalCase": {
+                  "unsafeName": "TaskView",
+                  "safeName": "TaskView"
+                }
+              },
+              "wireValue": "task_view"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.TaskView",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1TaskView",
+                      "safeName": "andurilTaskmanagerV1TaskView"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_task_view",
+                      "safeName": "anduril_taskmanager_v_1_task_view"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_TASK_VIEW",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_TASK_VIEW"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1TaskView",
+                      "safeName": "AndurilTaskmanagerV1TaskView"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.TaskView",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "task_view"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "View associated with this task."
           },
           {
             "name": {
@@ -62546,6 +66618,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Optional - if > 0, will get specific definition_version, otherwise latest (highest) definition_version is used."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "task_view",
+                "camelCase": {
+                  "unsafeName": "taskView",
+                  "safeName": "taskView"
+                },
+                "snakeCase": {
+                  "unsafeName": "task_view",
+                  "safeName": "task_view"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TASK_VIEW",
+                  "safeName": "TASK_VIEW"
+                },
+                "pascalCase": {
+                  "unsafeName": "TaskView",
+                  "safeName": "TaskView"
+                }
+              },
+              "wireValue": "task_view"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.TaskView",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1TaskView",
+                      "safeName": "andurilTaskmanagerV1TaskView"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_task_view",
+                      "safeName": "anduril_taskmanager_v_1_task_view"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_TASK_VIEW",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_TASK_VIEW"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1TaskView",
+                      "safeName": "AndurilTaskmanagerV1TaskView"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.TaskView",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "task_view"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Optional - select which view of the task to fetch. If not set, defaults to TASK_VIEW_MANAGER."
           }
         ],
         "extends": [],
@@ -62924,7 +67061,41 @@
                   "container": {
                     "_type": "list",
                     "list": {
-                      "_type": "unknown"
+                      "_type": "container",
+                      "container": {
+                        "_type": "optional",
+                        "optional": {
+                          "_type": "named",
+                          "fernFilepath": {
+                            "allParts": [],
+                            "packagePath": [],
+                            "file": null
+                          },
+                          "name": {
+                            "originalName": "anduril.taskmanager.v1.Status",
+                            "camelCase": {
+                              "unsafeName": "andurilTaskmanagerV1Status",
+                              "safeName": "andurilTaskmanagerV1Status"
+                            },
+                            "snakeCase": {
+                              "unsafeName": "anduril_taskmanager_v_1_status",
+                              "safeName": "anduril_taskmanager_v_1_status"
+                            },
+                            "screamingSnakeCase": {
+                              "unsafeName": "ANDURIL_TASKMANAGER_V_1_STATUS",
+                              "safeName": "ANDURIL_TASKMANAGER_V_1_STATUS"
+                            },
+                            "pascalCase": {
+                              "unsafeName": "AndurilTaskmanagerV1Status",
+                              "safeName": "AndurilTaskmanagerV1Status"
+                            }
+                          },
+                          "typeId": "anduril.taskmanager.v1.Status",
+                          "default": null,
+                          "inline": false,
+                          "displayName": "status"
+                        }
+                      }
                     }
                   }
                 }
@@ -62934,6 +67105,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Statuses to be part of the filter."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "filter_type",
+                "camelCase": {
+                  "unsafeName": "filterType",
+                  "safeName": "filterType"
+                },
+                "snakeCase": {
+                  "unsafeName": "filter_type",
+                  "safeName": "filter_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "FILTER_TYPE",
+                  "safeName": "FILTER_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "FilterType",
+                  "safeName": "FilterType"
+                }
+              },
+              "wireValue": "filter_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.QueryTasksRequest.FilterType",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1QueryTasksRequestFilterType",
+                      "safeName": "andurilTaskmanagerV1QueryTasksRequestFilterType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_query_tasks_request_filter_type",
+                      "safeName": "anduril_taskmanager_v_1_query_tasks_request_filter_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_QUERY_TASKS_REQUEST_FILTER_TYPE",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_QUERY_TASKS_REQUEST_FILTER_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1QueryTasksRequestFilterType",
+                      "safeName": "AndurilTaskmanagerV1QueryTasksRequestFilterType"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.QueryTasksRequest.FilterType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "filter_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "The type of filter to apply."
           }
         ],
         "extends": [],
@@ -63327,6 +67563,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "If provided, only provides Tasks updated within the time range."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "view",
+                "camelCase": {
+                  "unsafeName": "view",
+                  "safeName": "view"
+                },
+                "snakeCase": {
+                  "unsafeName": "view",
+                  "safeName": "view"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "VIEW",
+                  "safeName": "VIEW"
+                },
+                "pascalCase": {
+                  "unsafeName": "View",
+                  "safeName": "View"
+                }
+              },
+              "wireValue": "view"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.taskmanager.v1.TaskView",
+                    "camelCase": {
+                      "unsafeName": "andurilTaskmanagerV1TaskView",
+                      "safeName": "andurilTaskmanagerV1TaskView"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_taskmanager_v_1_task_view",
+                      "safeName": "anduril_taskmanager_v_1_task_view"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKMANAGER_V_1_TASK_VIEW",
+                      "safeName": "ANDURIL_TASKMANAGER_V_1_TASK_VIEW"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTaskmanagerV1TaskView",
+                      "safeName": "AndurilTaskmanagerV1TaskView"
+                    }
+                  },
+                  "typeId": "anduril.taskmanager.v1.TaskView",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "view"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Optional filter for view of a Task.\n If not set, defaults to TASK_VIEW_MANAGER."
           }
         ],
         "extends": [],
@@ -64665,7 +68966,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "power_state",
+                "camelCase": {
+                  "unsafeName": "powerState",
+                  "safeName": "powerState"
+                },
+                "snakeCase": {
+                  "unsafeName": "power_state",
+                  "safeName": "power_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "POWER_STATE",
+                  "safeName": "POWER_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "PowerState",
+                  "safeName": "PowerState"
+                }
+              },
+              "wireValue": "power_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.ad.desertguardian.common.v1.PowerState",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksAdDesertguardianCommonV1PowerState",
+                      "safeName": "andurilTasksAdDesertguardianCommonV1PowerState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_ad_desertguardian_common_v_1_power_state",
+                      "safeName": "anduril_tasks_ad_desertguardian_common_v_1_power_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_COMMON_V_1_POWER_STATE",
+                      "safeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_COMMON_V_1_POWER_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksAdDesertguardianCommonV1PowerState",
+                      "safeName": "AndurilTasksAdDesertguardianCommonV1PowerState"
+                    }
+                  },
+                  "typeId": "anduril.tasks.ad.desertguardian.common.v1.PowerState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "power_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -65368,7 +69735,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "transmit_state",
+                "camelCase": {
+                  "unsafeName": "transmitState",
+                  "safeName": "transmitState"
+                },
+                "snakeCase": {
+                  "unsafeName": "transmit_state",
+                  "safeName": "transmit_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TRANSMIT_STATE",
+                  "safeName": "TRANSMIT_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "TransmitState",
+                  "safeName": "TransmitState"
+                }
+              },
+              "wireValue": "transmit_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.ad.desertguardian.rf.v1.TransmitState",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksAdDesertguardianRfV1TransmitState",
+                      "safeName": "andurilTasksAdDesertguardianRfV1TransmitState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_ad_desertguardian_rf_v_1_transmit_state",
+                      "safeName": "anduril_tasks_ad_desertguardian_rf_v_1_transmit_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_RF_V_1_TRANSMIT_STATE",
+                      "safeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_RF_V_1_TRANSMIT_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksAdDesertguardianRfV1TransmitState",
+                      "safeName": "AndurilTasksAdDesertguardianRfV1TransmitState"
+                    }
+                  },
+                  "typeId": "anduril.tasks.ad.desertguardian.rf.v1.TransmitState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "transmit_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -65417,7 +69850,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "surveillance_state",
+                "camelCase": {
+                  "unsafeName": "surveillanceState",
+                  "safeName": "surveillanceState"
+                },
+                "snakeCase": {
+                  "unsafeName": "surveillance_state",
+                  "safeName": "surveillance_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "SURVEILLANCE_STATE",
+                  "safeName": "SURVEILLANCE_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "SurveillanceState",
+                  "safeName": "SurveillanceState"
+                }
+              },
+              "wireValue": "surveillance_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.ad.desertguardian.rf.v1.SurveillanceState",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksAdDesertguardianRfV1SurveillanceState",
+                      "safeName": "andurilTasksAdDesertguardianRfV1SurveillanceState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_ad_desertguardian_rf_v_1_surveillance_state",
+                      "safeName": "anduril_tasks_ad_desertguardian_rf_v_1_surveillance_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_RF_V_1_SURVEILLANCE_STATE",
+                      "safeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_RF_V_1_SURVEILLANCE_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksAdDesertguardianRfV1SurveillanceState",
+                      "safeName": "AndurilTasksAdDesertguardianRfV1SurveillanceState"
+                    }
+                  },
+                  "typeId": "anduril.tasks.ad.desertguardian.rf.v1.SurveillanceState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "surveillance_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -65466,7 +69965,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "emcon_state",
+                "camelCase": {
+                  "unsafeName": "emconState",
+                  "safeName": "emconState"
+                },
+                "snakeCase": {
+                  "unsafeName": "emcon_state",
+                  "safeName": "emcon_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "EMCON_STATE",
+                  "safeName": "EMCON_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "EmconState",
+                  "safeName": "EmconState"
+                }
+              },
+              "wireValue": "emcon_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.ad.desertguardian.rf.v1.EmissionControlState",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksAdDesertguardianRfV1EmissionControlState",
+                      "safeName": "andurilTasksAdDesertguardianRfV1EmissionControlState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_ad_desertguardian_rf_v_1_emission_control_state",
+                      "safeName": "anduril_tasks_ad_desertguardian_rf_v_1_emission_control_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_RF_V_1_EMISSION_CONTROL_STATE",
+                      "safeName": "ANDURIL_TASKS_AD_DESERTGUARDIAN_RF_V_1_EMISSION_CONTROL_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksAdDesertguardianRfV1EmissionControlState",
+                      "safeName": "AndurilTasksAdDesertguardianRfV1EmissionControlState"
+                    }
+                  },
+                  "typeId": "anduril.tasks.ad.desertguardian.rf.v1.EmissionControlState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "emcon_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -66472,7 +71037,73 @@
       },
       "shape": {
         "_type": "object",
-        "properties": [],
+        "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "power_state",
+                "camelCase": {
+                  "unsafeName": "powerState",
+                  "safeName": "powerState"
+                },
+                "snakeCase": {
+                  "unsafeName": "power_state",
+                  "safeName": "power_state"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "POWER_STATE",
+                  "safeName": "POWER_STATE"
+                },
+                "pascalCase": {
+                  "unsafeName": "PowerState",
+                  "safeName": "PowerState"
+                }
+              },
+              "wireValue": "power_state"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.jadc2.thirdparty.v1.PowerState",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksJadc2ThirdpartyV1PowerState",
+                      "safeName": "andurilTasksJadc2ThirdpartyV1PowerState"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_jadc_2_thirdparty_v_1_power_state",
+                      "safeName": "anduril_tasks_jadc_2_thirdparty_v_1_power_state"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_JADC_2_THIRDPARTY_V_1_POWER_STATE",
+                      "safeName": "ANDURIL_TASKS_JADC_2_THIRDPARTY_V_1_POWER_STATE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksJadc2ThirdpartyV1PowerState",
+                      "safeName": "AndurilTasksJadc2ThirdpartyV1PowerState"
+                    }
+                  },
+                  "typeId": "anduril.tasks.jadc2.thirdparty.v1.PowerState",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "power_state"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          }
+        ],
         "extends": [],
         "extendedProperties": [],
         "extra-properties": false
@@ -67991,6 +72622,71 @@
             "v2Examples": null,
             "availability": null,
             "docs": "Reference to GeoPolygon GeoEntity representing the ControlArea."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "control_area_type",
+                "camelCase": {
+                  "unsafeName": "controlAreaType",
+                  "safeName": "controlAreaType"
+                },
+                "snakeCase": {
+                  "unsafeName": "control_area_type",
+                  "safeName": "control_area_type"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "CONTROL_AREA_TYPE",
+                  "safeName": "CONTROL_AREA_TYPE"
+                },
+                "pascalCase": {
+                  "unsafeName": "ControlAreaType",
+                  "safeName": "ControlAreaType"
+                }
+              },
+              "wireValue": "control_area_type"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.v2.ControlAreaType",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksV2ControlAreaType",
+                      "safeName": "andurilTasksV2ControlAreaType"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_v_2_control_area_type",
+                      "safeName": "anduril_tasks_v_2_control_area_type"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_V_2_CONTROL_AREA_TYPE",
+                      "safeName": "ANDURIL_TASKS_V_2_CONTROL_AREA_TYPE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksV2ControlAreaType",
+                      "safeName": "AndurilTasksV2ControlAreaType"
+                    }
+                  },
+                  "typeId": "anduril.tasks.v2.ControlAreaType",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "control_area_type"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Type of ControlArea."
           }
         ],
         "extends": [],
@@ -70384,6 +75080,136 @@
       "shape": {
         "_type": "object",
         "properties": [
+          {
+            "name": {
+              "name": {
+                "originalName": "direction",
+                "camelCase": {
+                  "unsafeName": "direction",
+                  "safeName": "direction"
+                },
+                "snakeCase": {
+                  "unsafeName": "direction",
+                  "safeName": "direction"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "DIRECTION",
+                  "safeName": "DIRECTION"
+                },
+                "pascalCase": {
+                  "unsafeName": "Direction",
+                  "safeName": "Direction"
+                }
+              },
+              "wireValue": "direction"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.v2.OrbitDirection",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksV2OrbitDirection",
+                      "safeName": "andurilTasksV2OrbitDirection"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_v_2_orbit_direction",
+                      "safeName": "anduril_tasks_v_2_orbit_direction"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_V_2_ORBIT_DIRECTION",
+                      "safeName": "ANDURIL_TASKS_V_2_ORBIT_DIRECTION"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksV2OrbitDirection",
+                      "safeName": "AndurilTasksV2OrbitDirection"
+                    }
+                  },
+                  "typeId": "anduril.tasks.v2.OrbitDirection",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "direction"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Indicates the direction in which to perform the loiter."
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "pattern",
+                "camelCase": {
+                  "unsafeName": "pattern",
+                  "safeName": "pattern"
+                },
+                "snakeCase": {
+                  "unsafeName": "pattern",
+                  "safeName": "pattern"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "PATTERN",
+                  "safeName": "PATTERN"
+                },
+                "pascalCase": {
+                  "unsafeName": "Pattern",
+                  "safeName": "Pattern"
+                }
+              },
+              "wireValue": "pattern"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.v2.OrbitPattern",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksV2OrbitPattern",
+                      "safeName": "andurilTasksV2OrbitPattern"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_v_2_orbit_pattern",
+                      "safeName": "anduril_tasks_v_2_orbit_pattern"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_V_2_ORBIT_PATTERN",
+                      "safeName": "ANDURIL_TASKS_V_2_ORBIT_PATTERN"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksV2OrbitPattern",
+                      "safeName": "AndurilTasksV2OrbitPattern"
+                    }
+                  },
+                  "typeId": "anduril.tasks.v2.OrbitPattern",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "pattern"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": "Indicates the loiter pattern to perform."
+          },
           {
             "name": {
               "name": {
@@ -73644,6 +78470,71 @@
                   "default": null,
                   "inline": false,
                   "displayName": "plan"
+                }
+              }
+            },
+            "propertyAccess": null,
+            "v2Examples": null,
+            "availability": null,
+            "docs": null
+          },
+          {
+            "name": {
+              "name": {
+                "originalName": "tracking_mode",
+                "camelCase": {
+                  "unsafeName": "trackingMode",
+                  "safeName": "trackingMode"
+                },
+                "snakeCase": {
+                  "unsafeName": "tracking_mode",
+                  "safeName": "tracking_mode"
+                },
+                "screamingSnakeCase": {
+                  "unsafeName": "TRACKING_MODE",
+                  "safeName": "TRACKING_MODE"
+                },
+                "pascalCase": {
+                  "unsafeName": "TrackingMode",
+                  "safeName": "TrackingMode"
+                }
+              },
+              "wireValue": "tracking_mode"
+            },
+            "valueType": {
+              "_type": "container",
+              "container": {
+                "_type": "optional",
+                "optional": {
+                  "_type": "named",
+                  "fernFilepath": {
+                    "allParts": [],
+                    "packagePath": [],
+                    "file": null
+                  },
+                  "name": {
+                    "originalName": "anduril.tasks.v2.LaunchTrackingMode",
+                    "camelCase": {
+                      "unsafeName": "andurilTasksV2LaunchTrackingMode",
+                      "safeName": "andurilTasksV2LaunchTrackingMode"
+                    },
+                    "snakeCase": {
+                      "unsafeName": "anduril_tasks_v_2_launch_tracking_mode",
+                      "safeName": "anduril_tasks_v_2_launch_tracking_mode"
+                    },
+                    "screamingSnakeCase": {
+                      "unsafeName": "ANDURIL_TASKS_V_2_LAUNCH_TRACKING_MODE",
+                      "safeName": "ANDURIL_TASKS_V_2_LAUNCH_TRACKING_MODE"
+                    },
+                    "pascalCase": {
+                      "unsafeName": "AndurilTasksV2LaunchTrackingMode",
+                      "safeName": "AndurilTasksV2LaunchTrackingMode"
+                    }
+                  },
+                  "typeId": "anduril.tasks.v2.LaunchTrackingMode",
+                  "default": null,
+                  "inline": false,
+                  "displayName": "tracking_mode"
                 }
               }
             },


### PR DESCRIPTION
## Description
- use convertGrpcReferenceToTypeReference for message fields that are enums

## Testing
- [X] Unit tests added/updated
- [X] Manual testing completed

