### PR TITLE
EXP Python Wire Test Generation using dynamic snippets

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
@@ -20,4 +20,10 @@ export interface Options {
 
     // Style of the generated snippets. By default, the executable style is used.
     style?: Style;
+
+    // Whether to capture the response from the method call into a variable
+    captureResponse?: boolean;
+
+    // Optional name for the response variable (defaults to "response")
+    responseVariableName?: string;
 }

--- a/generators/python-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -1,4 +1,4 @@
-import { AbstractDynamicSnippetsGenerator, FernGeneratorExec } from "@fern-api/browser-compatible-base-generator";
+import { AbstractDynamicSnippetsGenerator, FernGeneratorExec, Options } from "@fern-api/browser-compatible-base-generator";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 
 import { EndpointSnippetGenerator } from "./EndpointSnippetGenerator";
@@ -19,13 +19,17 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
     }
 
     public async generate(
-        request: FernIr.dynamic.EndpointSnippetRequest
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options?: Options
     ): Promise<FernIr.dynamic.EndpointSnippetResponse> {
-        return super.generate(request);
+        return super.generate(request, options);
     }
 
-    public generateSync(request: FernIr.dynamic.EndpointSnippetRequest): FernIr.dynamic.EndpointSnippetResponse {
-        return super.generateSync(request);
+    public generateSync(
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options?: Options
+    ): FernIr.dynamic.EndpointSnippetResponse {
+        return super.generateSync(request, options);
     }
 
     protected createSnippetGenerator(context: DynamicSnippetsGeneratorContext): EndpointSnippetGenerator {

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -3,6 +3,7 @@ import { Severity } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { python } from "@fern-api/python-ast";
+import { Options } from "@fern-api/browser-compatible-base-generator";
 
 import { DynamicSnippetsGeneratorContext } from "./context/DynamicSnippetsGeneratorContext";
 import { FilePropertyInfo } from "./context/FilePropertyMapper";
@@ -24,36 +25,42 @@ export class EndpointSnippetGenerator {
 
     public async generateSnippet({
         endpoint,
-        request
+        request,
+        options
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
     }): Promise<string> {
-        const file = this.buildPythonFile({ endpoint, snippet: request });
+        const file = this.buildPythonFile({ endpoint, snippet: request, options });
         return file.toString();
     }
 
     public generateSnippetSync({
         endpoint,
-        request
+        request,
+        options
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
     }): string {
-        const file = this.buildPythonFile({ endpoint, snippet: request });
+        const file = this.buildPythonFile({ endpoint, snippet: request, options });
         return file.toString();
     }
 
     private buildPythonFile({
         endpoint,
-        snippet
+        snippet,
+        options
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
     }): python.PythonFile {
         return python.file({
             path: SNIPPET_MODULE_PATH,
-            statements: [this.constructClient({ endpoint, snippet }), this.callMethod({ endpoint, snippet })]
+            statements: [this.constructClient({ endpoint, snippet }), this.callMethod({ endpoint, snippet, options })]
         });
     }
 
@@ -359,11 +366,30 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        options
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
     }): python.AstNode {
+        if (options?.captureResponse) {
+            const responseVarName = options.responseVariableName || "response";
+            return python.assign({
+                lhs: python.reference({ name: responseVarName }),
+                rhs: python.invokeMethod({
+                    on: python.reference({ name: CLIENT_VAR_NAME }),
+                    method: this.getMethod({ endpoint }),
+                    arguments_: this.getMethodArgs({ endpoint, snippet }).map((arg) =>
+                        python.methodArgument({
+                            name: arg.name,
+                            value: arg.value
+                        })
+                    ),
+                    multiline: true
+                })
+            });
+        }
         return python.invokeMethod({
             on: python.reference({ name: CLIENT_VAR_NAME }),
             method: this.getMethod({ endpoint }),

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -32,6 +32,7 @@
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/python-base": "workspace:*",
+    "@fern-api/fs-utils": "workspace:*",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",
     "@fern-api/logger": "workspace:*",

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -34,12 +34,14 @@
     "@fern-api/python-base": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/python-dynamic-snippets": "workspace:*",
+    "@fern-api/dynamic-ir-sdk": "^58.2.0",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-cli-sdk": "0.0.28",
     "@trivago/prettier-plugin-sort-imports": "^5.2.1",
     "@types/node": "18.15.3",
+    "@types/url-join": "4.0.1",
     "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.14",
     "depcheck": "^1.4.7",
     "esbuild": "^0.25.0",
@@ -47,6 +49,7 @@
     "prettier": "^3.4.2",
     "tsup": "^8.0.2",
     "typescript": "5.7.2",
+    "url-join": "^5.0.0",
     "vitest": "^2.1.9",
     "zod": "^3.22.4"
   }

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -33,6 +33,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/python-base": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/python-dynamic-snippets": "workspace:*",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",
     "@fern-api/logger": "workspace:*",

--- a/generators/python-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorContext.ts
@@ -1,6 +1,6 @@
 import { GeneratorNotificationService } from "@fern-api/base-generator";
 import { AbstractPythonGeneratorContext, PythonProject } from "@fern-api/python-base";
-import { PythonWireTestGenerator } from "./test-generation";
+import { PythonWireTestGenerator } from "./test-generation/PythonWireTestGenerator";
 
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
@@ -31,13 +31,18 @@ export class SdkGeneratorContext extends AbstractPythonGeneratorContext<SdkCusto
             // Add required dependencies for wire tests
             this.addWireTestDependencies();
             
-            const wireTestGenerator = new PythonWireTestGenerator(this);
-            const wireTestFiles = wireTestGenerator.generateWireTests();
-            
-            // Add wire test files to the project
-            wireTestFiles.forEach(file => {
-                this.project.addRawFiles(file);
-            });
+            // Generate wire tests synchronously in constructor like the original
+            try {
+                const wireTestGenerator = new PythonWireTestGenerator(this);
+                const wireTestFiles = wireTestGenerator.generateWireTests();
+                
+                // Add wire test files to the project
+                wireTestFiles.forEach((file: any) => {
+                    this.project.addRawFiles(file);
+                });
+            } catch (error) {
+                this.logger.warn(`Failed to generate wire tests: ${error}`);
+            }
         }
     }
 
@@ -52,4 +57,6 @@ export class SdkGeneratorContext extends AbstractPythonGeneratorContext<SdkCusto
     private addWireTestDependencies(): void {
         // TODO: handle extra deps
     }
+
+
 }

