### PR TITLE
fix(java): use Java 8 compatible stream collection method

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/StreamTestGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/StreamTestGenerator.java
@@ -73,9 +73,10 @@ public final class StreamTestGenerator extends AbstractFileGenerator {
                 .addCode("        $T.of($S, $S)\n", ClassName.get("java.util", "Map"), "message", "world")
                 .addCode(");\n")
                 .addStatement(
-                        "$T jsonStrings = messages.stream().map($T::mapToJson).toList()",
+                        "$T jsonStrings = messages.stream().map($T::mapToJson).collect($T.toList())",
                         ClassName.get("java.util", "List"),
-                        ClassName.get(className.packageName(), STREAM_TEST_CLASS_NAME))
+                        ClassName.get(className.packageName(), STREAM_TEST_CLASS_NAME),
+                        ClassName.get("java.util.stream", "Collectors"))
                 .addStatement(
                         "$T input = $T.join($S, jsonStrings)",
                         ClassName.get(String.class),
@@ -114,9 +115,10 @@ public final class StreamTestGenerator extends AbstractFileGenerator {
                 .addCode("        $T.of($S, $S)\n", ClassName.get("java.util", "Map"), "event", "end")
                 .addCode(");\n")
                 .addStatement(
-                        "$T sseStrings = events.stream().map($T::mapToSse).toList()",
+                        "$T sseStrings = events.stream().map($T::mapToSse).collect($T.toList())",
                         ClassName.get("java.util", "List"),
-                        ClassName.get(className.packageName(), STREAM_TEST_CLASS_NAME))
+                        ClassName.get(className.packageName(), STREAM_TEST_CLASS_NAME),
+                        ClassName.get("java.util.stream", "Collectors"))
                 .addStatement(
                         "$T input = $T.join($S, sseStrings)",
                         ClassName.get(String.class),

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,11 @@
-# yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.38.4
+  changelogEntry:
+    - summary: |
+        Fix stream SSE test to use Java 8 compatible stream collection method.
+      type: fix
+  createdAt: '2025-07-17'
+  irVersion: 58
+
 - version: 2.38.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/server-sent-events/src/test/java/com/seed/serverSentEvents/StreamTest.java
+++ b/seed/java-sdk/server-sent-events/src/test/java/com/seed/serverSentEvents/StreamTest.java
@@ -18,7 +18,7 @@ public final class StreamTest {
     @Test
     public void testJsonStream() {
         List<Map> messages = List.of(Map.of("message", "hello"), Map.of("message", "world"));
-        List jsonStrings = messages.stream().map(StreamTest::mapToJson).toList();
+        List jsonStrings = messages.stream().map(StreamTest::mapToJson).collect(Collectors.toList());
         String input = String.join("\n", jsonStrings);
         StringReader jsonInput = new StringReader(input);
         Stream<Map> jsonStream = Stream.fromJson(Map.class, jsonInput);
@@ -34,7 +34,7 @@ public final class StreamTest {
     @Test
     public void testSseStream() {
         List<Map> events = List.of(Map.of("event", "start"), Map.of("event", "end"));
-        List sseStrings = events.stream().map(StreamTest::mapToSse).toList();
+        List sseStrings = events.stream().map(StreamTest::mapToSse).collect(Collectors.toList());
         String input = String.join("\n" + "\n", sseStrings);
         StringReader sseInput = new StringReader(input);
         Stream<Map> sseStream = Stream.fromSse(Map.class, sseInput);


### PR DESCRIPTION
## Description
Use Java 8 compatible stream collection method

Previous test file was using Java 16+ standards of `Stream.toList()`. However, this functionality does not exist on Java 8-15 and we need to use `collect()` as well. 

## Changes Made
- Updating StreamTest to go from `toList()` -> `collect(Collectors.toList())` 

## Testing
<!-- Describe how you tested these changes -->
- [X] Unit tests added/updated
- [X] Manual testing completed

