### PR TITLE
fix(go): handle optional and required enums

### DIFF
--- a/generators/go-v2/base/src/context/GoValueFormatter.ts
+++ b/generators/go-v2/base/src/context/GoValueFormatter.ts
@@ -43,11 +43,20 @@ export class GoValueFormatter {
         let isPrimitive = false;
 
         const optionalOrNullableType = this.context.maybeUnwrapOptionalOrNullable(reference);
+        const enumType = this.context.maybeEnum(reference);
+
         if (optionalOrNullableType != null) {
             if (this.context.needsOptionalDereference(reference)) {
                 prefix = go.codeblock("*");
+                if (enumType != null) {
+                    prefix = go.codeblock("string(*");
+                    suffix = go.codeblock(")");
+                }
             }
             isOptional = true;
+        } else if (enumType != null) {
+            prefix = go.codeblock("string(");
+            suffix = go.codeblock(")");
         }
 
         const primitive = this.context.maybePrimitive(reference);
@@ -111,12 +120,6 @@ export class GoValueFormatter {
                     assertNever(primitive);
             }
             isPrimitive = true;
-        }
-
-        const enumType = this.context.maybeEnum(reference);
-        if (enumType != null) {
-            prefix = go.codeblock("string(");
-            suffix = go.codeblock(")");
         }
 
         return {

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.5.2
+  changelogEntry:
+    - summary: |
+        Make sure that optional headers and query params are properly dereferenced before being sent to the server.
+      type: fix
+  createdAt: '2025-07-21'
+  irVersion: 58
+
 - version: 1.5.1
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/file-upload/no-custom-config/service/raw_client.go
+++ b/seed/go-sdk/file-upload/no-custom-config/service/raw_client.go
@@ -93,7 +93,7 @@ func (r *RawClient) Post(
 		}
 	}
 	if request.OptionalObjectType != nil {
-		if err := writer.WriteJSON("optional_object_type", string(request.OptionalObjectType)); err != nil {
+		if err := writer.WriteJSON("optional_object_type", string(*request.OptionalObjectType)); err != nil {
 			return nil, err
 		}
 	}
@@ -421,7 +421,7 @@ func (r *RawClient) WithFormEncodedContainers(
 		}
 	}
 	if request.OptionalObjectType != nil {
-		if err := writer.WriteJSON("optional_object_type", string(request.OptionalObjectType)); err != nil {
+		if err := writer.WriteJSON("optional_object_type", string(*request.OptionalObjectType)); err != nil {
 			return nil, err
 		}
 	}

--- a/seed/go-sdk/file-upload/package-name/service/raw_client.go
+++ b/seed/go-sdk/file-upload/package-name/service/raw_client.go
@@ -93,7 +93,7 @@ func (r *RawClient) Post(
 		}
 	}
 	if request.OptionalObjectType != nil {
-		if err := writer.WriteJSON("optional_object_type", string(request.OptionalObjectType)); err != nil {
+		if err := writer.WriteJSON("optional_object_type", string(*request.OptionalObjectType)); err != nil {
 			return nil, err
 		}
 	}
@@ -421,7 +421,7 @@ func (r *RawClient) WithFormEncodedContainers(
 		}
 	}
 	if request.OptionalObjectType != nil {
-		if err := writer.WriteJSON("optional_object_type", string(request.OptionalObjectType)); err != nil {
+		if err := writer.WriteJSON("optional_object_type", string(*request.OptionalObjectType)); err != nil {
 			return nil, err
 		}
 	}

--- a/seed/go-sdk/file-upload/v0/service/raw_client.go
+++ b/seed/go-sdk/file-upload/v0/service/raw_client.go
@@ -98,7 +98,7 @@ func (r *RawClient) Post(
 		}
 	}
 	if request.OptionalObjectType != nil {
-		if err := writer.WriteJSON("optional_object_type", string(request.OptionalObjectType)); err != nil {
+		if err := writer.WriteJSON("optional_object_type", string(*request.OptionalObjectType)); err != nil {
 			return nil, err
 		}
 	}
@@ -432,7 +432,7 @@ func (r *RawClient) WithFormEncodedContainers(
 		}
 	}
 	if request.OptionalObjectType != nil {
-		if err := writer.WriteJSON("optional_object_type", string(request.OptionalObjectType)); err != nil {
+		if err := writer.WriteJSON("optional_object_type", string(*request.OptionalObjectType)); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description
 Make sure that optional headers and query params are properly dereferenced before being sent to the server.

## Changes Made 
- See files changed

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

