### PR TITLE
fix(cli): Fix @fern-api/test-utils dependencies

### DIFF
--- a/packages/commons/test-utils/package.json
+++ b/packages/commons/test-utils/package.json
@@ -27,7 +27,7 @@
     "test": "vitest --run",
     "test:update": "vitest --run -u"
   },
-  "dependencies": {
+  "devDependencies": {
     "@fern-api/cli-source-resolver": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/configuration": "workspace:*",
@@ -35,9 +35,7 @@
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "@fern-api/workspace-loader": "workspace:*",
-    "@fern-fern/ir-sdk": "^58.2.0"
-  },
-  "devDependencies": {
+    "@fern-fern/ir-sdk": "^58.2.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.1",
     "@types/node": "18.15.3",
     "depcheck": "^1.4.7",

--- a/packages/commons/test-utils/tsconfig.json
+++ b/packages/commons/test-utils/tsconfig.json
@@ -6,5 +6,15 @@
     "rootDir": "src",
     "types": ["vitest/globals"]
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "references": [
+    { "path": "../core-utils" },
+    { "path": "../fs-utils" },
+    { "path": "../path-utils" },
+    { "path": "../../cli/cli-source-resolver" },
+    { "path": "../../cli/generation/ir-generator" },
+    { "path": "../../cli/task-context" },
+    { "path": "../../cli/workspace/loader" },
+    { "path": "../../cli/configuration" }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9491,7 +9491,7 @@ importers:
         version: 2.1.9(@types/node@18.15.3)(jsdom@20.0.3)(sass@1.89.2)(terser@5.43.1)
 
   packages/commons/test-utils:
-    dependencies:
+    devDependencies:
       '@fern-api/cli-source-resolver':
         specifier: workspace:*
         version: link:../../cli/cli-source-resolver
@@ -9516,7 +9516,6 @@ importers:
       '@fern-fern/ir-sdk':
         specifier: ^58.2.0
         version: 58.2.0
-    devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.1
         version: 5.2.2(@vue/compiler-sfc@3.5.17)(prettier@3.5.3)


### PR DESCRIPTION
This fixes the `@fern-api/test-utils` build whenever users run `pnpm compile` from a clean slate by updating the package's `tsconfig.json`.
