### PR TITLE
fix(java): bump java sdk version to 2.38.3 for Java reference.md gene…

### DIFF
--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.38.3
+  changelogEntry:
+    - summary: |
+        Add reference.md generation for Java SDKs.
+      type: fix
+  createdAt: '2025-07-16'
+  irVersion: 58
+
 - version: 2.38.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
I was mistaken about how we should bump the version for our SDK. Instead of updating the release version found in `packages/cli/cli/version.xml` it should be the java sdk version only that we should be updating. 

## Changes Made
Update version for java SDK

## Testing
No testing needed
