### PR TITLE
feat(swift): generate structs for inlined request body types

### DIFF
--- a/generators/swift/codegen/src/ast/Type.ts
+++ b/generators/swift/codegen/src/ast/Type.ts
@@ -178,6 +178,7 @@ export class Type extends AstNode {
                 writer.write("?");
                 break;
             case "custom":
+                // TODO(kafkas): We may need to escape reserved words here. Confirm this.
                 writer.write(this.internalType.name);
                 break;
             case "void":

--- a/generators/swift/codegen/src/ast/__test__/expression/expression.test.ts
+++ b/generators/swift/codegen/src/ast/__test__/expression/expression.test.ts
@@ -120,7 +120,7 @@ describe("Expression", () => {
                 ]
             });
 
-            expect(dictionaryLiteral.toString()).toMatchInlineSnapshot(`"["host": "localhost", "port": "8080"]"`);
+            expect(dictionaryLiteral.toString()).toMatchInlineSnapshot('"["host": "localhost", "port": "8080"]"');
         });
 
         it("should correctly write dictionary literal with multiple entries (multiline)", () => {

--- a/generators/swift/codegen/src/ast/__test__/method.test.ts
+++ b/generators/swift/codegen/src/ast/__test__/method.test.ts
@@ -144,7 +144,7 @@ describe("Method", () => {
                         type: Type.optional(Type.bool())
                     })
                 ],
-                returnType: Type.custom("User?")
+                returnType: Type.optional(Type.custom("User"))
             });
 
             expect(method.toString()).toMatchInlineSnapshot(

--- a/generators/swift/model/src/generateInlinedRequestModels.ts
+++ b/generators/swift/model/src/generateInlinedRequestModels.ts
@@ -1,0 +1,22 @@
+import { SwiftFile } from "@fern-api/swift-base";
+
+import { ModelGeneratorContext } from "./ModelGeneratorContext";
+import { ObjectGenerator } from "./object";
+
+export function generateInlinedRequestModels({ context }: { context: ModelGeneratorContext }): SwiftFile[] {
+    const files: SwiftFile[] = [];
+    Object.entries(context.ir.services).forEach(([_, service]) => {
+        service.endpoints.forEach((endpoint) => {
+            if (endpoint.requestBody?.type === "inlinedRequestBody") {
+                const generator = new ObjectGenerator(
+                    endpoint.requestBody.name.pascalCase.unsafeName,
+                    "inlined-request",
+                    endpoint.requestBody.properties,
+                    endpoint.requestBody.extendedProperties
+                );
+                files.push(generator.generate());
+            }
+        });
+    });
+    return files;
+}

--- a/generators/swift/model/src/generateModels.ts
+++ b/generators/swift/model/src/generateModels.ts
@@ -10,7 +10,13 @@ export function generateModels({ context }: { context: ModelGeneratorContext }):
         const file = typeDeclaration.shape._visit<SwiftFile | undefined>({
             alias: () => undefined,
             enum: (etd) => new StringEnumGenerator(typeDeclaration, etd).generate(),
-            object: (otd) => new ObjectGenerator(typeDeclaration, otd).generate(),
+            object: (otd) =>
+                new ObjectGenerator(
+                    typeDeclaration.name.name.pascalCase.unsafeName,
+                    "schema",
+                    otd.properties,
+                    otd.extendedProperties
+                ).generate(),
             undiscriminatedUnion: () => undefined,
             union: () => undefined,
             _other: () => undefined

--- a/generators/swift/model/src/index.ts
+++ b/generators/swift/model/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./converters";
 export * from "./helpers";
+export * from "./generateInlinedRequestModels";
 export * from "./generateModels";

--- a/generators/swift/model/src/object/ObjectGenerator.ts
+++ b/generators/swift/model/src/object/ObjectGenerator.ts
@@ -3,12 +3,7 @@ import { RelativeFilePath } from "@fern-api/fs-utils";
 import { SwiftFile } from "@fern-api/swift-base";
 import { swift } from "@fern-api/swift-codegen";
 
-import {
-    InlinedRequestBodyProperty,
-    ObjectProperty,
-    ObjectTypeDeclaration,
-    TypeDeclaration
-} from "@fern-fern/ir-sdk/api";
+import { InlinedRequestBodyProperty, ObjectProperty } from "@fern-fern/ir-sdk/api";
 
 import { getSwiftTypeForTypeReference } from "../converters";
 

--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -1,7 +1,6 @@
 import { GeneratorNotificationService } from "@fern-api/base-generator";
-import { RelativeFilePath } from "@fern-api/fs-utils";
 import { AbstractSwiftGeneratorCli, SwiftFile } from "@fern-api/swift-base";
-import { generateModels } from "@fern-api/swift-model";
+import { generateInlinedRequestModels, generateModels } from "@fern-api/swift-model";
 
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
@@ -81,6 +80,10 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
         // Schemas/**/*.swift
         const modelFiles = generateModels({ context });
         files.push(...modelFiles);
+
+        // Requests/**/*.swift
+        const inlinedRequestFiles = generateInlinedRequestModels({ context });
+        files.push(...inlinedRequestFiles);
 
         return files;
     }

--- a/generators/swift/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/SubClientGenerator.ts
@@ -115,7 +115,7 @@ export class SubClientGenerator {
                     swift.functionParameter({
                         argumentLabel: pathPart.unsafeNameCamelCase,
                         unsafeName: pathPart.unsafeNameCamelCase,
-                        type: swift.Type.custom("String")
+                        type: swift.Type.string()
                     })
                 );
             }
@@ -193,13 +193,13 @@ export class SubClientGenerator {
         return (
             endpoint.response.body?._visit({
                 json: (resp) => getSwiftTypeForTypeReference(resp.responseBodyType),
-                fileDownload: () => swift.Type.custom("Any"),
-                text: () => swift.Type.custom("Any"),
-                bytes: () => swift.Type.custom("Any"),
-                streaming: () => swift.Type.custom("Any"),
-                streamParameter: () => swift.Type.custom("Any"),
-                _other: () => swift.Type.custom("Any")
-            }) ?? swift.Type.custom("Any")
+                fileDownload: () => swift.Type.any(),
+                text: () => swift.Type.any(),
+                bytes: () => swift.Type.any(),
+                streaming: () => swift.Type.any(),
+                streamParameter: () => swift.Type.any(),
+                _other: () => swift.Type.any()
+            }) ?? swift.Type.any()
         );
     }
 

