### PR TITLE
docs: Update support channel formatting and add email option

### DIFF
--- a/fern/pages/docs/getting-started/docs-overview.mdx
+++ b/fern/pages/docs/getting-started/docs-overview.mdx
@@ -7,7 +7,7 @@ layout: overview
 
 Fern Docs provides versatile documentation to support all your content needs, including popular formats like:
 
-- **Landing Pages** - High-level introductions with navigation for different audiences
+- **Landing Pages** - High-level introductions with navigation for different audiences and MORE
 
 - **Guides** - Step-by-step tutorials, user guides, and recipes/cookbooks
 

--- a/fern/pages/docs/getting-started/docs-overview.mdx
+++ b/fern/pages/docs/getting-started/docs-overview.mdx
@@ -6,9 +6,13 @@ layout: overview
 ---
 
 Fern Docs provides versatile documentation to support all your content needs, including popular formats like:
+
 - **Landing Pages** - High-level introductions with navigation for different audiences
+
 - **Guides** - Step-by-step tutorials, user guides, and recipes/cookbooks
+
 - **API References** - Auto-generated docs with request/response examples and auto-updating SDK snippets
+
 - **Changelogs** - Release notes for new features and fixes
 
 ## Key Features

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -135,9 +135,12 @@ software companies.
 
 We love talking to users! Reach out via your preferred support channel so we can help you succeed with Fern.
 
-1. 💬 Message us in your Dedicated Slack Channel (for paid customers)
+1. 💬 Message us in your Dedicated Slack Channel (for paid customers), or email us!
+
 2. 🤝 [Join our community Slack](https://buildwithfern.com/slack)
+
 3. 🐛 [File a GitHub Issue](https://github.com/fern-api/fern/issues)
+
 4. ✉️ [Email us](mailto:support@buildwithfern.com)
 
 We're lightning-fast with support - you'll typically hear back from us in hours, not days! 


### PR DESCRIPTION

Updates the formatting of support channel options in the welcome page by adding line breaks between items for better readability. Also adds email as an alternative contact method for paid customers in the first support channel option.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)