### PR TITLE
fix(java): fix byte array methods to include all params

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
@@ -83,7 +83,7 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
             MethodSpec endpointWithRequestOptions) {
 
         StringBuilder params = new StringBuilder();
-        
+
         for (ParameterSpec param : byteArrayBaseMethodSpec.parameters) {
             if (!param.equals(requestParameterSpec)) {
                 if (params.length() > 0) {
@@ -92,12 +92,12 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
                 params.append(param.name);
             }
         }
-        
+
         if (params.length() > 0) {
             params.append(", ");
         }
         params.append("new $T($L)");
-        
+
         return methodBodyBuilder
                 .add(
                         "return $L(" + params.toString(),

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
@@ -81,9 +81,28 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
             MethodSpec byteArrayBaseMethodSpec,
             ParameterSpec requestParameterSpec,
             MethodSpec endpointWithRequestOptions) {
+        // Build the parameter list for the method call
+        StringBuilder params = new StringBuilder();
+        
+        // Add all parameters except the byte array request parameter
+        for (ParameterSpec param : byteArrayBaseMethodSpec.parameters) {
+            if (!param.equals(requestParameterSpec)) {
+                if (params.length() > 0) {
+                    params.append(", ");
+                }
+                params.append(param.name);
+            }
+        }
+        
+        // Add the converted byte array parameter
+        if (params.length() > 0) {
+            params.append(", ");
+        }
+        params.append("new $T($L)");
+        
         return methodBodyBuilder
                 .add(
-                        "return $L(new $T($L)",
+                        "return $L(" + params.toString(),
                         endpointWithRequestOptions.name,
                         ByteArrayInputStream.class,
                         requestParameterSpec.name)

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
@@ -81,10 +81,9 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
             MethodSpec byteArrayBaseMethodSpec,
             ParameterSpec requestParameterSpec,
             MethodSpec endpointWithRequestOptions) {
-        // Build the parameter list for the method call
+
         StringBuilder params = new StringBuilder();
         
-        // Add all parameters except the byte array request parameter
         for (ParameterSpec param : byteArrayBaseMethodSpec.parameters) {
             if (!param.equals(requestParameterSpec)) {
                 if (params.length() > 0) {
@@ -94,7 +93,6 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
             }
         }
         
-        // Add the converted byte array parameter
         if (params.length() > 0) {
             params.append(", ");
         }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
@@ -71,12 +71,28 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
             MethodSpec byteArrayBaseMethodSpec,
             ParameterSpec requestParameterSpec,
             MethodSpec endpointWithRequestOptions) {
-        if (!byteArrayBaseMethodSpec.returnType.equals(TypeName.VOID)) {
-            methodBodyBuilder.add("return ");
+        // Build the parameter list for the method call
+        StringBuilder params = new StringBuilder();
+        
+        // Add all parameters except the byte array request parameter
+        for (ParameterSpec param : byteArrayBaseMethodSpec.parameters) {
+            if (!param.equals(requestParameterSpec)) {
+                if (params.length() > 0) {
+                    params.append(", ");
+                }
+                params.append(param.name);
+            }
         }
+        
+        // Add the converted byte array parameter
+        if (params.length() > 0) {
+            params.append(", ");
+        }
+        params.append("new $T($L)");
+        
         return methodBodyBuilder
                 .add(
-                        "$L(new $T($L)",
+                        "return $L(" + params.toString(),
                         endpointWithRequestOptions.name,
                         ByteArrayInputStream.class,
                         requestParameterSpec.name)

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
@@ -71,9 +71,9 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
             MethodSpec byteArrayBaseMethodSpec,
             ParameterSpec requestParameterSpec,
             MethodSpec endpointWithRequestOptions) {
-                
+
         StringBuilder params = new StringBuilder();
-        
+
         for (ParameterSpec param : byteArrayBaseMethodSpec.parameters) {
             if (!param.equals(requestParameterSpec)) {
                 if (params.length() > 0) {
@@ -82,12 +82,12 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
                 params.append(param.name);
             }
         }
-        
+
         if (params.length() > 0) {
             params.append(", ");
         }
         params.append("new $T($L)");
-        
+
         return methodBodyBuilder
                 .add(
                         "return $L(" + params.toString(),

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
@@ -71,10 +71,9 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
             MethodSpec byteArrayBaseMethodSpec,
             ParameterSpec requestParameterSpec,
             MethodSpec endpointWithRequestOptions) {
-        // Build the parameter list for the method call
+                
         StringBuilder params = new StringBuilder();
         
-        // Add all parameters except the byte array request parameter
         for (ParameterSpec param : byteArrayBaseMethodSpec.parameters) {
             if (!param.equals(requestParameterSpec)) {
                 if (params.length() > 0) {
@@ -84,7 +83,6 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
             }
         }
         
-        // Add the converted byte array parameter
         if (params.length() > 0) {
             params.append(", ");
         }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 2.38.8
+  changelogEntry:
+    - summary: |
+        Fix byte array convenience methods to include all parameters when delegating to InputStream methods
+      type: fix
+  createdAt: '2025-07-23'
+  irVersion: 58
+
 - version: 2.38.7
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/RawServiceClient.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/RawServiceClient.java
@@ -65,10 +65,10 @@ public class RawServiceClient {
     }
 
     public SeedBytesUploadHttpResponse<Void> upload(byte[] request) {
-        upload(new ByteArrayInputStream(request));
+        return upload(new ByteArrayInputStream(request));
     }
 
     public SeedBytesUploadHttpResponse<Void> upload(byte[] request, RequestOptions requestOptions) {
-        upload(new ByteArrayInputStream(request), requestOptions);
+        return upload(new ByteArrayInputStream(request), requestOptions);
     }
 }

--- a/seed/java-sdk/bytes-upload/src/main/java/com/snippets/Example0.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/snippets/Example0.java
@@ -9,6 +9,6 @@ public class Example0 {
             .url("https://api.fern.com")
             .build();
 
-        client.service().upload();
+        client.service().upload("Hello World!".getBytes());
     }
 }


### PR DESCRIPTION
## Description
  Fix byte array convenience methods in Java SDK generator to properly pass all parameters when
  delegating to InputStream methods

  ## Changes Made
  - Modified `getByteArrayEndpointBaseMethodBody` in both `SyncHttpResponseParserGenerator` and
  `AsyncHttpResponseParserGenerator`
  - Added logic to build complete parameter lists including path parameters
  - Updated seed test snapshots for bytes-upload fixture

  ## Testing
  - [] Unit tests added/updated
  - [x] Manual testing with bytes-upload fixture and testing with anduril API Spec

I was able to generate the files and compile it 
```
tanmay@Tanmays-MacBook-Pro tmp-93770-XkYTLGLskf9D % ./gradlew compileJava

[Incubating] Problems report is available at: file:///private/var/folders/_6/_psvz94s3b7_sl57pzmm5l0c0000gn/T/tmp-93770-XkYTLGLskf9D/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 664ms
2 actionable tasks: 2 executed
```