--- a/generators/swift/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/SubClientGenerator.ts
@@ -155,12 +155,11 @@ export class SubClientGenerator {
                     })
                 );
             } else if (endpoint.requestBody.type === "inlinedRequestBody") {
-                // TODO(kafkas): Handle inlined request body types
                 params.push(
                     swift.functionParameter({
                         argumentLabel: "request",
                         unsafeName: "request",
-                        type: swift.Type.any()
+                        type: swift.Type.custom(endpoint.requestBody.name.pascalCase.unsafeName)
                     })
                 );
             } else {

--- a/seed/swift-sdk/alias-extends/Sources/Requests/InlinedChildRequest.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Requests/InlinedChildRequest.swift
@@ -1,0 +1,25 @@
+public struct InlinedChildRequest: Codable, Hashable {
+    public let child: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(child: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.child = child
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.child = try container.decode(String.self, forKey: .child)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.child, forKey: .child)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case child
+    }
+}

--- a/seed/swift-sdk/any-auth/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/any-auth/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,45 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/any-auth/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/any-auth/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getToken(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/audiences/Sources/Requests/FindRequest.swift
+++ b/seed/swift-sdk/audiences/Sources/Requests/FindRequest.swift
@@ -1,0 +1,30 @@
+public struct FindRequest: Codable, Hashable {
+    public let publicProperty: String?
+    public let privateProperty: Int?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(publicProperty: String? = nil, privateProperty: Int? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.publicProperty = publicProperty
+        self.privateProperty = privateProperty
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.publicProperty = try container.decodeIfPresent(String.self, forKey: .publicProperty)
+        self.privateProperty = try container.decodeIfPresent(Int.self, forKey: .privateProperty)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.publicProperty, forKey: .publicProperty)
+        try container.encodeIfPresent(self.privateProperty, forKey: .privateProperty)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case publicProperty
+        case privateProperty
+    }
+}