--- a/generators/python-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorContext.ts
@@ -1,5 +1,6 @@
 import { GeneratorNotificationService } from "@fern-api/base-generator";
 import { AbstractPythonGeneratorContext, PythonProject } from "@fern-api/python-base";
+import { PythonWireTestGenerator } from "./test-generation";
 
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
@@ -24,6 +25,20 @@ export class SdkGeneratorContext extends AbstractPythonGeneratorContext<SdkCusto
             config: this.config,
             ir: this.ir
         });
+
+        // Generate wire tests if enabled
+        if (true) {  // TODO: ADD CONFIG FOR THIS
+            // Add required dependencies for wire tests
+            this.addWireTestDependencies();
+            
+            const wireTestGenerator = new PythonWireTestGenerator(this);
+            const wireTestFiles = wireTestGenerator.generateWireTests();
+            
+            // Add wire test files to the project
+            wireTestFiles.forEach(file => {
+                this.project.addRawFiles(file);
+            });
+        }
     }
 
     public getRawAsIsFiles(): string[] {
@@ -32,5 +47,9 @@ export class SdkGeneratorContext extends AbstractPythonGeneratorContext<SdkCusto
 
     public isSelfHosted(): boolean {
         return this.ir.selfHosted ?? false;
+    }
+
+    private addWireTestDependencies(): void {
+        // TODO: handle extra deps
     }
 }

--- a/generators/python-v2/sdk/src/index.ts
+++ b/generators/python-v2/sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./test-generation"; 

