### PR TITLE
fix(swift): remove references to missing coding keys enum

### DIFF
--- a/generators/swift/model/src/object/ObjectGenerator.ts
+++ b/generators/swift/model/src/object/ObjectGenerator.ts
@@ -116,21 +116,25 @@ export class ObjectGenerator {
                 })
             ],
             body: swift.CodeBlock.withStatements([
-                swift.Statement.constantDeclaration(
-                    "container",
-                    swift.Expression.try(
-                        swift.Expression.methodCall({
-                            target: swift.Expression.reference("decoder"),
-                            methodName: "container",
-                            arguments_: [
-                                swift.functionArgument({
-                                    label: "keyedBy",
-                                    value: swift.Expression.rawValue("CodingKeys.self")
-                                })
-                            ]
-                        })
-                    )
-                ),
+                ...(this.objectTypeDeclaration.properties.length > 0
+                    ? [
+                          swift.Statement.constantDeclaration(
+                              "container",
+                              swift.Expression.try(
+                                  swift.Expression.methodCall({
+                                      target: swift.Expression.reference("decoder"),
+                                      methodName: "container",
+                                      arguments_: [
+                                          swift.functionArgument({
+                                              label: "keyedBy",
+                                              value: swift.Expression.rawValue("CodingKeys.self")
+                                          })
+                                      ]
+                                  })
+                              )
+                          )
+                      ]
+                    : []),
                 ...this.objectTypeDeclaration.properties.map((p) => {
                     const swiftType = getSwiftTypeForTypeReference(p.valueType);
                     return swift.Statement.propertyAssignment(
@@ -193,21 +197,25 @@ export class ObjectGenerator {
             throws: true,
             returnType: swift.Type.void(),
             body: swift.CodeBlock.withStatements([
-                swift.Statement.variableDeclaration(
-                    "container",
-                    swift.Expression.try(
-                        swift.Expression.methodCall({
-                            target: swift.Expression.reference("encoder"),
-                            methodName: "container",
-                            arguments_: [
-                                swift.functionArgument({
-                                    label: "keyedBy",
-                                    value: swift.Expression.rawValue("CodingKeys.self")
-                                })
-                            ]
-                        })
-                    )
-                ),
+                ...(this.objectTypeDeclaration.properties.length > 0
+                    ? [
+                          swift.Statement.variableDeclaration(
+                              "container",
+                              swift.Expression.try(
+                                  swift.Expression.methodCall({
+                                      target: swift.Expression.reference("encoder"),
+                                      methodName: "container",
+                                      arguments_: [
+                                          swift.functionArgument({
+                                              label: "keyedBy",
+                                              value: swift.Expression.rawValue("CodingKeys.self")
+                                          })
+                                      ]
+                                  })
+                              )
+                          )
+                      ]
+                    : []),
                 swift.Statement.expressionStatement(
                     swift.Expression.try(
                         swift.Expression.methodCall({

--- a/generators/swift/model/src/object/ObjectGenerator.ts
+++ b/generators/swift/model/src/object/ObjectGenerator.ts
@@ -162,10 +162,15 @@ export class ObjectGenerator {
                             target: swift.Expression.reference("decoder"),
                             methodName: "decodeAdditionalProperties",
                             arguments_: [
-                                swift.functionArgument({
-                                    label: "using",
-                                    value: swift.Expression.rawValue("CodingKeys.self")
-                                })
+                                this.objectTypeDeclaration.properties.length === 0
+                                    ? swift.functionArgument({
+                                          label: "knownKeys",
+                                          value: swift.Expression.rawValue("[]")
+                                      })
+                                    : swift.functionArgument({
+                                          label: "using",
+                                          value: swift.Expression.rawValue("CodingKeys.self")
+                                      })
                             ]
                         })
                     )

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/A.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/A.swift
@@ -6,12 +6,10 @@ public struct A: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/A.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/A.swift
@@ -7,7 +7,7 @@ public struct A: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/Acai.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/Acai.swift
@@ -6,12 +6,10 @@ public struct Acai: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/Acai.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/Acai.swift
@@ -7,7 +7,7 @@ public struct Acai: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/LeafNode.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/LeafNode.swift
@@ -6,12 +6,10 @@ public struct LeafNode: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/LeafNode.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/LeafNode.swift
@@ -7,7 +7,7 @@ public struct LeafNode: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/ObjectValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/ObjectValue.swift
@@ -6,12 +6,10 @@ public struct ObjectValue: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/ObjectValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/ObjectValue.swift
@@ -7,7 +7,7 @@ public struct ObjectValue: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {

--- a/seed/swift-sdk/circular-references/Sources/Schemas/A.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/A.swift
@@ -6,12 +6,10 @@ public struct A: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Schemas/A.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/A.swift
@@ -7,7 +7,7 @@ public struct A: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {

--- a/seed/swift-sdk/circular-references/Sources/Schemas/ObjectValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/ObjectValue.swift
@@ -6,12 +6,10 @@ public struct ObjectValue: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Schemas/ObjectValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/ObjectValue.swift
@@ -7,7 +7,7 @@ public struct ObjectValue: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {

--- a/seed/swift-sdk/trace/Sources/Schemas/TerminatedResponse.swift
+++ b/seed/swift-sdk/trace/Sources/Schemas/TerminatedResponse.swift
@@ -6,12 +6,10 @@ public struct TerminatedResponse: Codable, Hashable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Schemas/TerminatedResponse.swift
+++ b/seed/swift-sdk/trace/Sources/Schemas/TerminatedResponse.swift
@@ -7,7 +7,7 @@ public struct TerminatedResponse: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
     }
 
     public func encode(to encoder: Encoder) throws -> Void {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Structs that have 0 properties (other than `additionalProperties`) don't have a `CodingKeys` enum so we shouldn't have any references to it in the decoder and encoder.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updates ObjectGenerator to fix the above bug
- Updates seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