--- a/seed/swift-sdk/audiences/Sources/Resources/Foo.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/Foo.swift
@@ -5,7 +5,7 @@ public final class FooClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func find(optionalString: OptionalString, request: Any, requestOptions: RequestOptions? = nil) async throws -> ImportingType {
+    public func find(optionalString: OptionalString, request: FindRequest, requestOptions: RequestOptions? = nil) async throws -> ImportingType {
         return try await httpClient.performRequest(
             method: .post,
             path: "/",

--- a/seed/swift-sdk/content-type/Sources/Requests/PatchProxyRequest.swift
+++ b/seed/swift-sdk/content-type/Sources/Requests/PatchProxyRequest.swift
@@ -1,0 +1,30 @@
+public struct PatchProxyRequest: Codable, Hashable {
+    public let application: Any
+    public let requireAuth: Any
+    public let additionalProperties: [String: JSONValue]
+
+    public init(application: Any, requireAuth: Any, additionalProperties: [String: JSONValue] = .init()) {
+        self.application = application
+        self.requireAuth = requireAuth
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.application = try container.decode(Any.self, forKey: .application)
+        self.requireAuth = try container.decode(Any.self, forKey: .requireAuth)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.application, forKey: .application)
+        try container.encode(self.requireAuth, forKey: .requireAuth)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case application
+        case requireAuth = "require_auth"
+    }
+}

--- a/seed/swift-sdk/content-type/Sources/Resources/Service.swift
+++ b/seed/swift-sdk/content-type/Sources/Resources/Service.swift
@@ -5,7 +5,7 @@ public final class ServiceClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func patch(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func patch(request: PatchProxyRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .patch,
             path: "/",

--- a/seed/swift-sdk/cross-package-type-names/Sources/Requests/FindRequest.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Requests/FindRequest.swift
@@ -1,0 +1,30 @@
+public struct FindRequest: Codable, Hashable {
+    public let publicProperty: String?
+    public let privateProperty: Int?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(publicProperty: String? = nil, privateProperty: Int? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.publicProperty = publicProperty
+        self.privateProperty = privateProperty
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.publicProperty = try container.decodeIfPresent(String.self, forKey: .publicProperty)
+        self.privateProperty = try container.decodeIfPresent(Int.self, forKey: .privateProperty)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.publicProperty, forKey: .publicProperty)
+        try container.encodeIfPresent(self.privateProperty, forKey: .privateProperty)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case publicProperty
+        case privateProperty
+    }
+}

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/Foo.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/Foo.swift
@@ -5,7 +5,7 @@ public final class FooClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func find(optionalString: OptionalString, request: Any, requestOptions: RequestOptions? = nil) async throws -> ImportingType {
+    public func find(optionalString: OptionalString, request: FindRequest, requestOptions: RequestOptions? = nil) async throws -> ImportingType {
         return try await httpClient.performRequest(
             method: .post,
             path: "/",

--- a/seed/swift-sdk/enum/Sources/Requests/SendEnumInlinedRequest.swift
+++ b/seed/swift-sdk/enum/Sources/Requests/SendEnumInlinedRequest.swift
@@ -1,0 +1,40 @@
+public struct SendEnumInlinedRequest: Codable, Hashable {
+    public let operand: Operand
+    public let maybeOperand: Operand?
+    public let operandOrColor: ColorOrOperand
+    public let maybeOperandOrColor: ColorOrOperand?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(operand: Operand, maybeOperand: Operand? = nil, operandOrColor: ColorOrOperand, maybeOperandOrColor: ColorOrOperand? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.operand = operand
+        self.maybeOperand = maybeOperand
+        self.operandOrColor = operandOrColor
+        self.maybeOperandOrColor = maybeOperandOrColor
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.operand = try container.decode(Operand.self, forKey: .operand)
+        self.maybeOperand = try container.decodeIfPresent(Operand.self, forKey: .maybeOperand)
+        self.operandOrColor = try container.decode(ColorOrOperand.self, forKey: .operandOrColor)
+        self.maybeOperandOrColor = try container.decodeIfPresent(ColorOrOperand.self, forKey: .maybeOperandOrColor)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.operand, forKey: .operand)
+        try container.encodeIfPresent(self.maybeOperand, forKey: .maybeOperand)
+        try container.encode(self.operandOrColor, forKey: .operandOrColor)
+        try container.encodeIfPresent(self.maybeOperandOrColor, forKey: .maybeOperandOrColor)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case operand
+        case maybeOperand
+        case operandOrColor
+        case maybeOperandOrColor
+    }
+}

--- a/seed/swift-sdk/enum/Sources/Resources/InlinedRequest.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/InlinedRequest.swift
@@ -5,7 +5,7 @@ public final class InlinedRequestClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func send(request: SendEnumInlinedRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/inlined",

--- a/seed/swift-sdk/exhaustive/Sources/Requests/PostWithObjectBody.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Requests/PostWithObjectBody.swift
@@ -1,0 +1,35 @@
+public struct PostWithObjectBody: Codable, Hashable {
+    public let string: String
+    public let integer: Int
+    public let nestedObject: ObjectWithOptionalField
+    public let additionalProperties: [String: JSONValue]
+
+    public init(string: String, integer: Int, nestedObject: ObjectWithOptionalField, additionalProperties: [String: JSONValue] = .init()) {
+        self.string = string
+        self.integer = integer
+        self.nestedObject = nestedObject
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.string = try container.decode(String.self, forKey: .string)
+        self.integer = try container.decode(Int.self, forKey: .integer)
+        self.nestedObject = try container.decode(ObjectWithOptionalField.self, forKey: .nestedObject)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.string, forKey: .string)
+        try container.encode(self.integer, forKey: .integer)
+        try container.encode(self.nestedObject, forKey: .nestedObject)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case string
+        case integer
+        case nestedObject = "NestedObject"
+    }
+}

--- a/seed/swift-sdk/exhaustive/Sources/Resources/InlinedRequests.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/InlinedRequests.swift
@@ -5,7 +5,7 @@ public final class InlinedRequestsClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func postWithObjectBodyandResponse(request: Any, requestOptions: RequestOptions? = nil) async throws -> ObjectWithOptionalField {
+    public func postWithObjectBodyandResponse(request: PostWithObjectBody, requestOptions: RequestOptions? = nil) async throws -> ObjectWithOptionalField {
         return try await httpClient.performRequest(
             method: .post,
             path: "/req-bodies/object",

--- a/seed/swift-sdk/extends/Sources/Requests/Inlined.swift
+++ b/seed/swift-sdk/extends/Sources/Requests/Inlined.swift
@@ -1,0 +1,25 @@
+public struct Inlined: Codable, Hashable {
+    public let unique: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(unique: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.unique = unique
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.unique = try container.decode(String.self, forKey: .unique)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.unique, forKey: .unique)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case unique
+    }
+}

--- a/seed/swift-sdk/extra-properties/Sources/Requests/CreateUserRequest.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Requests/CreateUserRequest.swift
@@ -1,0 +1,35 @@
+public struct CreateUserRequest: Codable, Hashable {
+    public let type: Any
+    public let version: Any
+    public let name: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(type: Any, version: Any, name: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.type = type
+        self.version = version
+        self.name = name
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(Any.self, forKey: .type)
+        self.version = try container.decode(Any.self, forKey: .version)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.type, forKey: .type)
+        try container.encode(self.version, forKey: .version)
+        try container.encode(self.name, forKey: .name)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case type = "_type"
+        case version = "_version"
+        case name
+    }
+}

--- a/seed/swift-sdk/extra-properties/Sources/Resources/User.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Resources/User.swift
@@ -5,7 +5,7 @@ public final class UserClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func createUser(request: Any, requestOptions: RequestOptions? = nil) async throws -> User {
+    public func createUser(request: CreateUserRequest, requestOptions: RequestOptions? = nil) async throws -> User {
         return try await httpClient.performRequest(
             method: .post,
             path: "/user",

--- a/seed/swift-sdk/idempotency-headers/Sources/Requests/CreatePaymentRequest.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Requests/CreatePaymentRequest.swift
@@ -1,0 +1,30 @@
+public struct CreatePaymentRequest: Codable, Hashable {
+    public let amount: Int
+    public let currency: Currency
+    public let additionalProperties: [String: JSONValue]
+
+    public init(amount: Int, currency: Currency, additionalProperties: [String: JSONValue] = .init()) {
+        self.amount = amount
+        self.currency = currency
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.amount = try container.decode(Int.self, forKey: .amount)
+        self.currency = try container.decode(Currency.self, forKey: .currency)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.amount, forKey: .amount)
+        try container.encode(self.currency, forKey: .currency)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case amount
+        case currency
+    }
+}

--- a/seed/swift-sdk/idempotency-headers/Sources/Resources/Payment.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Resources/Payment.swift
@@ -5,7 +5,7 @@ public final class PaymentClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func create(request: Any, requestOptions: RequestOptions? = nil) async throws -> UUID {
+    public func create(request: CreatePaymentRequest, requestOptions: RequestOptions? = nil) async throws -> UUID {
         return try await httpClient.performRequest(
             method: .post,
             path: "/payment",

--- a/seed/swift-sdk/literal/Sources/Requests/SendLiteralsInHeadersRequest.swift
+++ b/seed/swift-sdk/literal/Sources/Requests/SendLiteralsInHeadersRequest.swift
@@ -1,0 +1,25 @@
+public struct SendLiteralsInHeadersRequest: Codable, Hashable {
+    public let query: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(query: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.query = query
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.query = try container.decode(String.self, forKey: .query)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.query, forKey: .query)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case query
+    }
+}

--- a/seed/swift-sdk/literal/Sources/Requests/SendLiteralsInlinedRequest.swift
+++ b/seed/swift-sdk/literal/Sources/Requests/SendLiteralsInlinedRequest.swift
@@ -1,0 +1,60 @@
+public struct SendLiteralsInlinedRequest: Codable, Hashable {
+    public let prompt: Any
+    public let context: Any?
+    public let query: String
+    public let temperature: Double?
+    public let stream: Any
+    public let aliasedContext: SomeAliasedLiteral
+    public let maybeContext: SomeAliasedLiteral?
+    public let objectWithLiteral: ATopLevelLiteral
+    public let additionalProperties: [String: JSONValue]
+
+    public init(prompt: Any, context: Any? = nil, query: String, temperature: Double? = nil, stream: Any, aliasedContext: SomeAliasedLiteral, maybeContext: SomeAliasedLiteral? = nil, objectWithLiteral: ATopLevelLiteral, additionalProperties: [String: JSONValue] = .init()) {
+        self.prompt = prompt
+        self.context = context
+        self.query = query
+        self.temperature = temperature
+        self.stream = stream
+        self.aliasedContext = aliasedContext
+        self.maybeContext = maybeContext
+        self.objectWithLiteral = objectWithLiteral
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.prompt = try container.decode(Any.self, forKey: .prompt)
+        self.context = try container.decodeIfPresent(Any.self, forKey: .context)
+        self.query = try container.decode(String.self, forKey: .query)
+        self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+        self.stream = try container.decode(Any.self, forKey: .stream)
+        self.aliasedContext = try container.decode(SomeAliasedLiteral.self, forKey: .aliasedContext)
+        self.maybeContext = try container.decodeIfPresent(SomeAliasedLiteral.self, forKey: .maybeContext)
+        self.objectWithLiteral = try container.decode(ATopLevelLiteral.self, forKey: .objectWithLiteral)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.prompt, forKey: .prompt)
+        try container.encodeIfPresent(self.context, forKey: .context)
+        try container.encode(self.query, forKey: .query)
+        try container.encodeIfPresent(self.temperature, forKey: .temperature)
+        try container.encode(self.stream, forKey: .stream)
+        try container.encode(self.aliasedContext, forKey: .aliasedContext)
+        try container.encodeIfPresent(self.maybeContext, forKey: .maybeContext)
+        try container.encode(self.objectWithLiteral, forKey: .objectWithLiteral)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case prompt
+        case context
+        case query
+        case temperature
+        case stream
+        case aliasedContext
+        case maybeContext
+        case objectWithLiteral
+    }
+}

--- a/seed/swift-sdk/literal/Sources/Resources/Headers.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Headers.swift
@@ -5,7 +5,7 @@ public final class HeadersClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(endpointVersion: Any, async: Any, request: Any, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
+    public func send(endpointVersion: Any, async: Any, request: SendLiteralsInHeadersRequest, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/headers",

--- a/seed/swift-sdk/literal/Sources/Resources/Inlined.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Inlined.swift
@@ -5,7 +5,7 @@ public final class InlinedClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(request: Any, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
+    public func send(request: SendLiteralsInlinedRequest, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/inlined",

--- a/seed/swift-sdk/multi-line-docs/Sources/Requests/CreateUserRequest.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Requests/CreateUserRequest.swift
@@ -1,0 +1,30 @@
+public struct CreateUserRequest: Codable, Hashable {
+    public let name: String
+    public let age: Int?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(name: String, age: Int? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.name = name
+        self.age = age
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.age = try container.decodeIfPresent(Int.self, forKey: .age)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.name, forKey: .name)
+        try container.encodeIfPresent(self.age, forKey: .age)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case name
+        case age
+    }
+}

--- a/seed/swift-sdk/multi-line-docs/Sources/Resources/User.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Resources/User.swift
@@ -14,7 +14,7 @@ public final class UserClient: Sendable {
         )
     }
 
-    public func createUser(request: Any, requestOptions: RequestOptions? = nil) async throws -> User {
+    public func createUser(request: CreateUserRequest, requestOptions: RequestOptions? = nil) async throws -> User {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Requests/BootInstanceRequest.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Requests/BootInstanceRequest.swift
@@ -1,0 +1,25 @@
+public struct BootInstanceRequest: Codable, Hashable {
+    public let size: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(size: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.size = size
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.size = try container.decode(String.self, forKey: .size)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.size, forKey: .size)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case size
+    }
+}

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Requests/GetPresignedUrlRequest.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Requests/GetPresignedUrlRequest.swift
@@ -1,0 +1,25 @@
+public struct GetPresignedUrlRequest: Codable, Hashable {
+    public let s3Key: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(s3Key: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.s3Key = s3Key
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.s3Key = try container.decode(String.self, forKey: .s3Key)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.s3Key, forKey: .s3Key)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case s3Key
+    }
+}

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/Ec2.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/Ec2.swift
@@ -5,7 +5,7 @@ public final class Ec2Client: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func bootInstance(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func bootInstance(request: BootInstanceRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/ec2/boot",

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/S3.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/S3.swift
@@ -5,7 +5,7 @@ public final class S3Client: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getPresignedUrl(request: Any, requestOptions: RequestOptions? = nil) async throws -> String {
+    public func getPresignedUrl(request: GetPresignedUrlRequest, requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/s3/presigned-url",

--- a/seed/swift-sdk/multi-url-environment/Sources/Requests/BootInstanceRequest.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Requests/BootInstanceRequest.swift
@@ -1,0 +1,25 @@
+public struct BootInstanceRequest: Codable, Hashable {
+    public let size: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(size: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.size = size
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.size = try container.decode(String.self, forKey: .size)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.size, forKey: .size)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case size
+    }
+}

--- a/seed/swift-sdk/multi-url-environment/Sources/Requests/GetPresignedUrlRequest.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Requests/GetPresignedUrlRequest.swift
@@ -1,0 +1,25 @@
+public struct GetPresignedUrlRequest: Codable, Hashable {
+    public let s3Key: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(s3Key: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.s3Key = s3Key
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.s3Key = try container.decode(String.self, forKey: .s3Key)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.s3Key, forKey: .s3Key)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case s3Key
+    }
+}

--- a/seed/swift-sdk/multi-url-environment/Sources/Resources/Ec2.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Resources/Ec2.swift
@@ -5,7 +5,7 @@ public final class Ec2Client: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func bootInstance(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func bootInstance(request: BootInstanceRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/ec2/boot",

--- a/seed/swift-sdk/multi-url-environment/Sources/Resources/S3.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Resources/S3.swift
@@ -5,7 +5,7 @@ public final class S3Client: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getPresignedUrl(request: Any, requestOptions: RequestOptions? = nil) async throws -> String {
+    public func getPresignedUrl(request: GetPresignedUrlRequest, requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/s3/presigned-url",

--- a/seed/swift-sdk/nullable/Sources/Requests/CreateUserRequest.swift
+++ b/seed/swift-sdk/nullable/Sources/Requests/CreateUserRequest.swift
@@ -1,0 +1,40 @@
+public struct CreateUserRequest: Codable, Hashable {
+    public let username: String
+    public let tags: [String]?
+    public let metadata: Metadata?
+    public let avatar: Any?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(username: String, tags: [String]? = nil, metadata: Metadata? = nil, avatar: Any? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.username = username
+        self.tags = tags
+        self.metadata = metadata
+        self.avatar = avatar
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.username = try container.decode(String.self, forKey: .username)
+        self.tags = try container.decodeIfPresent([String].self, forKey: .tags)
+        self.metadata = try container.decodeIfPresent(Metadata.self, forKey: .metadata)
+        self.avatar = try container.decodeIfPresent(Any.self, forKey: .avatar)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.username, forKey: .username)
+        try container.encodeIfPresent(self.tags, forKey: .tags)
+        try container.encodeIfPresent(self.metadata, forKey: .metadata)
+        try container.encodeIfPresent(self.avatar, forKey: .avatar)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case username
+        case tags
+        case metadata
+        case avatar
+    }
+}

--- a/seed/swift-sdk/nullable/Sources/Requests/DeleteUserRequest.swift
+++ b/seed/swift-sdk/nullable/Sources/Requests/DeleteUserRequest.swift
@@ -1,0 +1,25 @@
+public struct DeleteUserRequest: Codable, Hashable {
+    public let username: Any?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(username: Any? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.username = username
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.username = try container.decodeIfPresent(Any.self, forKey: .username)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.username, forKey: .username)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case username
+    }
+}

--- a/seed/swift-sdk/nullable/Sources/Resources/Nullable.swift
+++ b/seed/swift-sdk/nullable/Sources/Resources/Nullable.swift
@@ -21,7 +21,7 @@ public final class NullableClient: Sendable {
         )
     }
 
-    public func createUser(request: Any, requestOptions: RequestOptions? = nil) async throws -> User {
+    public func createUser(request: CreateUserRequest, requestOptions: RequestOptions? = nil) async throws -> User {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",
@@ -31,7 +31,7 @@ public final class NullableClient: Sendable {
         )
     }
 
-    public func deleteUser(request: Any, requestOptions: RequestOptions? = nil) async throws -> Bool {
+    public func deleteUser(request: DeleteUserRequest, requestOptions: RequestOptions? = nil) async throws -> Bool {
         return try await httpClient.performRequest(
             method: .delete,
             path: "/users",

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,55 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let cid: String
+    public let csr: String
+    public let scp: String
+    public let entityId: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(cid: String, csr: String, scp: String, entityId: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.cid = cid
+        self.csr = csr
+        self.scp = scp
+        self.entityId = entityId
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.cid = try container.decode(String.self, forKey: .cid)
+        self.csr = try container.decode(String.self, forKey: .csr)
+        self.scp = try container.decode(String.self, forKey: .scp)
+        self.entityId = try container.decode(String.self, forKey: .entityId)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.cid, forKey: .cid)
+        try container.encode(self.csr, forKey: .csr)
+        try container.encode(self.scp, forKey: .scp)
+        try container.encode(self.entityId, forKey: .entityId)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case cid
+        case csr
+        case scp
+        case entityId = "entity_id"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Requests/RefreshTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Requests/RefreshTokenRequest.swift
@@ -1,0 +1,50 @@
+public struct RefreshTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let refreshToken: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, refreshToken: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.refreshToken = refreshToken
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.refreshToken = try container.decode(String.self, forKey: .refreshToken)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.refreshToken, forKey: .refreshToken)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case refreshToken = "refresh_token"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -15,7 +15,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(request: RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,35 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let grantType: Any
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, grantType: Any, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.grantType = grantType
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.grantType, forKey: .grantType)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case grantType = "grant_type"
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getToken(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,45 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Requests/RefreshTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Requests/RefreshTokenRequest.swift
@@ -1,0 +1,50 @@
+public struct RefreshTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let refreshToken: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, refreshToken: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.refreshToken = refreshToken
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.refreshToken = try container.decode(String.self, forKey: .refreshToken)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.refreshToken, forKey: .refreshToken)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case refreshToken = "refresh_token"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -15,7 +15,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(request: RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,45 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getToken(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,45 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Requests/RefreshTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Requests/RefreshTokenRequest.swift
@@ -1,0 +1,50 @@
+public struct RefreshTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let refreshToken: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, refreshToken: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.refreshToken = refreshToken
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.refreshToken = try container.decode(String.self, forKey: .refreshToken)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.refreshToken, forKey: .refreshToken)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case refreshToken = "refresh_token"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -15,7 +15,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(request: RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Requests/GetTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Requests/GetTokenRequest.swift
@@ -1,0 +1,45 @@
+public struct GetTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Requests/RefreshTokenRequest.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Requests/RefreshTokenRequest.swift
@@ -1,0 +1,50 @@
+public struct RefreshTokenRequest: Codable, Hashable {
+    public let clientId: String
+    public let clientSecret: String
+    public let refreshToken: String
+    public let audience: Any
+    public let grantType: Any
+    public let scope: String?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(clientId: String, clientSecret: String, refreshToken: String, audience: Any, grantType: Any, scope: String? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.refreshToken = refreshToken
+        self.audience = audience
+        self.grantType = grantType
+        self.scope = scope
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
+        self.refreshToken = try container.decode(String.self, forKey: .refreshToken)
+        self.audience = try container.decode(Any.self, forKey: .audience)
+        self.grantType = try container.decode(Any.self, forKey: .grantType)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encode(self.clientSecret, forKey: .clientSecret)
+        try container.encode(self.refreshToken, forKey: .refreshToken)
+        try container.encode(self.audience, forKey: .audience)
+        try container.encode(self.grantType, forKey: .grantType)
+        try container.encodeIfPresent(self.scope, forKey: .scope)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case refreshToken = "refresh_token"
+        case audience
+        case grantType = "grant_type"
+        case scope
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Auth.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Auth.swift
@@ -5,7 +5,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(request: GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -15,7 +15,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(request: Any, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(request: RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Requests/ListUsersBodyCursorPaginationRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Requests/ListUsersBodyCursorPaginationRequest.swift
@@ -1,0 +1,25 @@
+public struct ListUsersBodyCursorPaginationRequest: Codable, Hashable {
+    public let pagination: WithCursor?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(pagination: WithCursor? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.pagination = pagination
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pagination = try container.decodeIfPresent(WithCursor.self, forKey: .pagination)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.pagination, forKey: .pagination)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case pagination
+    }
+}

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Requests/ListUsersBodyOffsetPaginationRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Requests/ListUsersBodyOffsetPaginationRequest.swift
@@ -1,0 +1,25 @@
+public struct ListUsersBodyOffsetPaginationRequest: Codable, Hashable {
+    public let pagination: WithPage?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(pagination: WithPage? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.pagination = pagination
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pagination = try container.decodeIfPresent(WithPage.self, forKey: .pagination)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.pagination, forKey: .pagination)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case pagination
+    }
+}

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Users.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Users.swift
@@ -32,7 +32,7 @@ public final class UsersClient: Sendable {
         )
     }
 
-    public func listWithBodyCursorPagination(request: Any, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
+    public func listWithBodyCursorPagination(request: ListUsersBodyCursorPaginationRequest, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",
@@ -72,7 +72,7 @@ public final class UsersClient: Sendable {
         )
     }
 
-    public func listWithBodyOffsetPagination(request: Any, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
+    public func listWithBodyOffsetPagination(request: ListUsersBodyOffsetPaginationRequest, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Requests/ListUsersBodyCursorPaginationRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Requests/ListUsersBodyCursorPaginationRequest.swift
@@ -1,0 +1,25 @@
+public struct ListUsersBodyCursorPaginationRequest: Codable, Hashable {
+    public let pagination: WithCursor?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(pagination: WithCursor? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.pagination = pagination
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pagination = try container.decodeIfPresent(WithCursor.self, forKey: .pagination)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.pagination, forKey: .pagination)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case pagination
+    }
+}

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Requests/ListUsersBodyOffsetPaginationRequest.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Requests/ListUsersBodyOffsetPaginationRequest.swift
@@ -1,0 +1,25 @@
+public struct ListUsersBodyOffsetPaginationRequest: Codable, Hashable {
+    public let pagination: WithPage?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(pagination: WithPage? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.pagination = pagination
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pagination = try container.decodeIfPresent(WithPage.self, forKey: .pagination)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.pagination, forKey: .pagination)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case pagination
+    }
+}

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Users.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Users.swift
@@ -32,7 +32,7 @@ public final class UsersClient: Sendable {
         )
     }
 
-    public func listWithBodyCursorPagination(request: Any, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
+    public func listWithBodyCursorPagination(request: ListUsersBodyCursorPaginationRequest, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",
@@ -72,7 +72,7 @@ public final class UsersClient: Sendable {
         )
     }
 
-    public func listWithBodyOffsetPagination(request: Any, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
+    public func listWithBodyOffsetPagination(request: ListUsersBodyOffsetPaginationRequest, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Requests/ListUsersBodyCursorPaginationRequest.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Requests/ListUsersBodyCursorPaginationRequest.swift
@@ -1,0 +1,25 @@
+public struct ListUsersBodyCursorPaginationRequest: Codable, Hashable {
+    public let pagination: WithCursor?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(pagination: WithCursor? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.pagination = pagination
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pagination = try container.decodeIfPresent(WithCursor.self, forKey: .pagination)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.pagination, forKey: .pagination)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case pagination
+    }
+}

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Requests/ListUsersBodyOffsetPaginationRequest.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Requests/ListUsersBodyOffsetPaginationRequest.swift
@@ -1,0 +1,25 @@
+public struct ListUsersBodyOffsetPaginationRequest: Codable, Hashable {
+    public let pagination: WithPage?
+    public let additionalProperties: [String: JSONValue]
+
+    public init(pagination: WithPage? = nil, additionalProperties: [String: JSONValue] = .init()) {
+        self.pagination = pagination
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pagination = try container.decodeIfPresent(WithPage.self, forKey: .pagination)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.pagination, forKey: .pagination)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case pagination
+    }
+}

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Users.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Users.swift
@@ -32,7 +32,7 @@ public final class UsersClient: Sendable {
         )
     }
 
-    public func listWithBodyCursorPagination(request: Any, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
+    public func listWithBodyCursorPagination(request: ListUsersBodyCursorPaginationRequest, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",
@@ -72,7 +72,7 @@ public final class UsersClient: Sendable {
         )
     }
 
-    public func listWithBodyOffsetPagination(request: Any, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
+    public func listWithBodyOffsetPagination(request: ListUsersBodyOffsetPaginationRequest, requestOptions: RequestOptions? = nil) async throws -> ListUsersPaginationResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/users",

--- a/seed/swift-sdk/request-parameters/Sources/Requests/CreateUsernameRequest.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Requests/CreateUsernameRequest.swift
@@ -1,0 +1,35 @@
+public struct CreateUsernameRequest: Codable, Hashable {
+    public let username: String
+    public let password: String
+    public let name: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(username: String, password: String, name: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.username = username
+        self.password = password
+        self.name = name
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.username = try container.decode(String.self, forKey: .username)
+        self.password = try container.decode(String.self, forKey: .password)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.username, forKey: .username)
+        try container.encode(self.password, forKey: .password)
+        try container.encode(self.name, forKey: .name)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case username
+        case password
+        case name
+    }
+}

--- a/seed/swift-sdk/request-parameters/Sources/Resources/User.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Resources/User.swift
@@ -5,7 +5,7 @@ public final class UserClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func createUsername(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func createUsername(request: CreateUsernameRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/user/username",

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Requests/StreamCompletionRequest.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Requests/StreamCompletionRequest.swift
@@ -1,0 +1,25 @@
+public struct StreamCompletionRequest: Codable, Hashable {
+    public let query: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(query: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.query = query
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.query = try container.decode(String.self, forKey: .query)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.query, forKey: .query)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case query
+    }
+}

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Resources/Completions.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Resources/Completions.swift
@@ -5,7 +5,7 @@ public final class CompletionsClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func stream(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func stream(request: StreamCompletionRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/stream",

--- a/seed/swift-sdk/server-sent-events/Sources/Requests/StreamCompletionRequest.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Requests/StreamCompletionRequest.swift
@@ -1,0 +1,25 @@
+public struct StreamCompletionRequest: Codable, Hashable {
+    public let query: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(query: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.query = query
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.query = try container.decode(String.self, forKey: .query)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.query, forKey: .query)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case query
+    }
+}

--- a/seed/swift-sdk/server-sent-events/Sources/Resources/Completions.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Resources/Completions.swift
@@ -5,7 +5,7 @@ public final class CompletionsClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func stream(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func stream(request: StreamCompletionRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/stream",

--- a/seed/swift-sdk/streaming-parameter/Sources/Requests/GenerateRequest.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Requests/GenerateRequest.swift
@@ -1,0 +1,30 @@
+public struct GenerateRequest: Codable, Hashable {
+    public let stream: Bool
+    public let numEvents: Int
+    public let additionalProperties: [String: JSONValue]
+
+    public init(stream: Bool, numEvents: Int, additionalProperties: [String: JSONValue] = .init()) {
+        self.stream = stream
+        self.numEvents = numEvents
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.stream = try container.decode(Bool.self, forKey: .stream)
+        self.numEvents = try container.decode(Int.self, forKey: .numEvents)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.stream, forKey: .stream)
+        try container.encode(self.numEvents, forKey: .numEvents)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case stream
+        case numEvents = "num_events"
+    }
+}

--- a/seed/swift-sdk/streaming-parameter/Sources/Resources/Dummy.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Resources/Dummy.swift
@@ -5,7 +5,7 @@ public final class DummyClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func generate(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func generate(request: GenerateRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/generate",

--- a/seed/swift-sdk/streaming/Sources/Requests/GenerateStreamRequest.swift
+++ b/seed/swift-sdk/streaming/Sources/Requests/GenerateStreamRequest.swift
@@ -1,0 +1,30 @@
+public struct GenerateStreamRequest: Codable, Hashable {
+    public let stream: Any
+    public let numEvents: Int
+    public let additionalProperties: [String: JSONValue]
+
+    public init(stream: Any, numEvents: Int, additionalProperties: [String: JSONValue] = .init()) {
+        self.stream = stream
+        self.numEvents = numEvents
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.stream = try container.decode(Any.self, forKey: .stream)
+        self.numEvents = try container.decode(Int.self, forKey: .numEvents)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.stream, forKey: .stream)
+        try container.encode(self.numEvents, forKey: .numEvents)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case stream
+        case numEvents = "num_events"
+    }
+}

--- a/seed/swift-sdk/streaming/Sources/Requests/Generateequest.swift
+++ b/seed/swift-sdk/streaming/Sources/Requests/Generateequest.swift
@@ -1,0 +1,30 @@
+public struct Generateequest: Codable, Hashable {
+    public let stream: Any
+    public let numEvents: Int
+    public let additionalProperties: [String: JSONValue]
+
+    public init(stream: Any, numEvents: Int, additionalProperties: [String: JSONValue] = .init()) {
+        self.stream = stream
+        self.numEvents = numEvents
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.stream = try container.decode(Any.self, forKey: .stream)
+        self.numEvents = try container.decode(Int.self, forKey: .numEvents)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.stream, forKey: .stream)
+        try container.encode(self.numEvents, forKey: .numEvents)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case stream
+        case numEvents = "num_events"
+    }
+}

--- a/seed/swift-sdk/streaming/Sources/Resources/Dummy.swift
+++ b/seed/swift-sdk/streaming/Sources/Resources/Dummy.swift
@@ -5,7 +5,7 @@ public final class DummyClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func generateStream(request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func generateStream(request: GenerateStreamRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/generate-stream",
@@ -15,7 +15,7 @@ public final class DummyClient: Sendable {
         )
     }
 
-    public func generate(request: Any, requestOptions: RequestOptions? = nil) async throws -> StreamResponse {
+    public func generate(request: Generateequest, requestOptions: RequestOptions? = nil) async throws -> StreamResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/generate",

--- a/seed/swift-sdk/trace/Sources/Requests/GetDefaultStarterFilesRequest.swift
+++ b/seed/swift-sdk/trace/Sources/Requests/GetDefaultStarterFilesRequest.swift
@@ -1,0 +1,35 @@
+public struct GetDefaultStarterFilesRequest: Codable, Hashable {
+    public let inputParams: [VariableTypeAndName]
+    public let outputType: VariableType
+    public let methodName: String
+    public let additionalProperties: [String: JSONValue]
+
+    public init(inputParams: [VariableTypeAndName], outputType: VariableType, methodName: String, additionalProperties: [String: JSONValue] = .init()) {
+        self.inputParams = inputParams
+        self.outputType = outputType
+        self.methodName = methodName
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.inputParams = try container.decode([VariableTypeAndName].self, forKey: .inputParams)
+        self.outputType = try container.decode(VariableType.self, forKey: .outputType)
+        self.methodName = try container.decode(String.self, forKey: .methodName)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.inputParams, forKey: .inputParams)
+        try container.encode(self.outputType, forKey: .outputType)
+        try container.encode(self.methodName, forKey: .methodName)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case inputParams
+        case outputType
+        case methodName
+    }
+}

--- a/seed/swift-sdk/trace/Sources/Requests/StoreTracedTestCaseRequest.swift
+++ b/seed/swift-sdk/trace/Sources/Requests/StoreTracedTestCaseRequest.swift
@@ -1,0 +1,30 @@
+public struct StoreTracedTestCaseRequest: Codable, Hashable {
+    public let result: TestCaseResultWithStdout
+    public let traceResponses: [TraceResponse]
+    public let additionalProperties: [String: JSONValue]
+
+    public init(result: TestCaseResultWithStdout, traceResponses: [TraceResponse], additionalProperties: [String: JSONValue] = .init()) {
+        self.result = result
+        self.traceResponses = traceResponses
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.result = try container.decode(TestCaseResultWithStdout.self, forKey: .result)
+        self.traceResponses = try container.decode([TraceResponse].self, forKey: .traceResponses)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.result, forKey: .result)
+        try container.encode(self.traceResponses, forKey: .traceResponses)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case result
+        case traceResponses
+    }
+}

--- a/seed/swift-sdk/trace/Sources/Requests/StoreTracedWorkspaceRequest.swift
+++ b/seed/swift-sdk/trace/Sources/Requests/StoreTracedWorkspaceRequest.swift
@@ -1,0 +1,30 @@
+public struct StoreTracedWorkspaceRequest: Codable, Hashable {
+    public let workspaceRunDetails: WorkspaceRunDetails
+    public let traceResponses: [TraceResponse]
+    public let additionalProperties: [String: JSONValue]
+
+    public init(workspaceRunDetails: WorkspaceRunDetails, traceResponses: [TraceResponse], additionalProperties: [String: JSONValue] = .init()) {
+        self.workspaceRunDetails = workspaceRunDetails
+        self.traceResponses = traceResponses
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.workspaceRunDetails = try container.decode(WorkspaceRunDetails.self, forKey: .workspaceRunDetails)
+        self.traceResponses = try container.decode([TraceResponse].self, forKey: .traceResponses)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.workspaceRunDetails, forKey: .workspaceRunDetails)
+        try container.encode(self.traceResponses, forKey: .traceResponses)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case workspaceRunDetails
+        case traceResponses
+    }
+}

--- a/seed/swift-sdk/trace/Sources/Resources/Admin.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Admin.swift
@@ -45,7 +45,7 @@ public final class AdminClient: Sendable {
         )
     }
 
-    public func storeTracedTestCase(submissionId: String, testCaseId: String, request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func storeTracedTestCase(submissionId: String, testCaseId: String, request: StoreTracedTestCaseRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/admin/store-test-trace/submission/\(submissionId)/testCase/\(testCaseId)",
@@ -65,7 +65,7 @@ public final class AdminClient: Sendable {
         )
     }
 
-    public func storeTracedWorkspace(submissionId: String, request: Any, requestOptions: RequestOptions? = nil) async throws -> Any {
+    public func storeTracedWorkspace(submissionId: String, request: StoreTracedWorkspaceRequest, requestOptions: RequestOptions? = nil) async throws -> Any {
         return try await httpClient.performRequest(
             method: .post,
             path: "/admin/store-workspace-trace/submission/\(submissionId)",

--- a/seed/swift-sdk/validation/Sources/Requests/CreateRequest.swift
+++ b/seed/swift-sdk/validation/Sources/Requests/CreateRequest.swift
@@ -1,0 +1,40 @@
+public struct CreateRequest: Codable, Hashable {
+    public let decimal: Double
+    public let even: Int
+    public let name: String
+    public let shape: Shape
+    public let additionalProperties: [String: JSONValue]
+
+    public init(decimal: Double, even: Int, name: String, shape: Shape, additionalProperties: [String: JSONValue] = .init()) {
+        self.decimal = decimal
+        self.even = even
+        self.name = name
+        self.shape = shape
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.decimal = try container.decode(Double.self, forKey: .decimal)
+        self.even = try container.decode(Int.self, forKey: .even)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.shape = try container.decode(Shape.self, forKey: .shape)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.decimal, forKey: .decimal)
+        try container.encode(self.even, forKey: .even)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.shape, forKey: .shape)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case decimal
+        case even
+        case name
+        case shape
+    }
+}


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
With this PR, we'll be traversing all endpoints to extract inlined request body types and generate a struct for each of those types. We are currently adding these structs to the new `Requests` directory. Also we are assuming the definition names for these types are unique for now–we'll handle collisions later.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Slight adjustments in `ObjectGenerator` to allow it to be reused for inlined request body type generation
- Implements `generateInlinedRequestModels` function in `model` package.
- Updates `SdkGeneratorCli` to generate the new models
- Updates seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

