### PR TITLE
fix(docs): renamed starter to basic plan

### DIFF
--- a/fern/pages/api-definition/openapi/extensions/others.mdx
+++ b/fern/pages/api-definition/openapi/extensions/others.mdx
@@ -391,7 +391,7 @@ paths:
                 client.users.get("Fern Fernie")
 ```
 
-If you're on the Fern Starter plan or higher for SDKs you won't have to worry about manually adding code samples! Our generators do that for you.
+If you're on the Fern Basic plan or higher for SDKs you won't have to worry about manually adding code samples! Our generators do that for you.
 
 ## Availability
 

--- a/fern/pages/docs/api-references/sdk-snippets.mdx
+++ b/fern/pages/docs/api-references/sdk-snippets.mdx
@@ -53,7 +53,7 @@ groups:
 
 <Callout intent='info'>
   SDK snippets automatically populated in your Fern Docs is a paid feature included
-  in the [SDK Starter plan](https://buildwithfern.com/pricing).
+  in the [SDK Basic plan](https://buildwithfern.com/pricing).
 </Callout>
 
 ### Add the package name to your docs configuration


### PR DESCRIPTION
## Description
Renamed starter plan to basic plan to reflect current pricing names

## Changes Made
Changed 2 instances of starter plan in the docs to basic plan
<img width="1057" height="146" alt="Screenshot 2025-07-17 at 8 19 36 AM" src="https://github.com/user-attachments/assets/02ab394d-1fa8-469c-ba83-71b01d473b21" />

<img width="1025" height="149" alt="Screenshot 2025-07-17 at 8 24 46 AM" src="https://github.com/user-attachments/assets/37d131ee-e24f-46b0-9568-a78dac6ecd05" />


## Testing
running local preview

