### PR TITLE
fix(java): remove okhttp util dependency and use try-with-resources statement 

### DIFF
--- a/generators/java/sdk/src/main/resources/InputStreamRequestBody.java
+++ b/generators/java/sdk/src/main/resources/InputStreamRequestBody.java
@@ -3,7 +3,6 @@ import java.io.InputStream;
 import java.util.Objects;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
@@ -63,12 +62,8 @@ public class InputStreamRequestBody extends RequestBody {
      */
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        Source source = null;
-        try {
-            source = Okio.source(inputStream);
+        try (Source source = Okio.source(inputStream)) {
             sink.writeAll(source);
-        } finally {
-            Util.closeQuietly(Objects.requireNonNull(source));
         }
     }
 }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 2.38.5
+  changelogEntry:
+    - summary: |
+        Remove internal OkHttp utility dependency and use a more robust file closing method. 
+      type: chore
+  createdAt: '2025-07-18'
+  irVersion: 58
+
 - version: 2.38.4
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/InputStreamRequestBody.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/InputStreamRequestBody.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.util.Objects;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
@@ -68,12 +67,8 @@ public class InputStreamRequestBody extends RequestBody {
      */
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        Source source = null;
-        try {
-            source = Okio.source(inputStream);
+        try (Source source = Okio.source(inputStream)) {
             sink.writeAll(source);
-        } finally {
-            Util.closeQuietly(Objects.requireNonNull(source));
         }
     }
 }

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/InputStreamRequestBody.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/InputStreamRequestBody.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.util.Objects;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
@@ -68,12 +67,8 @@ public class InputStreamRequestBody extends RequestBody {
      */
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        Source source = null;
-        try {
-            source = Okio.source(inputStream);
+        try (Source source = Okio.source(inputStream)) {
             sink.writeAll(source);
-        } finally {
-            Util.closeQuietly(Objects.requireNonNull(source));
         }
     }
 }

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/InputStreamRequestBody.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/InputStreamRequestBody.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.util.Objects;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
@@ -68,12 +67,8 @@ public class InputStreamRequestBody extends RequestBody {
      */
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        Source source = null;
-        try {
-            source = Okio.source(inputStream);
+        try (Source source = Okio.source(inputStream)) {
             sink.writeAll(source);
-        } finally {
-            Util.closeQuietly(Objects.requireNonNull(source));
         }
     }
 }


### PR DESCRIPTION
## Description
Remove `okhttp3.internal.Util` dependency and use try-with-resources statement. The old pattern utilized an flaky internal package that should not be used. See [here](https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/#backwards-incompatible-changes). 

Instead we now use a [try-with-resources statement](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) that automatically handles file closing in an elegant and standard way that is compatible since Java 7. 

## Changes Made
- Update file closing method using a try-with-resources statement 

## Testing
- [Not Applicable] Unit tests added/updated
- [X] Manual testing completed

## Manual Testing Steps and Artifacts 

Gonna keep for reference here in case need in future. 

Update OkHttp to 5.1.0

1. Updated versions:
   - versions.props: 4.12.0 → 5.1.0
   - ParsedGradleDependency.java: "4.12.0" → "5.1.0"

2. Regenerated lock file:
   `cd generators/java && ./gradlew --write-locks`

3. Tested generation with OkHttp 5.1.0:
   `pnpm seed test --generator java-sdk --fixture file-upload --skip-scripts`

4. Verified compilation:
   `cd seed/java-sdk/file-upload/no-custom-config && ./gradlew compileJava`

---

Success Artifacts

Generated build.gradle:
```api 'com.squareup.okhttp3:okhttp:5.1.0'```

Generated InputStreamRequestBody.java:
```@Override
public void writeTo(BufferedSink sink) throws IOException {
    try (Source source = Okio.source(inputStream)) {
        sink.writeAll(source);
    }
}
```

- No okhttp3.internal.Util import
- Uses try-with-resources

Test Results:
3/3 test cases passed 
BUILD SUCCESSFUL in 5s

Lock file confirms OkHttp 5.1.0:
com.squareup.okhttp3:okhttp:5.1.0 (1 constraints: 08050736)