### PR TITLE
docs: Update project structure formatting and emphasis

### DIFF
--- a/fern/pages/docs/getting-started/project-structure.mdx
+++ b/fern/pages/docs/getting-started/project-structure.mdx
@@ -3,7 +3,7 @@ title: Project Structure
 description: An overview of the file and folder structure of a Fern Docs project
 ---
 
-This page provides an overview of the file and folder structure of a Fern Docs project. The following structure is recommended for organizing your documentation content, but is customizable to fit your needs.
+This page provides an overview of the file and folder structure of a Fern Docs project. The following structure is recommended for organizing your ***documentation*** content, but is customizable to fit your needs.
 
 ## Top-level folders 
 
@@ -20,11 +20,17 @@ This page provides an overview of the file and folder structure of a Fern Docs p
 
 A Fern Docs project has the following top-level folders:
 
-- `pages`: Contains the Markdown (MDX) files that make up your documentation.
-- `assets`: Contains any images or videos used in your documentation.
-- `docs.yml`: The configuration file that defines the navigation, theme, and hosting details of your documentation.
-- `openapi`: Contains the OpenAPI Specification file (if you have an API Reference section in your documentation).
-- `fern.config.json`: The configuration file specifying your organization name and CLI version.
+
+
+* `pages`: Contains the Markdown (MDX) files that make up your documentation.
+
+* `assets`: Contains any images or videos used in your documentation.
+
+* `docs.yml`: The configuration file that defines the navigation, theme, and hosting details of your documentation.
+
+* `openapi`: Contains the OpenAPI Specification file (if you have an API Reference section in your documentation).
+
+* `fern.config.json`: The configuration file specifying your organization name and CLI version.
 
 ## Pages folder
 
@@ -151,7 +157,6 @@ title: Fern's Documentation
   </Accordion>
 </AccordionGroup>
 
-
 ## `fern.config.json`
 
 The `fern.config.json` file specifies your organization name and the version of the Fern CLI used to generate the documentation. You can customize this file to reflect your organization's details.
@@ -164,3 +169,4 @@ The `fern.config.json` file specifies your organization name and the version of 
 }
 ```
 </CodeBlock>
+


### PR DESCRIPTION
This PR makes minor formatting improvements to the project structure documentation page. Changes include:
- Converting bullet points to a more spaced-out list format for better readability
- Adding emphasis to the word "documentation" in the introduction
- Removing an extra blank line
- Minor whitespace adjustments

These changes improve the visual presentation and readability of the documentation while maintaining the same content and structure.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)