### PR TITLE
fix(cli): endpoint example creation should be ignoring global auth headers

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/hathora.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/hathora.json
@@ -3748,9 +3748,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -3797,9 +3795,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -3843,9 +3839,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -3936,8 +3930,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           response:
             body: string
     CreatePublicLobbyDeprecated:
@@ -3969,8 +3962,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           response:
             body: string
     ListActivePublicLobbiesDeprecated:
@@ -3999,8 +3991,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           response:
             body:
               - state:
@@ -4040,9 +4031,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -4116,9 +4105,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -4190,9 +4177,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -4264,9 +4249,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -4543,8 +4526,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             initialConfig:
               key: value
@@ -4593,8 +4575,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             initialConfig:
               key: value
@@ -4643,8 +4624,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             initialConfig:
               key: value
@@ -4693,8 +4673,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             visibility: public
             initialConfig:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/hathora.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/hathora.json
@@ -2398,9 +2398,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2447,9 +2445,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2493,9 +2489,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2586,8 +2580,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           response:
             body: string
     CreatePublicLobbyDeprecated:
@@ -2619,8 +2612,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           response:
             body: string
     ListActivePublicLobbiesDeprecated:
@@ -2649,8 +2641,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           response:
             body:
               - state:
@@ -2690,9 +2681,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2766,9 +2755,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2840,9 +2827,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2914,9 +2899,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -3193,8 +3176,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             initialConfig:
               key: value
@@ -3243,8 +3225,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             initialConfig:
               key: value
@@ -3293,8 +3274,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             initialConfig:
               key: value
@@ -3343,8 +3323,7 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers:
-            Authorization: Authorization
+          headers: {}
           request:
             visibility: public
             initialConfig:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -41,15 +41,18 @@ export function buildEndpointExample({
 
     if (hasEndpointHeaders || hasGlobalHeaders) {
         const namedFullExamples: NamedFullExample[] = [
-            ...(endpointExample.headers ?? []),
+            // ignore auth headers
+            ...(endpointExample.headers ?? []).filter((header) => header.name !== context.builder.getAuthHeaderName()),
+
+            // include global headers that are not already in the endpoint headers
             ...(Object.entries(context.builder.getGlobalHeaders())
                 .filter(([header]) => !endpointHeaderNames.has(header))
-                .map(([header, schema]) => ({
+                .map(([header, _]) => ({
                     name: header,
                     value: FullExample.primitive(PrimitiveExample.string(header))
                 })) ?? [])
         ];
-
+        // create examples for all headers
         example.headers = convertHeaderExamples({
             context,
             namedFullExamples

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        endpoint example creation ignores global auth headers 
+      type: feat
+  irVersion: 58
+  createdAt: "2025-07-23"
+  version: 0.65.28
+
+- changelogEntry:
+    - summary: |
         Support multiple 2XX responses on http endpoints.
       type: feat
   irVersion: 58


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
If a client specifies header auth keys in their OAS for certain endpoints, they may see a fern check fail saying there is an unexpected header 'x-api-key'.  

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
Updated our Fern definition endpoint example generation to ignore global auth headers, so we won't need to check those headers match in the generated examples. 

