### PR TITLE
chore(typescript): bump ts docker to node:22.12-alpine3.20

### DIFF
--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18-alpine3.20
+FROM node:22.12-alpine3.20
 
 RUN apk --no-cache add git zip
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.4.11
+  changelogEntry:
+    - summary: Bump the docker image for the generator to node:22.12-alpine3.20
+      type: chore
+  createdAt: "2025-07-18"
+  irVersion: 58
+
 - version: 2.4.10
   changelogEntry:
     - summary: Escape strings containing `*/` inside of JSDoc comments to avoid premature JSDoc block ending.


### PR DESCRIPTION
This PR bumps the TypeScript generator docker container `node:22.12-alpine3.20`