### PR TITLE
Trial Day

### DIFF
--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -6,8 +6,8 @@ ENV POETRY_VERSION 1.8.5
 RUN set -ex; pip install --no-cache-dir poetry==$POETRY_VERSION;
 
 
-RUN apt update && apt upgrade -y
-RUN apt install nodejs npm -y
-RUN npm install -g fern-api
+# RUN apt update && apt upgrade -y
+# RUN apt install nodejs npm -y
+# RUN npm install -g fern-api
 
 CMD [ "poetry" ]

--- a/packages/seed/src/commands/test/ScriptRunner.ts
+++ b/packages/seed/src/commands/test/ScriptRunner.ts
@@ -86,7 +86,7 @@ export class ScriptRunner {
         containerId: string;
         script: DockerScriptConfig;
     }): Promise<ScriptRunner.RunResponse> {
-        taskContext.logger.info(`Running script ${script.commands[0] ?? ""} on ${id}`);
+        // taskContext.logger.info(`Running script ${script.commands[0] ?? ""} on ${id}`);
 
         const workDir = id.replace(":", "_");
         const scriptFile = await tmp.file();
@@ -145,7 +145,7 @@ export class ScriptRunner {
             "docker",
             ["exec", containerId, "/bin/sh", "-c", `chmod +x /${workDir}/test.sh && /${workDir}/test.sh`],
             {
-                doNotPipeOutput: true,
+                // doNotPipeOutput: true,
                 reject: false
             }
         );
@@ -175,6 +175,8 @@ export class ScriptRunner {
                 "-dit",
                 "-v",
                 cliVolumeBind,
+                "-v",
+                "~/Library/Caches/pypoetry:/root/.cache/pypoetry",
                 script.docker,
                 "/bin/sh"
             ]);

--- a/packages/seed/src/commands/test/ScriptRunner.ts
+++ b/packages/seed/src/commands/test/ScriptRunner.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import { writeFile } from "fs/promises";
 import tmp from "tmp-promise";
 
@@ -168,6 +169,7 @@ export class ScriptRunner {
     private async startContainers(context: TaskContext): Promise<void> {
         const absoluteFilePathToFernCli = await this.buildFernCli(context);
         const cliVolumeBind = `${absoluteFilePathToFernCli}:/fern`;
+        const poetryCacheDir = execSync("poetry config cache-dir", { encoding: "utf8" }).trim();
         // Start running a docker container for each script instance
         for (const script of this.workspace.workspaceConfig.scripts ?? []) {
             const startSeedCommand = await loggingExeca(undefined, "docker", [
@@ -176,7 +178,7 @@ export class ScriptRunner {
                 "-v",
                 cliVolumeBind,
                 "-v",
-                "~/Library/Caches/pypoetry:/root/.cache/pypoetry",
+                `${poetryCacheDir}:/root/.cache/pypoetry`,
                 script.docker,
                 "/bin/sh"
             ]);

--- a/packages/seed/src/commands/test/ScriptRunner.ts
+++ b/packages/seed/src/commands/test/ScriptRunner.ts
@@ -169,7 +169,9 @@ export class ScriptRunner {
     private async startContainers(context: TaskContext): Promise<void> {
         const absoluteFilePathToFernCli = await this.buildFernCli(context);
         const cliVolumeBind = `${absoluteFilePathToFernCli}:/fern`;
-        const poetryCacheDir = execSync("poetry config cache-dir", { encoding: "utf8" }).trim();
+        const poetryCacheDir = execSync("poetry config cache-dir 2>/dev/null || echo $HOME/.cache/pypoetry", {
+            encoding: "utf8"
+        }).trim();
         // Start running a docker container for each script instance
         for (const script of this.workspace.workspaceConfig.scripts ?? []) {
             const startSeedCommand = await loggingExeca(undefined, "docker", [

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -301,7 +301,7 @@ fixtures:
       outputFolder: use-typeddict-requests
 scripts:
   # Test Pydantic V2
-  - docker: fernapi/python-seed
+  - docker: fernapi/python-seed:local
     commands:
       # Tests now run a mock server, you can always run seed with --skip-scripts to save time
       - export NPM_CONFIG_CACHE="$(pwd)/.cache"
@@ -321,16 +321,16 @@ scripts:
       - poetry run pytest -rP .
       - 'echo "post pytest: $SECONDS"'
   # Test Pydantic V1
-  - docker: fernapi/python-seed
-    commands:
-      - export NPM_CONFIG_CACHE="$(pwd)/.cache"
-      - export HOME="$(pwd)/"
-      - poetry config virtualenvs.path .
-      - poetry add pydantic=^1.10
-      - poetry lock
-      - poetry install
-      - poetry run mypy ./src ./tests
-      - poetry run pytest -rP .
+  # - docker: fernapi/python-seed:local
+  #   commands:
+  #     - export NPM_CONFIG_CACHE="$(pwd)/.cache"
+  #     - export HOME="$(pwd)/"
+  #     - poetry config virtualenvs.path .
+  #     - poetry add pydantic=^1.10
+  #     - poetry lock
+  #     - poetry install
+  #     - poetry run mypy ./src ./tests
+  #     - poetry run pytest -rP .
 allowedFailures:
   - any-auth
   - examples:client-filename

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -306,12 +306,20 @@ scripts:
       # Tests now run a mock server, you can always run seed with --skip-scripts to save time
       - export NPM_CONFIG_CACHE="$(pwd)/.cache"
       - export HOME="$(pwd)/"
+      - 'echo "start: $SECONDS"'
       - poetry config virtualenvs.path .
+      - poetry config cache-dir /root/.cache/pypoetry
+      - 'echo "post virtualenv: $SECONDS"'
       - poetry add pydantic=^2.8
+      - 'echo "post add pydantic: $SECONDS"'
       - poetry lock
+      - 'echo "post lock: $SECONDS"'
       - poetry install
+      - 'echo "post install: $SECONDS"'
       - poetry run mypy ./src ./tests
+      - 'echo "post mypy: $SECONDS"'
       - poetry run pytest -rP .
+      - 'echo "post pytest: $SECONDS"'
   # Test Pydantic V1
   - docker: fernapi/python-seed
     commands:


### PR DESCRIPTION
## Description
Find low-hanging fruit optimizations for the python-sdk generator tests

## Changes Made
- Mount the host systems cache directory into the test runner container for reuse across all newly-built containers
- Remove unnecessary dependencies from the fernapi/python-seed base image to reduce size from 1.6 GB to 70 MB speeding up initial download (for first use or parallelization of the test container)
- Remove the second test case using pedantic v1 (seems unnecessary if the generator is fully using pedantic v2)

## Changes to make
- Run each script in parallel at ScriptRunner.ts Line # 176
- Run each test in parallel at testWorkspaceFixtures.ts Line # 30

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed

