### PR TITLE
fix(java): swap InputStreamRequestBody arguments to match constructor

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/OnlyRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/OnlyRequestEndpointWriter.java
@@ -282,13 +282,13 @@ public final class OnlyRequestEndpointWriter extends AbstractEndpointWriter {
         @Override
         public Void visitBytes(BytesRequest bytes) {
             codeBlock.addStatement(
-                    "$T $L = new $T($L, $T.parse($S))",
+                    "$T $L = new $T($T.parse($S), $L)",
                     RequestBody.class,
                     variables.getOkhttpRequestBodyName(),
                     clientGeneratorContext.getPoetClassNameFactory().getInputStreamRequestBodyClassName(),
-                    sdkRequest.getRequestParameterName().getCamelCase().getSafeName(),
                     MediaType.class,
-                    bytes.getContentType().orElse(APPLICATION_OCTET_STREAM));
+                    bytes.getContentType().orElse(APPLICATION_OCTET_STREAM),
+                    sdkRequest.getRequestParameterName().getCamelCase().getSafeName());
             return null;
         }
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 2.38.7
+  changelogEntry:
+    - summary: |
+        Swap InputStreamRequestBody arguments to match constructor
+      type: fix
+  createdAt: '2025-07-23'
+  irVersion: 58
+
 - version: 2.38.6
   changelogEntry:
     - summary: |
@@ -5,7 +13,7 @@
       type: fix
   createdAt: '2025-07-21'
   irVersion: 58
-
+  
 - version: 2.38.5
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/AsyncRawServiceClient.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/AsyncRawServiceClient.java
@@ -43,7 +43,7 @@ public class AsyncRawServiceClient {
                 .newBuilder()
                 .addPathSegments("upload-content")
                 .build();
-        RequestBody body = new InputStreamRequestBody(request, MediaType.parse("application/octet-stream"));
+        RequestBody body = new InputStreamRequestBody(MediaType.parse("application/octet-stream"), request);
         Request okhttpRequest = new Request.Builder()
                 .url(httpUrl)
                 .method("POST", body)

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/RawServiceClient.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/RawServiceClient.java
@@ -38,7 +38,7 @@ public class RawServiceClient {
                 .newBuilder()
                 .addPathSegments("upload-content")
                 .build();
-        RequestBody body = new InputStreamRequestBody(request, MediaType.parse("application/octet-stream"));
+        RequestBody body = new InputStreamRequestBody(MediaType.parse("application/octet-stream"), request);
         Request okhttpRequest = new Request.Builder()
                 .url(httpUrl)
                 .method("POST", body)


### PR DESCRIPTION
 ## Description
  Fixed incorrect argument order in InputStreamRequestBody constructor calls in the Java SDK generator. The constructor expects MediaType as the first parameter and InputStream as the second, but the generated code was passing them in reverse order. This is happening because `visitBytes` is only generated when generating code for endpoints that accept byte/stream payloads. This wasn't surfaced before I'm guessing because other SDKs don't have endpoints that accept raw input streams. 

  ## Changes Made
  - Updated `OnlyRequestEndpointWriter.java` to pass MediaTypefirst, then InputStream when creating InputStreamRequestBody
  - Fixed generated code in bytes-upload seed test to matchcorrect constructor signature
  - This aligns with the InputStreamRequestBody constructor signature used across all Java SDKs

  ## Testing
  - [] Unit tests added/updated
  - [x] Manual testing

  Tested by:
  - bytes-upload fixture tests and more 
  - Verified existing SDKs (Cohere, Square) already use correct
  argument order and won't be impacted