### PR TITLE
fix(go): Respect useReaderForBytesRequest in go-v2

### DIFF
--- a/generators/go-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorContext.ts
@@ -5,7 +5,6 @@ import { go } from "@fern-api/go-ast";
 import { AbstractGoGeneratorContext, FileLocation, ModuleConfig } from "@fern-api/go-base";
 
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
-import { GithubOutputMode, OutputMode } from "@fern-fern/generator-exec-sdk/api";
 import {
     EnvironmentId,
     EnvironmentUrl,

--- a/generators/go-v2/sdk/src/endpoint/request/BytesRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/BytesRequest.ts
@@ -4,7 +4,6 @@ import { HttpEndpoint, HttpService, SdkRequest } from "@fern-fern/ir-sdk/api";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
 import { EndpointRequest } from "./EndpointRequest";
-import { IoReaderTypeReference } from "@fern-api/go-ast/src/ast";
 
 export class BytesRequest extends EndpointRequest {
     // biome-ignore lint/complexity/noUselessConstructor: allow

--- a/generators/go-v2/sdk/src/endpoint/request/BytesRequest.ts
+++ b/generators/go-v2/sdk/src/endpoint/request/BytesRequest.ts
@@ -4,6 +4,7 @@ import { HttpEndpoint, HttpService, SdkRequest } from "@fern-fern/ir-sdk/api";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
 import { EndpointRequest } from "./EndpointRequest";
+import { IoReaderTypeReference } from "@fern-api/go-ast/src/ast";
 
 export class BytesRequest extends EndpointRequest {
     // biome-ignore lint/complexity/noUselessConstructor: allow
@@ -17,6 +18,9 @@ export class BytesRequest extends EndpointRequest {
     }
 
     public getRequestParameterType(): go.Type {
+        if (this.context.customConfig.useReaderForBytesRequest) {
+            return go.Type.reference(this.context.getIoReaderTypeReference());
+        }
         return go.Type.bytes();
     }
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.5.3
+  changelogEntry:
+    - summary: |
+        Fix a regression where the `useReaderForBytesRequest` configuration option was not being respected after `1.5.0`.
+      type: fix
+  createdAt: '2025-07-25'
+  irVersion: 58
+
 - version: 1.5.2
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/bytes-upload/service/client.go
+++ b/seed/go-sdk/bytes-upload/service/client.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/bytes-upload/fern/core"
 	internal "github.com/bytes-upload/fern/internal"
 	option "github.com/bytes-upload/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -35,7 +36,7 @@ func NewClient(opts ...option.RequestOption) *Client {
 
 func (c *Client) Upload(
 	ctx context.Context,
-	request []byte,
+	request io.Reader,
 	opts ...option.RequestOption,
 ) error {
 	_, err := c.WithRawResponse.Upload(

--- a/seed/go-sdk/bytes-upload/service/raw_client.go
+++ b/seed/go-sdk/bytes-upload/service/raw_client.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/bytes-upload/fern/core"
 	internal "github.com/bytes-upload/fern/internal"
 	option "github.com/bytes-upload/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -31,7 +32,7 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 
 func (r *RawClient) Upload(
 	ctx context.Context,
-	request []byte,
+	request io.Reader,
 	opts ...option.RequestOption,
 ) (*core.Response[any], error) {
 	options := core.NewRequestOptions(opts...)

--- a/seed/go-sdk/go-bytes-request/no-custom-config/service/client.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/service/client.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/go-bytes-request/fern/core"
 	internal "github.com/go-bytes-request/fern/internal"
 	option "github.com/go-bytes-request/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -35,7 +36,7 @@ func NewClient(opts ...option.RequestOption) *Client {
 
 func (c *Client) Upload(
 	ctx context.Context,
-	request []byte,
+	request io.Reader,
 	opts ...option.RequestOption,
 ) error {
 	_, err := c.WithRawResponse.Upload(

--- a/seed/go-sdk/go-bytes-request/no-custom-config/service/raw_client.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/service/raw_client.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/go-bytes-request/fern/core"
 	internal "github.com/go-bytes-request/fern/internal"
 	option "github.com/go-bytes-request/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -31,7 +32,7 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 
 func (r *RawClient) Upload(
 	ctx context.Context,
-	request []byte,
+	request io.Reader,
 	opts ...option.RequestOption,
 ) (*core.Response[any], error) {
 	options := core.NewRequestOptions(opts...)

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/service/client.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/service/client.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/go-bytes-request/fern/core"
 	internal "github.com/go-bytes-request/fern/internal"
 	option "github.com/go-bytes-request/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -35,7 +36,7 @@ func NewClient(opts ...option.RequestOption) *Client {
 
 func (c *Client) Upload(
 	ctx context.Context,
-	request []byte,
+	request io.Reader,
 	opts ...option.RequestOption,
 ) error {
 	_, err := c.WithRawResponse.Upload(

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/service/raw_client.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/service/raw_client.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/go-bytes-request/fern/core"
 	internal "github.com/go-bytes-request/fern/internal"
 	option "github.com/go-bytes-request/fern/option"
+	io "io"
 	http "net/http"
 )
 
@@ -31,7 +32,7 @@ func NewRawClient(options *core.RequestOptions) *RawClient {
 
 func (r *RawClient) Upload(
 	ctx context.Context,
-	request []byte,
+	request io.Reader,
 	opts ...option.RequestOption,
 ) (*core.Response[any], error) {
 	options := core.NewRequestOptions(opts...)


### PR DESCRIPTION
This resolves a regression introduced in `1.5.0` (with the TypeScript implementation overhaul) so that the `useReaderForBytesRequest` configuration option is respected. This setting is enabled by default for anyone on `^1.0.0`.