--- a/generators/python-v2/sdk/src/test-generation/PythonWireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/test-generation/PythonWireTestGenerator.ts
@@ -1,0 +1,566 @@
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { IntermediateRepresentation, HttpService, HttpEndpoint, ExampleEndpointCall } from "@fern-fern/ir-sdk/api";
+import { DynamicSnippetsGenerator } from "@fern-api/python-dynamic-snippets";
+import { dynamic } from "@fern-api/dynamic-ir-sdk/api";
+import urlJoin from "url-join";
+import { python } from "@fern-api/python-ast";
+
+import { AbstractPythonGeneratorContext, WriteablePythonFile } from "@fern-api/python-base";
+
+export class PythonWireTestGenerator {
+    private static readonly DEFAULT_BASE_URL = "http://example.test/";
+    private static readonly DEFAULT_RESPONSE_VARIABLE_NAME = "response";
+    
+    private context: AbstractPythonGeneratorContext<any>;
+    private dynamicSnippetsGenerator: DynamicSnippetsGenerator;
+
+    constructor(context: AbstractPythonGeneratorContext<any>) {
+        this.context = context;
+        
+        // Create dynamic snippets generator instance
+        this.dynamicSnippetsGenerator = new DynamicSnippetsGenerator({
+            ir: this.convertIrToDynamicIr(context.ir),
+            config: this.createGeneratorConfig(context)
+        });
+    }
+
+    public generateWireTests(): WriteablePythonFile[] {
+        const wireTestFiles: WriteablePythonFile[] = [];
+
+        // Generate wire tests for each service
+        for (const [serviceId, service] of Object.entries(this.context.ir.services)) {
+            const serviceContent = this.generateServiceContent(service);
+            if (serviceContent) {
+                wireTestFiles.push(serviceContent);
+            }
+        }
+
+        // Generate empty __init__.py
+        wireTestFiles.push(this.generateInitFile());
+
+        return wireTestFiles;
+    }
+
+    private generateServiceContent(service: HttpService): WriteablePythonFile | undefined {
+        const endpointsWithExamples = service.endpoints.filter(endpoint => 
+            this.hasUsableExamples(endpoint)
+        );
+        
+        if (endpointsWithExamples.length === 0) {
+            return undefined;
+        }
+
+        const serviceName = this.getServiceName(service);
+        
+        // Create the test class using AST
+        const testClass = python.class_({
+            name: `Test${serviceName}Wire`,
+            docs: `Wire tests for ${serviceName} endpoints using sync client`
+        });
+
+        // Generate test methods for each endpoint with examples
+        for (const endpoint of endpointsWithExamples) {
+            const examples = this.getEndpointExamples(endpoint);
+            
+            for (let i = 0; i < examples.length; i++) {
+                const example = examples[i]!;
+                const testMethod = this.generateWireTestMethodFromExample(endpoint, service, example, i);
+                if (testMethod) {
+                    testClass.add(testMethod);
+                }
+            }
+        }
+
+        // Create file and add imports
+        const file = python.file({ path: ["tests", "wire"] });
+        
+        // Add imports
+        file.addStatement(python.codeBlock("import httpx"));
+        file.addStatement(python.codeBlock("import respx"));
+        file.addStatement(python.codeBlock(""));  // Empty line
+        
+        // Add the test class
+        file.addStatement(testClass);
+
+        return new WriteablePythonFile({
+            contents: file,
+            directory: RelativeFilePath.of("tests/wire"),
+            filename: this.getServiceTestFileName(service)
+        });
+    }
+
+    private generateWireTestMethodFromExample(
+        endpoint: HttpEndpoint,
+        service: HttpService,
+        example: ExampleEndpointCall,
+        exampleIndex: number
+    ): python.Method | undefined {
+        const methodName = this.getEndpointMethodName(endpoint);
+        const testMethodName = exampleIndex > 0 ? `${methodName}_example_${exampleIndex}` : methodName;
+
+        // generate dynamic snippets
+        let snippetContent: string | undefined;
+        try {
+            const snippetRequest = this.convertExampleToSnippetRequest(example, endpoint);
+            const snippetResponse = this.dynamicSnippetsGenerator.generateSync(snippetRequest, {
+                captureResponse: true,
+                responseVariableName: PythonWireTestGenerator.DEFAULT_RESPONSE_VARIABLE_NAME
+            });
+            
+            snippetContent = snippetResponse.snippet;
+        } catch (snippetError) {
+            snippetContent = undefined;
+        }
+
+        // potentially fallback
+        if (!snippetContent) {
+            return this.generateFallbackTestMethod(endpoint, example, exampleIndex);
+        }
+
+        // create test method structure
+        const testMethod = python.method({
+            name: `test_${testMethodName}`,
+            parameters: [
+                python.parameter({ name: "self", type: undefined })
+            ],
+            return_: python.Type.none(),
+            docstring: `Test ${methodName} endpoint with wire test`,
+            decorators: [
+                python.decorator({
+                    callable: python.reference({ name: "respx.mock" })
+                })
+            ]
+        });
+
+        // add mock construction
+        const mockStatements = this.generateMockSetup(endpoint, example, testMethodName);
+        mockStatements.forEach(statement => testMethod.addStatement(statement));
+
+        // add dynamic snippet
+        testMethod.addStatement(python.codeBlock(snippetContent));
+
+        // add assertions
+        const responseAssertions = this.generateResponseAssertionsFromExample(example);
+        if (responseAssertions.trim()) {
+            testMethod.addStatement(python.codeBlock(responseAssertions));
+        }
+
+        return testMethod;
+    }
+
+    private generateMockSetup(
+        endpoint: HttpEndpoint,
+        example: ExampleEndpointCall,
+        testMethodName: string
+    ): python.AstNode[] {
+        const statements: python.AstNode[] = [];
+        
+        // Add expected URL assignment
+        const expectedUrl = this.buildExpectedUrl(example, endpoint);
+        statements.push(python.assign({
+            lhs: python.reference({ name: "expected_url" }),
+            rhs: python.TypeInstantiation.str(expectedUrl)
+        }));
+        
+        // Add mock response setup using proper AST construction
+        const mockResponse = this.extractResponseFromExample(example);
+        const statusCode = this.getResponseStatusCode(example, endpoint);
+        
+        const httpxResponseCall = python.instantiateClass({
+            classReference: python.reference({ name: "Response", modulePath: ["httpx"] }),
+            arguments_: [
+                python.methodArgument({ value: python.TypeInstantiation.int(statusCode) }),
+                python.methodArgument({ 
+                    name: "json", 
+                    value: python.codeBlock(JSON.stringify(mockResponse))
+                }),
+                python.methodArgument({ 
+                    name: "headers", 
+                    value: python.TypeInstantiation.dict([
+                        { 
+                            key: python.TypeInstantiation.str("content-type"), 
+                            value: python.TypeInstantiation.str("application/json") 
+                        }
+                    ])
+                })
+            ],
+            multiline: true
+        });
+        
+        statements.push(python.assign({
+            lhs: python.reference({ name: "expected_response" }),
+            rhs: httpxResponseCall
+        }));
+        
+        // Add respx mock setup using proper AST construction
+        const httpMethod = endpoint.method.toLowerCase();
+        const respxCall = python.invokeMethod({
+            on: python.reference({ name: "respx" }),
+            method: httpMethod,
+            arguments_: [
+                python.methodArgument({ value: python.reference({ name: "expected_url" }) })
+            ]
+        });
+        
+        // Assign the respx call to an intermediate variable
+        statements.push(python.assign({
+            lhs: python.reference({ name: `${testMethodName}_request` }),
+            rhs: respxCall
+        }));
+        
+        const mockSetup = python.invokeMethod({
+            on: python.reference({ name: `${testMethodName}_request` }),
+            method: "mock",
+            arguments_: [
+                python.methodArgument({ 
+                    name: "return_value",
+                    value: python.reference({ name: "expected_response" })
+                })
+            ]
+        });
+        
+        statements.push(python.assign({
+            lhs: python.reference({ name: `${testMethodName}_mock` }),
+            rhs: mockSetup
+        }));
+
+        return statements;
+    }
+
+    private generateInitFile(): WriteablePythonFile {
+        const file = python.file({ path: ["tests", "wire"] });
+        return new WriteablePythonFile({
+            contents: file,
+            directory: RelativeFilePath.of("tests/wire"),
+            filename: "__init__"
+        });
+    }
+
+    private hasUsableExamples(endpoint: HttpEndpoint): boolean {
+        const examples = this.getEndpointExamples(endpoint);
+        return examples.length > 0;
+    }
+
+    private getEndpointExamples(endpoint: HttpEndpoint): ExampleEndpointCall[] {
+        const examples: ExampleEndpointCall[] = [];
+        
+        // Get user-specified examples
+        if (endpoint.userSpecifiedExamples && endpoint.userSpecifiedExamples.length > 0) {
+            for (const userExample of endpoint.userSpecifiedExamples) {
+                if (userExample.example) {
+                    examples.push(userExample.example);
+                }
+            }
+        }
+        
+        // Get auto-generated examples if no user examples
+        if (examples.length === 0 && endpoint.autogeneratedExamples && endpoint.autogeneratedExamples.length > 0) {
+            for (const autoExample of endpoint.autogeneratedExamples) {
+                if (autoExample.example) {
+                    examples.push(autoExample.example);
+                }
+            }
+        }
+        
+        return examples;
+    }
+
+    private convertExampleToSnippetRequest(
+        example: ExampleEndpointCall,
+        endpoint: HttpEndpoint
+    ): dynamic.EndpointSnippetRequest {
+        // Create endpoint location
+        let path = endpoint.fullPath.head;
+        for (const part of endpoint.fullPath.parts) {
+            path += `{${part.pathParameter}}${part.tail}`;
+        }
+
+        const endpointLocation: dynamic.EndpointLocation = {
+            method: endpoint.method,
+            path
+        };
+
+        // Extract path parameters
+        const pathParameters: Record<string, unknown> = {};
+        [
+            ...(example.rootPathParameters || []),
+            ...(example.servicePathParameters || []),
+            ...(example.endpointPathParameters || [])
+        ].forEach((param) => {
+            pathParameters[param.name.originalName] = param.value.jsonExample;
+        });
+
+        // Extract query parameters
+        const queryParameters: Record<string, unknown> = {};
+        (example.queryParameters || []).forEach((param) => {
+            queryParameters[param.name.name.originalName] = param.value.jsonExample;
+        });
+
+        // Extract headers
+        const headers: Record<string, unknown> = {};
+        [...(example.serviceHeaders || []), ...(example.endpointHeaders || [])].forEach((header) => {
+            headers[header.name.name.originalName] = header.value.jsonExample;
+        });
+
+        // Extract request body
+        let requestBody: unknown = undefined;
+        if (example.request && example.request.type === "inlinedRequestBody") {
+            const properties: Record<string, unknown> = {};
+            example.request.properties.forEach((prop) => {
+                properties[prop.name.name.originalName] = prop.value.jsonExample;
+            });
+            requestBody = properties;
+        } else if (example.request && example.request.type === "reference") {
+            requestBody = example.request.jsonExample;
+        }
+
+        const request: dynamic.EndpointSnippetRequest = {
+            endpoint: endpointLocation,
+            baseURL: PythonWireTestGenerator.DEFAULT_BASE_URL,
+            pathParameters: Object.keys(pathParameters).length > 0 ? pathParameters : undefined,
+            queryParameters: Object.keys(queryParameters).length > 0 ? queryParameters : undefined,
+            headers: Object.keys(headers).length > 0 ? headers : undefined,
+            requestBody,
+            auth: undefined, // TODO: Extract auth from examples if needed
+            environment: undefined
+        };
+        
+        return request;
+    }
+
+    private generateFallbackTestMethod(
+        endpoint: HttpEndpoint,
+        example: ExampleEndpointCall,
+        exampleIndex: number
+    ): python.Method {
+        const methodName = this.getEndpointMethodName(endpoint);
+        const testMethodName = exampleIndex > 0 ? `${methodName}_example_${exampleIndex}_fallback` : `${methodName}_fallback`;
+        
+        const testMethod = python.method({
+            name: `test_${testMethodName}`,
+            parameters: [
+                python.parameter({ name: "self", type: undefined })
+            ],
+            return_: python.Type.none(),
+            docstring: `Test ${methodName} endpoint with wire test`,
+            decorators: [
+                python.decorator({
+                    callable: python.reference({ name: "pytest.mark.skip", modulePath: [] })
+                }),
+                python.decorator({
+                    callable: python.reference({ name: "respx.mock" })
+                })
+            ]
+        });
+
+        testMethod.addStatement(python.codeBlock("# TODO snippet generation failed -- manual implementation needed"));
+        testMethod.addStatement(python.codeBlock("pass"));
+
+        return testMethod;
+    }
+
+    private buildExpectedUrl(example: ExampleEndpointCall, endpoint: HttpEndpoint): string {
+        // Use the URL from the example if available, otherwise construct from base URL and path
+        if (example.url) {
+            return example.url;
+        }
+        
+        // Collect all path parameters from the example
+        const pathParameters = new Map<string, string>();
+        [
+            ...(example.rootPathParameters || []),
+            ...(example.servicePathParameters || []),
+            ...(example.endpointPathParameters || [])
+        ].forEach((param) => {
+            // Convert the JSON example to a string representation
+            let paramValue: string;
+            if (typeof param.value.jsonExample === 'string') {
+                paramValue = param.value.jsonExample;
+            } else {
+                paramValue = JSON.stringify(param.value.jsonExample);
+            }
+            pathParameters.set(param.name.originalName, paramValue);
+        });
+        
+        // Build the path with actual parameter values
+        let path = endpoint.fullPath.head;
+        for (const part of endpoint.fullPath.parts) {
+            // Use actual parameter value instead of placeholder
+            const paramValue = pathParameters.get(part.pathParameter) || part.pathParameter;
+            path = urlJoin(path, paramValue);
+            if (part.tail.length > 0) {
+                path = urlJoin(path, part.tail);
+            }
+        }
+        
+        // Properly join base URL with the constructed path
+        return urlJoin(PythonWireTestGenerator.DEFAULT_BASE_URL, path);
+    }
+
+    private extractRequestBodyFromExample(example: ExampleEndpointCall): any {
+        if (example.request && example.request.type === "inlinedRequestBody") {
+            const properties: Record<string, unknown> = {};
+            example.request.properties.forEach((prop) => {
+                properties[prop.name.name.originalName] = prop.value.jsonExample;
+            });
+            return properties;
+        } else if (example.request && example.request.type === "reference") {
+            return example.request.jsonExample;
+        }
+        return null;
+    }
+
+    private extractResponseFromExample(example: ExampleEndpointCall): any {
+        if (example.response && example.response.type === "ok") {
+            // For success responses, extract the jsonExample directly from the response body
+            if (example.response.value && example.response.value.type === "body") {
+                const responseValue = example.response.value.value;
+                if (responseValue && typeof responseValue === "object" && "jsonExample" in responseValue) {
+                    return responseValue.jsonExample;
+                }
+                // Fallback to the value itself if it doesn't have jsonExample wrapper
+                return responseValue;
+            }
+        }
+        
+        // Fallback for cases where we don't have proper response examples
+        return { message: "success" };
+    }
+
+    private generateResponseAssertionsFromExample(example: ExampleEndpointCall): string {
+        const responseVar = PythonWireTestGenerator.DEFAULT_RESPONSE_VARIABLE_NAME;
+        const responseData = this.extractResponseFromExample(example);
+        
+        if (!responseData || responseData === null) {
+            return `assert ${responseVar} is not None`;
+        }
+        
+        // Handle object responses (most common case)
+        if (typeof responseData === "object" && responseData !== null && !Array.isArray(responseData)) {
+            const assertions: string[] = [];
+            
+            Object.entries(responseData).forEach(([key, value]) => {
+                if (typeof value === "string") {
+                    assertions.push(`assert ${responseVar}.${key} == "${value}"`);
+                } else if (typeof value === "number") {
+                    assertions.push(`assert ${responseVar}.${key} == ${value}`);
+                } else if (typeof value === "boolean") {
+                    assertions.push(`assert ${responseVar}.${key} == ${value}`);
+                } else if (value === null) {
+                    assertions.push(`assert ${responseVar}.${key} is None`);
+                } else if (Array.isArray(value)) {
+                    assertions.push(`assert len(${responseVar}.${key}) == ${value.length}`);
+                    // Add basic type checking for array elements if not empty
+                    if (value.length > 0) {
+                        const firstElement = value[0];
+                        if (typeof firstElement === "string") {
+                            assertions.push(`assert all(isinstance(item, str) for item in ${responseVar}.${key})`);
+                        } else if (typeof firstElement === "number") {
+                            assertions.push(`assert all(isinstance(item, (int, float)) for item in ${responseVar}.${key})`);
+                        }
+                    }
+                } else {
+                    // For nested objects, just check they exist for now
+                    assertions.push(`assert ${responseVar}.${key} is not None`);
+                }
+            });
+            
+            if (assertions.length > 0) {
+                return assertions.join('\n');
+            }
+        } 
+        // Handle array responses
+        else if (Array.isArray(responseData)) {
+            const assertions: string[] = [];
+            assertions.push(`assert len(${responseVar}) == ${responseData.length}`);
+            
+            if (responseData.length > 0) {
+                const firstElement = responseData[0];
+                if (typeof firstElement === "string") {
+                    assertions.push(`assert all(isinstance(item, str) for item in ${responseVar})`);
+                } else if (typeof firstElement === "number") {
+                    assertions.push(`assert all(isinstance(item, (int, float)) for item in ${responseVar})`);
+                } else if (typeof firstElement === "object") {
+                    assertions.push(`assert all(isinstance(item, dict) for item in ${responseVar})`);
+                }
+            }
+            
+            return assertions.join('\n');
+        }
+        // Handle primitive responses
+        else {
+            if (typeof responseData === "string") {
+                return `assert ${responseVar} == "${responseData}"`;
+            } else if (typeof responseData === "number") {
+                return `assert ${responseVar} == ${responseData}`;
+            } else if (typeof responseData === "boolean") {
+                return `assert ${responseVar} == ${responseData}`;
+            } else {
+                return `assert ${responseVar} == ${JSON.stringify(responseData)}`;
+            }
+        }
+        
+        // Final fallback
+        return `assert ${responseVar} is not None`;
+    }
+
+    private getServiceSnakeCaseSafeName(service: HttpService): string {
+        if (service.name.fernFilepath.file) {
+            return this.context.getSnakeCaseSafeName(service.name.fernFilepath.file);
+        } else if (service.name.fernFilepath.allParts.length > 0) {
+            return this.context.getSnakeCaseSafeName(service.name.fernFilepath.allParts[service.name.fernFilepath.allParts.length - 1]!);
+        }
+        return "service";  // fallback
+    }
+
+    private getServiceName(service: HttpService): string {
+        return service.displayName || this.getServiceSnakeCaseSafeName(service);
+    }
+
+    private getServiceTestFileName(service: HttpService): string {
+        return `test_${this.getServiceSnakeCaseSafeName(service)}`;
+    }
+
+    private getEndpointMethodName(endpoint: HttpEndpoint): string {
+        return endpoint.name.snakeCase.safeName || "endpoint";
+    }
+
+    // Helper methods for dynamic snippets generator setup
+    private convertIrToDynamicIr(ir: IntermediateRepresentation): dynamic.DynamicIntermediateRepresentation {
+        // Check if dynamic IR is available
+        if (!ir.dynamic) {
+            throw new Error("Dynamic IR is not available - cannot generate wire tests using dynamic snippets. Make sure the IR generation includes dynamic snippets.");
+        }
+        
+        // The dynamic IR from the context should be compatible, but there might be type differences
+        // between @fern-fern/ir-sdk and @fern-api/dynamic-ir-sdk packages
+        // For now, we'll use type assertion but this should be fixed with proper conversion
+        return ir.dynamic as any;
+    }
+
+    private createGeneratorConfig(context: AbstractPythonGeneratorContext<any>): any {
+        // Extract the actual organization and workspace names from the context
+        // This ensures the dynamic snippets generator uses the same naming as the main generator
+        return {
+            organization: context.config.organization,
+            workspaceName: context.config.workspaceName,
+            customConfig: context.customConfig || {}
+        };
+    }
+
+    private getResponseStatusCode(example: ExampleEndpointCall, endpoint: HttpEndpoint): number {
+        // For success responses, default to appropriate status code based on HTTP method
+        switch (endpoint.method) {
+            case "POST":
+                return 201; // Created
+            case "PUT":
+            case "PATCH":
+            case "GET":
+                return 200; // OK
+            case "DELETE":
+                return 204; // No Content - but we'll use 200 since we're returning JSON
+            default:
+                return 200;
+        }
+    }
+} 

