### PR TITLE
chore(swift): Ignore biome error when throwing on the default case

### DIFF
--- a/generators/swift/model/src/object/ObjectGenerator.ts
+++ b/generators/swift/model/src/object/ObjectGenerator.ts
@@ -29,6 +29,7 @@ export class ObjectGenerator {
         this.additionalPropertiesInfo = this.getAdditionalPropertiesInfo(properties);
     }
 
+    // biome-ignore lint/suspicious/useGetterReturn: This getter intentionally does not return a value in the default case
     private get fileDirectory(): RelativeFilePath {
         switch (this.objectType) {
             case "schema":


### PR DESCRIPTION
## Description
biome lint checks are broken
this ignore fixes them