### PR TITLE
feat(fastapi): Bump release to support ignoring extra fields

### DIFF
--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.7.1
+  changelogEntry:
+    - summary: |
+        Enabled "ignore" as an option for extra fields
+      type: feat
+  createdAt: '2025-07-19'
+  irVersion: 58
+
 - version: 1.7.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
- Added a new fastapi generator version to support the `extra_fields: ignore` update I made in a previous PR [here](https://github.com/fern-api/fern/pull/8150)
## Changes Made
- All changes were made previously [here](https://github.com/fern-api/fern/pull/8150), just bumping fastapi to support this

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