--- a/generators/python-v2/sdk/src/test-generation/index.ts
+++ b/generators/python-v2/sdk/src/test-generation/index.ts
@@ -1,0 +1,1 @@
+export * from "./PythonWireTestGenerator"; 

--- a/generators/python-v2/sdk/src/test-generation/index.ts
+++ b/generators/python-v2/sdk/src/test-generation/index.ts
@@ -1,1 +1,1 @@
-export * from "./PythonWireTestGenerator"; 
+export * from "./PythonWireTestGenerator";

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -234,6 +234,7 @@ pytest = "^7.4.0"
 pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
+respx = "^0.21.0"
 {dev_deps}"""
 
     @dataclass(frozen=True)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1900,6 +1900,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../packages/configs
+      '@fern-api/fs-utils':
+        specifier: workspace:*
+        version: link:../../../packages/commons/fs-utils
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1900,6 +1900,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../packages/configs
+      '@fern-api/dynamic-ir-sdk':
+        specifier: ^58.2.0
+        version: 58.2.0
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
@@ -1927,6 +1930,9 @@ importers:
       '@types/node':
         specifier: 18.15.3
         version: 18.15.3
+      '@types/url-join':
+        specifier: 4.0.1
+        version: 4.0.1
       '@yarnpkg/esbuild-plugin-pnp':
         specifier: ^3.0.0-rc.14
         version: 3.0.0-rc.15(esbuild@0.25.5)
@@ -1948,6 +1954,9 @@ importers:
       typescript:
         specifier: 5.7.2
         version: 5.7.2
+      url-join:
+        specifier: ^5.0.0
+        version: 5.0.0
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@18.15.3)(jsdom@20.0.3)(sass@1.89.2)(terser@5.43.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,6 +1909,9 @@ importers:
       '@fern-api/python-base':
         specifier: workspace:*
         version: link:../base
+      '@fern-api/python-dynamic-snippets':
+        specifier: workspace:*
+        version: link:../dynamic-snippets
       '@fern-fern/generator-cli-sdk':
         specifier: 0.0.28
         version: 0.0.28

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -47,6 +47,7 @@ pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"
+respx = "^0.21.0"
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]

--- a/seed/python-sdk/imdb/tests/wire/conftest.py
+++ b/seed/python-sdk/imdb/tests/wire/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+from seed import AsyncSeedApi, SeedApi
+
+BASE_URL = "https://example.test"
+
+@pytest.fixture
+def base_url() -> str:
+    """Return the base URL for the test environment"""
+    return BASE_URL
+
+@pytest.fixture
+def client() -> SeedApi:
+    """Create a sync client for testing"""
+    return SeedApi(
+        token="test_token",
+        base_url=BASE_URL
+    )
+
+
+@pytest.fixture
+def async_client() -> AsyncSeedApi:
+    """Create an async client for testing"""
+    return AsyncSeedApi(
+        token="test_token", 
+        base_url=BASE_URL
+    ) 

--- a/seed/python-sdk/imdb/tests/wire/test_imdb.py
+++ b/seed/python-sdk/imdb/tests/wire/test_imdb.py
@@ -1,0 +1,135 @@
+import httpx
+import respx
+
+from seed import AsyncSeedApi, SeedApi
+
+
+class TestImdbWire:
+    """Wire tests for IMDB endpoints using sync client"""
+
+    @respx.mock
+    def test_create_movie(self, client: SeedApi, base_url: str) -> None:
+        """Test create_movie endpoint with wire test"""
+
+        # mock endpoint
+        expected_url = f"{base_url}/movies/create-movie"
+        expected_json = {"title": "title", "rating": 1.1}
+        expected_response = httpx.Response(
+            200,
+            json="string",
+            headers={"content-type": "application/json"}
+        )
+        create_movie_mock = respx.post(expected_url, json=expected_json).mock(
+            return_value=expected_response
+        )
+
+        # make request
+        response = client.imdb.create_movie(
+            title="title",
+            rating=1.1
+        )
+
+        # verify response
+        assert response == "string"
+
+        # verify request was made
+        assert create_movie_mock.called
+        assert create_movie_mock.call_count == 1
+
+    @respx.mock
+    def test_get_movie(self, client: SeedApi, base_url: str) -> None:
+        """Test get_movie endpoint with wire test"""
+
+        response_body = {
+            "id": "id",
+            "title": "title",
+            "rating": 1.1
+        }
+
+        # mock endpoint
+        expected_url = f"{base_url}/movies/movieId"
+        expected_response = httpx.Response(
+            200,
+            json=response_body,
+            headers={"content-type": "application/json"}
+        )
+        get_movie_mock = respx.get(expected_url).mock(
+            return_value=expected_response
+        )
+
+        # make request
+        response = client.imdb.get_movie("movieId")
+
+        # verify response
+        assert response.id == "id"
+        assert response.title == "title"
+        assert response.rating == 1.1
+
+        # verify request was made
+        assert get_movie_mock.called
+        assert get_movie_mock.call_count == 1
+
+
+class TestImdbWireAsync:
+    """Wire tests for IMDB endpoints using async client"""
+
+    @respx.mock
+    async def test_create_movie_async(self, async_client: AsyncSeedApi, base_url: str) -> None:
+        """Test async create_movie endpoint with wire test"""
+
+        # mock endpoint
+        expected_url = f"{base_url}/movies/create-movie"
+        expected_response = httpx.Response(
+            200,
+            json="string",
+            headers={"content-type": "application/json"}
+        )
+        create_movie_mock = respx.post(expected_url).mock(
+            return_value=expected_response
+        )
+
+        # make request
+        response = await async_client.imdb.create_movie(
+            title="title",
+            rating=1.1
+        )
+
+        # verify response
+        assert response == "string"
+
+        # verify request was made
+        assert create_movie_mock.called
+        assert create_movie_mock.call_count == 1
+
+    @respx.mock
+    async def test_get_movie_async(self, async_client: AsyncSeedApi, base_url: str) -> None:
+        """Test async get_movie endpoint with wire test"""
+
+        response_body = {
+            "id": "id",
+            "title": "title",
+            "rating": 1.1
+        }
+
+        # mock endpoint
+        expected_url = f"{base_url}/movies/movieId"
+        expected_response = httpx.Response(
+            200,
+            json=response_body,
+            headers={"content-type": "application/json"}
+        )
+        get_movie_mock = respx.get(expected_url).mock(
+            return_value=expected_response
+        )
+
+        # make request
+        response = await async_client.imdb.get_movie("movieId")
+
+        # verify response
+        assert response.id == "id"
+        assert response.title == "title"
+        assert response.rating == 1.1
+
+        # verify request was made
+        assert get_movie_mock.called
+        assert get_movie_mock.call_count == 1


### PR DESCRIPTION
WIP draft

See cross-generator change to dynamic snippets Options.

---

As of 2025-07-22, generates wire tests for the IMDB API test definition as:

```python
import httpx

import respx



class TestimdbWire:
    """Wire tests for imdb endpoints using sync client"""
    @respx.mock
    def test_create_movie(self) -> None:
        """Test create_movie endpoint with wire test (generated from dynamic snippet)"""
        expected_url = "/movies/create-movie"
        expected_response = httpx.Response(
                    201,
                    json="string",
                    headers={"content-type": "application/json"}
                )
        create_movie_mock = respx.post(expected_url).mock(
                    return_value=expected_response
                )
        from seed import SeedApi
        
        client = SeedApi(
            base_url="http://example.test/"
        )
        
        response = client.imdb.create_movie(
            title="title",
            rating=1.1
        )

        assert response == "string"
    @respx.mock
    def test_get_movie(self) -> None:
        """Test get_movie endpoint with wire test (generated from dynamic snippet)"""
        expected_url = "/movies/movieId"
        expected_response = httpx.Response(
                    200,
                    json={"id":"id","title":"title","rating":1.1},
                    headers={"content-type": "application/json"}
                )
        get_movie_mock = respx.get(expected_url).mock(
                    return_value=expected_response
                )
        from seed import SeedApi
        
        client = SeedApi(
            base_url="http://example.test/"
        )
        
        response = client.imdb.get_movie(
            movie_id="movieId"
        )

        assert response.id == "id"
        assert response.title == "title"
        assert response.rating == 1.1

```