### PR TITLE
feat(go): Generate MarhsalJSON methods in go-v2

### DIFF
--- a/generators/go-v2/ast/src/ast/Enum.ts
+++ b/generators/go-v2/ast/src/ast/Enum.ts
@@ -98,6 +98,6 @@ export class Enum extends AstNode {
     }
 
     public static getMemberIdentifier({ name, member }: { name: string; member: Enum.Member }): Identifier {
-        return new Identifier({ name: `${name}${member.name}` });
+        return new Identifier(`${name}${member.name}`);
     }
 }

--- a/generators/go-v2/ast/src/ast/Identifier.ts
+++ b/generators/go-v2/ast/src/ast/Identifier.ts
@@ -2,16 +2,13 @@ import { AstNode } from "./core/AstNode";
 import { Writer } from "./core/Writer";
 
 export declare namespace Identifier {
-    interface Args {
-        /* The name of the identifier */
-        name: string;
-    }
+    type Args = string;
 }
 
 export class Identifier extends AstNode {
     public readonly name: string;
 
-    constructor({ name }: Identifier.Args) {
+    constructor(name: Identifier.Args) {
         super();
         this.name = name;
     }

--- a/generators/go-v2/ast/src/ast/Switch.ts
+++ b/generators/go-v2/ast/src/ast/Switch.ts
@@ -36,7 +36,7 @@ export class Switch extends AstNode {
         const cases = this.cases;
         if (this.default != null) {
             cases.push({
-                on: new Identifier({ name: "default" }),
+                on: new Identifier("default"),
                 body: this.default
             });
         }

--- a/generators/go-v2/ast/src/ast/TypeDeclaration.ts
+++ b/generators/go-v2/ast/src/ast/TypeDeclaration.ts
@@ -3,7 +3,7 @@ import { Comment } from "./Comment";
 import { Writer } from "./core/Writer";
 import { Type } from "./Type";
 
-export declare namespace Alias {
+export declare namespace TypeDeclaration {
     interface Args {
         /* The name of the alias */
         name: string;
@@ -14,12 +14,12 @@ export declare namespace Alias {
     }
 }
 
-export class Alias extends AstNode {
+export class TypeDeclaration extends AstNode {
     public readonly name: string;
     public readonly type: Type;
     public readonly docs: string | undefined;
 
-    constructor({ name, type, docs }: Alias.Args) {
+    constructor({ name, type, docs }: TypeDeclaration.Args) {
         super();
         this.name = name;
         this.type = type;
@@ -30,7 +30,7 @@ export class Alias extends AstNode {
         writer.writeNode(new Comment({ docs: this.docs }));
         writer.write("type ");
         writer.write(this.name);
-        writer.write(" = ");
+        writer.write(" ");
         writer.writeNode(this.type);
     }
 }

--- a/generators/go-v2/ast/src/ast/TypeInstantiation.ts
+++ b/generators/go-v2/ast/src/ast/TypeInstantiation.ts
@@ -111,7 +111,7 @@ interface Slice {
 
 interface Struct {
     type: "struct";
-    typeReference: GoTypeReference;
+    typeReference: AstNode;
     fields: StructField[];
     generics?: Type[];
 }
@@ -329,7 +329,7 @@ export class TypeInstantiation extends AstNode {
         typeReference,
         fields
     }: {
-        typeReference: GoTypeReference;
+        typeReference: AstNode;
         fields: StructField[];
     }): TypeInstantiation {
         return new this({
@@ -344,7 +344,7 @@ export class TypeInstantiation extends AstNode {
         fields,
         generics
     }: {
-        typeReference: GoTypeReference;
+        typeReference: AstNode;
         fields: StructField[];
         generics?: Type[];
     }): TypeInstantiation {

--- a/generators/go-v2/ast/src/ast/__test__/Snippets.test.ts
+++ b/generators/go-v2/ast/src/ast/__test__/Snippets.test.ts
@@ -7,6 +7,7 @@ import { Type } from "../Type";
 import { TypeInstantiation } from "../TypeInstantiation";
 import { AstNode } from "../core/AstNode";
 import { GoFile } from "../core/GoFile";
+import { MultiNode } from "../MultiNode";
 
 interface TestCase {
     description: string;
@@ -316,7 +317,7 @@ describe("file", () => {
                 )
             })
         );
-        file.add(foo, bar);
+        file.add(new MultiNode({ nodes: [foo, bar] }));
         const content = file.toString({
             packageName: "example",
             rootImportPath: "github.com/acme/acme-go",

--- a/generators/go-v2/ast/src/ast/__test__/__snapshots__/Snippets.test.ts.snap
+++ b/generators/go-v2/ast/src/ast/__test__/__snapshots__/Snippets.test.ts.snap
@@ -219,9 +219,11 @@ import (
     nestedcommon "github.com/acme/acme-go/nested/common"
 )
 
+
 type Foo struct {
     Name common.Identifier
 }
+
 type Bar struct {
     Name nestedcommon.Identifier
 }

--- a/generators/go-v2/ast/src/ast/index.ts
+++ b/generators/go-v2/ast/src/ast/index.ts
@@ -17,5 +17,6 @@ export { Selector } from "./Selector";
 export { Struct } from "./Struct";
 export { Switch } from "./Switch";
 export { Type } from "./Type";
+export { TypeDeclaration } from "./TypeDeclaration";
 export { TypeInstantiation, type StructField } from "./TypeInstantiation";
 export { TimeTypeReference, UuidTypeReference, IoReaderTypeReference } from "./Type";

--- a/generators/go-v2/ast/src/go.ts
+++ b/generators/go-v2/ast/src/go.ts
@@ -14,7 +14,8 @@ import {
     Pointer,
     Selector,
     Struct,
-    Switch
+    Switch,
+    TypeDeclaration
 } from "./ast";
 
 export function alias(args: Alias.Args): Alias {
@@ -69,12 +70,16 @@ export function selector(args: Selector.Args): Selector {
     return new Selector(args);
 }
 
-export function struct(args: Struct.Args): Struct {
+export function struct(args: Struct.Args = {}): Struct {
     return new Struct(args);
 }
 
 export function switch_(args: Switch.Args): Switch {
     return new Switch(args);
+}
+
+export function typeDeclaration(args: TypeDeclaration.Args): TypeDeclaration {
+    return new TypeDeclaration(args);
 }
 
 export function typeReference(args: GoTypeReference.Args): GoTypeReference {
@@ -99,6 +104,7 @@ export {
     Selector,
     Struct,
     Type,
+    TypeDeclaration,
     TypeInstantiation,
     type StructField,
     Writer,

--- a/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
+++ b/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
@@ -139,6 +139,20 @@ export abstract class AbstractGoGeneratorContext<
         return name.camelCase.safeName;
     }
 
+    public getDateTypeReference(): go.TypeReference {
+        return go.typeReference({
+            name: "Date",
+            importPath: this.getInternalImportPath()
+        });
+    }
+
+    public getDateTimeTypeReference(): go.TypeReference {
+        return go.typeReference({
+            name: "DateTime",
+            importPath: this.getInternalImportPath()
+        });
+    }
+
     public callFmtErrorf(format: string, args: go.AstNode[]): go.FuncInvocation {
         return go.invokeFunc({
             func: go.typeReference({ name: "Errorf", importPath: "fmt" }),
@@ -155,7 +169,55 @@ export abstract class AbstractGoGeneratorContext<
         });
     }
 
-    public callInternalStringifyJSON(arg: go.TypeInstantiation): go.FuncInvocation {
+    public callJsonMarshal(arg: go.AstNode): go.FuncInvocation {
+        return go.invokeFunc({
+            func: go.typeReference({ name: "Marshal", importPath: "encoding/json" }),
+            arguments_: [arg],
+            multiline: false
+        });
+    }
+
+    public callMarshalJsonWithExtraProperties(args: go.AstNode[]): go.FuncInvocation {
+        return this.callInternalFunc({
+            name: "MarshalJSONWithExtraProperties",
+            arguments_: args,
+            multiline: false
+        });
+    }
+
+    public callNewDate(arg: go.AstNode): go.FuncInvocation {
+        return this.callInternalFunc({
+            name: "NewDate",
+            arguments_: [arg],
+            multiline: false
+        });
+    }
+
+    public callNewOptionalDate(arg: go.AstNode): go.FuncInvocation {
+        return this.callInternalFunc({
+            name: "NewOptionalDate",
+            arguments_: [arg],
+            multiline: false
+        });
+    }
+
+    public callNewDateTime(arg: go.AstNode): go.FuncInvocation {
+        return this.callInternalFunc({
+            name: "NewDateTime",
+            arguments_: [arg],
+            multiline: false
+        });
+    }
+
+    public callNewOptionalDateTime(arg: go.AstNode): go.FuncInvocation {
+        return this.callInternalFunc({
+            name: "NewOptionalDateTime",
+            arguments_: [arg],
+            multiline: false
+        });
+    }
+
+    public callStringifyJson(arg: go.TypeInstantiation): go.FuncInvocation {
         return this.callInternalFunc({
             name: "StringifyJSON",
             arguments_: [arg],
@@ -316,6 +378,12 @@ export abstract class AbstractGoGeneratorContext<
 
     public getLiteralAsString(literal: Literal): string {
         return literal.type === "string" ? `"${literal.string}"` : literal.boolean ? '"true"' : '"false"';
+    }
+
+    public getLiteralValue(literal: Literal): go.AstNode {
+        return literal.type === "string"
+            ? go.TypeInstantiation.string(literal.string)
+            : go.TypeInstantiation.bool(literal.boolean);
     }
 
     public getContextTypeReference(): go.TypeReference {

--- a/generators/go-v2/model/src/enum/EnumGenerator.ts
+++ b/generators/go-v2/model/src/enum/EnumGenerator.ts
@@ -48,7 +48,7 @@ export class EnumGenerator extends AbstractModelGenerator {
         members: go.Enum.Member[];
     }): go.Func {
         const switch_ = go.switch_({
-            on: go.identifier({ name: STRING_VALUE_PARAM_NAME }),
+            on: go.identifier(STRING_VALUE_PARAM_NAME),
             cases: members.map((member) => ({
                 on: go.TypeInstantiation.string(member.value),
                 body: go.codeblock((writer) => {
@@ -69,8 +69,8 @@ export class EnumGenerator extends AbstractModelGenerator {
                 writer.write('return "", ');
                 writer.writeNode(
                     this.context.callFmtErrorf("%s is not a valid %T", [
-                        go.identifier({ name: STRING_VALUE_PARAM_NAME }),
-                        go.identifier({ name: TYPE_PARAMETER_NAME })
+                        go.identifier(STRING_VALUE_PARAM_NAME),
+                        go.identifier(TYPE_PARAMETER_NAME)
                     ])
                 );
                 writer.newLine();

--- a/generators/go-v2/model/src/object/ObjectGenerator.ts
+++ b/generators/go-v2/model/src/object/ObjectGenerator.ts
@@ -1,18 +1,38 @@
 import { GoFile } from "@fern-api/go-base";
 import { go } from "@fern-api/go-ast";
 
-import { ObjectProperty, ObjectTypeDeclaration, TypeDeclaration } from "@fern-fern/ir-sdk/api";
+import {
+    Literal,
+    Name,
+    NameAndWireValue,
+    ObjectProperty,
+    ObjectTypeDeclaration,
+    TypeDeclaration,
+    TypeReference
+} from "@fern-fern/ir-sdk/api";
 
 import { ModelGeneratorContext } from "../ModelGeneratorContext";
 import { AbstractModelGenerator } from "../AbstractModelGenerator";
 
+const EMBED_TYPE_NAME = "embed";
 const RAW_JSON_FIELD_NAME = "rawJSON";
 
 declare namespace ObjectGenerator {
+    interface Marshaler {
+        /* The field defined within the marshaler struct. */
+        field: go.Field;
+        /* The mapper function used to map the field to the marshaler struct. */
+        mapper: go.AstNode;
+    }
+
     interface FieldWithZeroValue {
         field: go.Field;
         zeroValue: go.TypeInstantiation;
-        isLiteral: boolean;
+
+        // Some types require special [de]serialization logic, such
+        // as dates. These mappers are used in the MarshalJSON and
+        // UnmarshalJSON implementations.
+        marshaler?: Marshaler;
     }
 }
 
@@ -36,6 +56,9 @@ export class ObjectGenerator extends AbstractModelGenerator {
         const fieldsWithZeroValue = this.getFieldsWithZeroValue();
         struct_.addField(...fieldsWithZeroValue.map((field) => field.field));
         struct_.addMethod(...this.getGetterMethods(fieldsWithZeroValue));
+        if (this.needsCustomMarshalJsonMethod(fieldsWithZeroValue)) {
+            struct_.addMethod(this.getMarshalJsonMethod(fieldsWithZeroValue));
+        }
         struct_.addMethod(this.getStringMethod());
         return this.toFile(struct_);
     }
@@ -44,13 +67,14 @@ export class ObjectGenerator extends AbstractModelGenerator {
         const properties = this.getAllObjectProperties();
         const fields = properties.map((property) => {
             return {
+                name: property.name,
                 field: this.context.goFieldMapper.convert({
                     name: property.name,
                     reference: property.valueType,
                     docs: property.docs
                 }),
                 zeroValue: this.context.goZeroValueMapper.convert({ reference: property.valueType }),
-                isLiteral: this.context.maybeLiteral(property.valueType) !== undefined
+                marshaler: this.getMarshaler({ name: property.name, typeReference: property.valueType })
             };
         });
         return [...fields, this.getExtraPropertiesField(), this.getRawJsonField()];
@@ -81,11 +105,92 @@ export class ObjectGenerator extends AbstractModelGenerator {
             });
     }
 
-    private getStringMethod(): go.Method {
-        const rawJsonFieldReference = go.selector({
-            on: go.identifier({ name: this.receiver }),
-            selector: go.identifier({ name: RAW_JSON_FIELD_NAME })
+    private getMarshalJsonMethod(fieldsWithZeroValue: ObjectGenerator.FieldWithZeroValue[]): go.Method {
+        const marshalerType = go.struct({
+            embeds: [
+                go.typeReference({
+                    name: EMBED_TYPE_NAME
+                })
+            ]
         });
+        for (const field of fieldsWithZeroValue) {
+            if (field.marshaler == null) {
+                continue;
+            }
+            marshalerType.addField(field.marshaler.field);
+        }
+        const marshalerInstantiation = go.TypeInstantiation.struct({
+            typeReference: marshalerType,
+            fields: [
+                {
+                    name: EMBED_TYPE_NAME,
+                    value: go.TypeInstantiation.reference(go.identifier(`${EMBED_TYPE_NAME}(*${this.receiver})`))
+                },
+                ...fieldsWithZeroValue
+                    .map((field) => {
+                        const fieldMarshaler = field.marshaler;
+                        if (fieldMarshaler == null) {
+                            return undefined;
+                        }
+                        return {
+                            name: fieldMarshaler.field.name,
+                            value: go.TypeInstantiation.reference(fieldMarshaler.mapper)
+                        };
+                    })
+                    .filter((field) => field != null)
+            ]
+        });
+        return go.method({
+            typeReference: this.typeReference,
+            name: "MarshalJSON",
+            parameters: [],
+            return_: [go.Type.bytes(), go.Type.error()],
+            body: go.codeblock((writer) => {
+                writer.writeNode(
+                    go.typeDeclaration({
+                        name: EMBED_TYPE_NAME,
+                        type: go.Type.reference(
+                            go.typeReference({
+                                name: this.context.getClassName(this.typeDeclaration.name.name)
+                            })
+                        )
+                    })
+                );
+                writer.newLine();
+                writer.write("var marshaler = ");
+                writer.writeNode(marshalerInstantiation);
+                writer.newLine();
+                writer.write("return ");
+                if (this.objectDeclaration.extraProperties) {
+                    writer.writeNode(
+                        this.context.callMarshalJsonWithExtraProperties([
+                            go.identifier("marshaler"),
+                            this.getExtraPropertiesFieldReference()
+                        ])
+                    );
+                } else {
+                    writer.writeNode(this.context.callJsonMarshal(go.identifier("marshaler")));
+                }
+                writer.newLine();
+            }),
+            pointerReceiver: true
+        });
+    }
+
+    private getUnmarshalJsonMethod(fieldsWithZeroValue: ObjectGenerator.FieldWithZeroValue[]): go.Method {
+        return go.method({
+            typeReference: this.typeReference,
+            name: "UnmarshalJSON",
+            parameters: [go.parameter({ name: "data", type: go.Type.bytes() })],
+            return_: [go.Type.error()],
+            body: go.codeblock((writer) => {
+                writer.writeLine("return nil");
+            }),
+            pointerReceiver: true
+        });
+    }
+
+    private getStringMethod(): go.Method {
         return go.method({
             typeReference: this.typeReference,
             name: "String",
@@ -93,21 +198,21 @@ export class ObjectGenerator extends AbstractModelGenerator {
             return_: [go.Type.string()],
             body: go.codeblock((writer) => {
                 writer.write(`if len(`);
-                writer.writeNode(rawJsonFieldReference);
+                writer.writeNode(this.getRawJsonFieldReference());
                 writer.writeLine(`) > 0 {`);
                 writer.indent();
                 this.callStringifyJsonAndReturnValue({
                     writer,
-                    arg: rawJsonFieldReference
+                    arg: this.getRawJsonFieldReference()
                 });
                 writer.dedent();
                 writer.writeLine("}");
                 this.callStringifyJsonAndReturnValue({
                     writer,
-                    arg: go.identifier({ name: this.receiver })
+                    arg: go.identifier(this.receiver)
                 });
                 writer.write("return ");
-                writer.writeNode(this.context.callFmtSprintf("%#v", [go.identifier({ name: this.receiver })]));
+                writer.writeNode(this.context.callFmtSprintf("%#v", [go.identifier(this.receiver)]));
             }),
             pointerReceiver: true
         });
@@ -115,7 +220,7 @@ export class ObjectGenerator extends AbstractModelGenerator {
 
     private callStringifyJsonAndReturnValue({ writer, arg }: { writer: go.Writer; arg: go.AstNode }): void {
         writer.write("if value, err := ");
-        writer.writeNode(this.context.callInternalStringifyJSON(go.TypeInstantiation.reference(arg)));
+        writer.writeNode(this.context.callStringifyJson(go.TypeInstantiation.reference(arg)));
         writer.writeLine(`; err == nil {`);
         writer.indent();
         writer.writeLine("return value");
@@ -140,8 +245,7 @@ export class ObjectGenerator extends AbstractModelGenerator {
                         }
                     ]
                 }),
-                zeroValue: go.TypeInstantiation.nil(),
-                isLiteral: false
+                zeroValue: go.TypeInstantiation.nil()
             };
         }
         return {
@@ -149,9 +253,15 @@ export class ObjectGenerator extends AbstractModelGenerator {
                 name: "extraProperties",
                 type: go.Type.map(go.Type.string(), go.Type.any())
             }),
-            zeroValue: go.TypeInstantiation.nil(),
-            isLiteral: false
+            zeroValue: go.TypeInstantiation.nil()
         };
+    }
+
+    private getExtraPropertiesFieldReference(): go.AstNode {
+        return go.selector({
+            on: go.identifier(this.receiver),
+            selector: go.identifier(this.getExtraPropertiesField().field.name)
+        });
     }
 
     private getRawJsonField(): ObjectGenerator.FieldWithZeroValue {
@@ -160,8 +270,110 @@ export class ObjectGenerator extends AbstractModelGenerator {
                 name: RAW_JSON_FIELD_NAME,
                 type: go.Type.reference(this.context.getJsonRawMessageTypeReference())
             }),
-            zeroValue: go.TypeInstantiation.nil(),
-            isLiteral: false
+            zeroValue: go.TypeInstantiation.nil()
+        };
+    }
+
+    private getRawJsonFieldReference(): go.AstNode {
+        return go.selector({
+            on: go.identifier(this.receiver),
+            selector: go.identifier(RAW_JSON_FIELD_NAME)
+        });
+    }
+
+    private getMarshaler({
+        name,
+        typeReference
+    }: {
+        name: NameAndWireValue;
+        typeReference: TypeReference;
+    }): ObjectGenerator.Marshaler | undefined {
+        const literal = this.context.maybeLiteral(typeReference);
+        if (literal != null) {
+            return this.getLiteralMarshaler({ name, typeReference, literal });
+        }
+        if (this.context.isDate(typeReference)) {
+            return this.getDateMarshaler({ name, typeReference });
+        }
+        if (this.context.isDateTime(typeReference)) {
+            return this.getDateTimeMarshaler({ name, typeReference });
+        }
+        return undefined;
+    }
+
+    private getLiteralMarshaler({
+        name,
+        typeReference,
+        literal
+    }: {
+        name: NameAndWireValue;
+        typeReference: TypeReference;
+        literal: Literal;
+    }): ObjectGenerator.Marshaler | undefined {
+        return {
+            field: go.field({
+                name: this.context.getFieldName(name.name),
+                type: this.context.goTypeMapper.convert({ reference: typeReference }),
+                tags: [
+                    {
+                        name: "json",
+                        value: name.wireValue
+                    }
+                ]
+            }),
+            mapper: this.context.getLiteralValue(literal)
+        };
+    }
+
+    private getDateMarshaler({
+        name,
+        typeReference
+    }: {
+        name: NameAndWireValue;
+        typeReference: TypeReference;
+    }): ObjectGenerator.Marshaler | undefined {
+        const fieldReference = this.getFieldReference(name.name);
+        const isOptional = this.context.isOptional(typeReference);
+        return {
+            field: go.field({
+                name: this.context.getFieldName(name.name),
+                type: go.Type.pointer(go.Type.reference(this.context.getDateTypeReference())),
+                tags: [
+                    {
+                        name: "json",
+                        value: name.wireValue
+                    }
+                ]
+            }),
+            mapper: isOptional
+                ? this.context.callNewOptionalDate(fieldReference)
+                : this.context.callNewDate(fieldReference)
+        };
+    }
+
+    private getDateTimeMarshaler({
+        name,
+        typeReference
+    }: {
+        name: NameAndWireValue;
+        typeReference: TypeReference;
+    }): ObjectGenerator.Marshaler | undefined {
+        const fieldReference = this.getFieldReference(name.name);
+        const isOptional = this.context.isOptional(typeReference);
+        return {
+            field: go.field({
+                name: this.context.getFieldName(name.name),
+                type: go.Type.pointer(go.Type.reference(this.context.getDateTimeTypeReference())),
+                tags: [
+                    {
+                        name: "json",
+                        value: name.wireValue
+                    }
+                ]
+            }),
+            mapper: isOptional
+                ? this.context.callNewOptionalDateTime(fieldReference)
+                : this.context.callNewDateTime(fieldReference)
         };
     }
 
@@ -169,8 +381,23 @@ export class ObjectGenerator extends AbstractModelGenerator {
         return `Get${field.name.charAt(0).toUpperCase()}${field.name.slice(1)}`;
     }
 
+    private getFieldReference(name: Name): go.AstNode {
+        return go.selector({
+            on: go.identifier(this.receiver),
+            selector: go.identifier(this.context.getFieldName(name))
+        });
+    }
+
     private shouldExcludeGetterMethod(fieldWithZeroValue: ObjectGenerator.FieldWithZeroValue): boolean {
         return fieldWithZeroValue.field.name === RAW_JSON_FIELD_NAME;
+    }
+
+    private needsCustomMarshalJsonMethod(fields: ObjectGenerator.FieldWithZeroValue[]): boolean {
+        return this.objectDeclaration.extraProperties || fields.some((field) => field.marshaler != null);
+    }
+
+    private needsCustomUnmarshalJsonMethod(fields: ObjectGenerator.FieldWithZeroValue[]): boolean {
+        return fields.some((field) => field.marshaler != null);
     }
 
     private getAllObjectProperties(): ObjectProperty[] {

--- a/seed/go-model/empty-clients/level1/level2/types.go
+++ b/seed/go-model/empty-clients/level1/level2/types.go
@@ -110,6 +110,18 @@ func (a *Address) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Address) MarshalJSON() ([]byte, error) {
+	type embed Address
+	var marshaler = struct {
+		embed
+		Country string `json:"country"`
+	}{
+		embed:   embed(*a),
+		Country: "USA",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (a *Address) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {

--- a/seed/go-model/empty-clients/level1/types.go
+++ b/seed/go-model/empty-clients/level1/types.go
@@ -110,6 +110,18 @@ func (a *Address) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Address) MarshalJSON() ([]byte, error) {
+	type embed Address
+	var marshaler = struct {
+		embed
+		Country string `json:"country"`
+	}{
+		embed:   embed(*a),
+		Country: "USA",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (a *Address) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {

--- a/seed/go-model/examples/types.go
+++ b/seed/go-model/examples/types.go
@@ -208,6 +208,18 @@ func (m *Movie) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*m),
+		Type:  "movie",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (m *Movie) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -451,6 +463,18 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]any {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
+	type embed ExtendedMovie
+	var marshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*e),
+		Type:  "movie",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (e *ExtendedMovie) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -498,6 +522,20 @@ func (m *Moment) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return m.extraProperties
+}
+
+func (m *Moment) MarshalJSON() ([]byte, error) {
+	type embed Moment
+	var marshaler = struct {
+		embed
+		Date     *internal.Date     `json:"date"`
+		Datetime *internal.DateTime `json:"datetime"`
+	}{
+		embed:    embed(*m),
+		Date:     internal.NewDate(m.Date),
+		Datetime: internal.NewDateTime(m.Datetime),
+	}
+	return json.Marshal(marshaler)
 }
 
 func (m *Moment) String() string {

--- a/seed/go-model/exhaustive/types/object.go
+++ b/seed/go-model/exhaustive/types/object.go
@@ -128,6 +128,20 @@ func (o *ObjectWithOptionalField) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *ObjectWithOptionalField) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithOptionalField
+	var marshaler = struct {
+		embed
+		Datetime *internal.DateTime `json:"datetime"`
+		Date     *internal.Date     `json:"date"`
+	}{
+		embed:    embed(*o),
+		Datetime: internal.NewOptionalDateTime(o.Datetime),
+		Date:     internal.NewOptionalDate(o.Date),
+	}
+	return json.Marshal(marshaler)
+}
+
 func (o *ObjectWithOptionalField) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {

--- a/seed/go-model/extra-properties/types.go
+++ b/seed/go-model/extra-properties/types.go
@@ -29,6 +29,18 @@ func (f *Failure) GetExtraProperties() map[string]any {
 	return f.ExtraProperties
 }
 
+func (f *Failure) MarshalJSON() ([]byte, error) {
+	type embed Failure
+	var marshaler = struct {
+		embed
+		Status string `json:"status"`
+	}{
+		embed:  embed(*f),
+		Status: "failure",
+	}
+	return internal.MarshalJSONWithExtraProperties(marshaler, f.ExtraProperties)
+}
+
 func (f *Failure) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {

--- a/seed/go-model/extra-properties/user.go
+++ b/seed/go-model/extra-properties/user.go
@@ -29,6 +29,16 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.ExtraProperties
 }
 
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	return internal.MarshalJSONWithExtraProperties(marshaler, u.ExtraProperties)
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/literal/inlined.go
+++ b/seed/go-model/literal/inlined.go
@@ -65,6 +65,18 @@ func (a *ANestedLiteral) GetExtraProperties() map[string]any{
     return a.extraProperties
 }
 
+func (a *ANestedLiteral) MarshalJSON() ([]byte, error){
+    type embed ANestedLiteral
+    var marshaler = struct{
+        embed
+        MyLiteral string `json:"myLiteral"`
+    }{
+        embed: embed(*a),
+        MyLiteral: "How super cool",
+    }
+    return json.Marshal(marshaler)
+}
+
 func (a *ANestedLiteral) String() string{
     if len(a.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -86,7 +98,6 @@ type DiscriminatedLiteral struct {
     LiteralGeorge bool
 }
 
-
 type UndiscriminatedLiteral struct {
     String string
     $endingStringLiteral string
@@ -95,4 +106,3 @@ type UndiscriminatedLiteral struct {
     FalseLiteral bool
     Boolean bool
 }
-

--- a/seed/go-model/literal/reference.go
+++ b/seed/go-model/literal/reference.go
@@ -77,6 +77,22 @@ func (s *SendRequest) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SendRequest) MarshalJSON() ([]byte, error) {
+	type embed SendRequest
+	var marshaler = struct {
+		embed
+		Prompt string `json:"prompt"`
+		Stream bool   `json:"stream"`
+		Ending string `json:"ending"`
+	}{
+		embed:  embed(*s),
+		Prompt: "You are a helpful assistant",
+		Stream: false,
+		Ending: "$ending",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (s *SendRequest) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -157,6 +173,20 @@ func (n *NestedObjectWithLiterals) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NestedObjectWithLiterals) MarshalJSON() ([]byte, error) {
+	type embed NestedObjectWithLiterals
+	var marshaler = struct {
+		embed
+		Literal1 string `json:"literal1"`
+		Literal2 string `json:"literal2"`
+	}{
+		embed:    embed(*n),
+		Literal1: "literal1",
+		Literal2: "literal2",
+	}
+	return json.Marshal(marshaler)
 }
 
 func (n *NestedObjectWithLiterals) String() string {

--- a/seed/go-model/literal/types.go
+++ b/seed/go-model/literal/types.go
@@ -45,6 +45,18 @@ func (s *SendResponse) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SendResponse) MarshalJSON() ([]byte, error) {
+	type embed SendResponse
+	var marshaler = struct {
+		embed
+		Success bool `json:"success"`
+	}{
+		embed:   embed(*s),
+		Success: true,
+	}
+	return json.Marshal(marshaler)
+}
+
 func (s *SendResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {

--- a/seed/go-model/nullable/nullable.go
+++ b/seed/go-model/nullable/nullable.go
@@ -177,6 +177,20 @@ func (m *Metadata) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+		CreatedAt *internal.DateTime `json:"createdAt"`
+		UpdatedAt *internal.DateTime `json:"updatedAt"`
+	}{
+		embed:     embed(*m),
+		CreatedAt: internal.NewDateTime(m.CreatedAt),
+		UpdatedAt: internal.NewDateTime(m.UpdatedAt),
+	}
+	return json.Marshal(marshaler)
+}
+
 func (m *Metadata) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {

--- a/seed/go-model/object/types.go
+++ b/seed/go-model/object/types.go
@@ -224,6 +224,26 @@ func (t *Type) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *Type) MarshalJSON() ([]byte, error) {
+	type embed Type
+	var marshaler = struct {
+		embed
+		Six        *internal.DateTime `json:"six"`
+		Seven      *internal.Date     `json:"seven"`
+		Eighteen   string             `json:"eighteen"`
+		Twentyfour *internal.DateTime `json:"twentyfour"`
+		Twentyfive *internal.Date     `json:"twentyfive"`
+	}{
+		embed:      embed(*t),
+		Six:        internal.NewDateTime(t.Six),
+		Seven:      internal.NewDate(t.Seven),
+		Eighteen:   "eighteen",
+		Twentyfour: internal.NewOptionalDateTime(t.Twentyfour),
+		Twentyfive: internal.NewOptionalDate(t.Twentyfive),
+	}
+	return json.Marshal(marshaler)
+}
+
 func (t *Type) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/pagination/complex.go
+++ b/seed/go-model/pagination/complex.go
@@ -262,6 +262,18 @@ func (p *PaginatedConversationResponse) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *PaginatedConversationResponse) MarshalJSON() ([]byte, error) {
+	type embed PaginatedConversationResponse
+	var marshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*p),
+		Type:  "conversation.list",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (p *PaginatedConversationResponse) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -325,6 +337,18 @@ func (c *CursorPages) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *CursorPages) MarshalJSON() ([]byte, error) {
+	type embed CursorPages
+	var marshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*c),
+		Type:  "pages",
+	}
+	return json.Marshal(marshaler)
 }
 
 func (c *CursorPages) String() string {

--- a/seed/go-model/simple-fhir/types.go
+++ b/seed/go-model/simple-fhir/types.go
@@ -174,6 +174,18 @@ func (a *Account) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Account) MarshalJSON() ([]byte, error) {
+	type embed Account
+	var marshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed:        embed(*a),
+		ResourceType: "Account",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (a *Account) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -247,6 +259,18 @@ func (p *Patient) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Patient) MarshalJSON() ([]byte, error) {
+	type embed Patient
+	var marshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed:        embed(*p),
+		ResourceType: "Patient",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (p *Patient) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -312,6 +336,18 @@ func (p *Practitioner) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Practitioner) MarshalJSON() ([]byte, error) {
+	type embed Practitioner
+	var marshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed:        embed(*p),
+		ResourceType: "Practitioner",
+	}
+	return json.Marshal(marshaler)
+}
+
 func (p *Practitioner) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -375,6 +411,18 @@ func (s *Script) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *Script) MarshalJSON() ([]byte, error) {
+	type embed Script
+	var marshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed:        embed(*s),
+		ResourceType: "Script",
+	}
+	return json.Marshal(marshaler)
 }
 
 func (s *Script) String() string {

--- a/seed/go-model/trace/admin.go
+++ b/seed/go-model/trace/admin.go
@@ -8,4 +8,3 @@ type Test struct {
     And bool
     Or bool
 }
-

--- a/seed/go-model/trace/commons.go
+++ b/seed/go-model/trace/commons.go
@@ -29,7 +29,6 @@ type VariableType struct {
     DoublyLinkedListType any
 }
 
-
 type ListType struct {
     ValueType *VariableType `json:"valueType" url:"valueType"`
     // Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.
@@ -130,7 +129,6 @@ type VariableValue struct {
     NullValue any
 }
 
-
 type DebugVariableValue struct {
     Type string
     IntegerValue int
@@ -147,7 +145,6 @@ type DebugVariableValue struct {
     NullValue any
     GenericValue GenericValue
 }
-
 
 type GenericValue struct {
     StringifiedType *string `json:"stringifiedType,omitempty" url:"stringifiedType,omitempty"`

--- a/seed/go-model/trace/playlist.go
+++ b/seed/go-model/trace/playlist.go
@@ -159,7 +159,6 @@ type PlaylistIdNotFoundErrorBody struct {
     PlaylistId PlaylistId
 }
 
-
 type ReservedKeywordEnum string
 
 const (

--- a/seed/go-model/trace/problem.go
+++ b/seed/go-model/trace/problem.go
@@ -156,7 +156,6 @@ type ProblemDescriptionBoard struct {
     TestCaseId string
 }
 
-
 type ProblemFiles struct {
     SolutionFile *FileInfo `json:"solutionFile" url:"solutionFile"`
     ReadOnlyFiles []*FileInfo `json:"readOnlyFiles" url:"readOnlyFiles"`
@@ -329,7 +328,6 @@ type CreateProblemResponse struct {
     Error *CreateProblemError
 }
 
-
 type UpdateProblemResponse struct {
     ProblemVersion int `json:"problemVersion" url:"problemVersion"`
 
@@ -368,7 +366,6 @@ type CreateProblemError struct {
     ErrorType string
     Generic GenericCreateProblemError
 }
-
 
 type GenericCreateProblemError struct {
     Message string `json:"message" url:"message"`

--- a/seed/go-model/trace/submission.go
+++ b/seed/go-model/trace/submission.go
@@ -25,7 +25,6 @@ type SubmissionRequest struct {
     Stop StopRequest
 }
 
-
 type InitializeProblemRequest struct {
     ProblemId ProblemId `json:"problemId" url:"problemId"`
     ProblemVersion *int `json:"problemVersion,omitempty" url:"problemVersion,omitempty"`
@@ -314,7 +313,6 @@ type SubmissionResponse struct {
     Terminated TerminatedResponse
 }
 
-
 type CodeExecutionUpdate struct {
     Type string
     BuildingExecutor BuildingExecutorResponse
@@ -329,7 +327,6 @@ type CodeExecutionUpdate struct {
     InvalidRequest InvalidRequestResponse
     Finished FinishedResponse
 }
-
 
 type BuildingExecutorResponse struct {
     SubmissionId SubmissionId `json:"submissionId" url:"submissionId"`
@@ -494,7 +491,6 @@ type ErrorInfo struct {
     RuntimeError RuntimeError
     InternalError InternalError
 }
-
 
 type CompileError struct {
     Message string `json:"message" url:"message"`
@@ -813,7 +809,6 @@ type TestCaseGrade struct {
     Hidden TestCaseHiddenGrade
     NonHidden TestCaseNonHiddenGrade
 }
-
 
 type TestCaseHiddenGrade struct {
     Passed bool `json:"passed" url:"passed"`
@@ -1164,13 +1159,11 @@ type ActualResult struct {
     ExceptionV2 *ExceptionV2
 }
 
-
 type ExceptionV2 struct {
     Type string
     Generic ExceptionInfo
     Timeout any
 }
-
 
 type ExceptionInfo struct {
     ExceptionType string `json:"exceptionType" url:"exceptionType"`
@@ -1270,7 +1263,6 @@ type InvalidRequestCause struct {
     CustomTestCasesUnsupported CustomTestCasesUnsupported
     UnexpectedLanguage UnexpectedLanguageError
 }
-
 
 type ExistingSubmissionExecuting struct {
     SubmissionId SubmissionId `json:"submissionId" url:"submissionId"`
@@ -2031,7 +2023,6 @@ type SubmissionStatusV2 struct {
     Workspace WorkspaceSubmissionStatusV2
 }
 
-
 type TestSubmissionStatusV2 struct {
     Updates []*TestSubmissionUpdate `json:"updates" url:"updates"`
     ProblemId ProblemId `json:"problemId" url:"problemId"`
@@ -2153,6 +2144,18 @@ func (t *TestSubmissionUpdate) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TestSubmissionUpdate) MarshalJSON() ([]byte, error){
+    type embed TestSubmissionUpdate
+    var marshaler = struct{
+        embed
+        UpdateTime *internal.DateTime `json:"updateTime"`
+    }{
+        embed: embed(*t),
+        UpdateTime: internal.NewDateTime(t.UpdateTime),
+    }
+    return json.Marshal(marshaler)
+}
+
 func (t *TestSubmissionUpdate) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2175,7 +2178,6 @@ type TestSubmissionUpdateInfo struct {
     RecordedTestCase RecordedTestCaseUpdate
     Finished any
 }
-
 
 type WorkspaceSubmissionUpdate struct {
     UpdateTime time.Time `json:"updateTime" url:"updateTime"`
@@ -2206,6 +2208,18 @@ func (w *WorkspaceSubmissionUpdate) GetExtraProperties() map[string]any{
     return w.extraProperties
 }
 
+func (w *WorkspaceSubmissionUpdate) MarshalJSON() ([]byte, error){
+    type embed WorkspaceSubmissionUpdate
+    var marshaler = struct{
+        embed
+        UpdateTime *internal.DateTime `json:"updateTime"`
+    }{
+        embed: embed(*w),
+        UpdateTime: internal.NewDateTime(w.UpdateTime),
+    }
+    return json.Marshal(marshaler)
+}
+
 func (w *WorkspaceSubmissionUpdate) String() string{
     if len(w.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -2229,7 +2243,6 @@ type WorkspaceSubmissionUpdateInfo struct {
     Errored *ErrorInfo
     Finished any
 }
-
 
 type GradedTestCaseUpdate struct {
     TestCaseId v2.TestCaseId `json:"testCaseId" url:"testCaseId"`
@@ -2355,7 +2368,6 @@ type SubmissionTypeState struct {
     Workspace WorkspaceSubmissionState
 }
 
-
 type WorkspaceSubmissionState struct {
     Status *WorkspaceSubmissionStatus `json:"status" url:"status"`
 
@@ -2398,7 +2410,6 @@ type WorkspaceSubmissionStatus struct {
     Ran WorkspaceRunDetails
     Traced WorkspaceRunDetails
 }
-
 
 type TestSubmissionState struct {
     ProblemId ProblemId `json:"problemId" url:"problemId"`
@@ -2466,14 +2477,12 @@ type TestSubmissionStatus struct {
     TestCaseIdToState map[string]*SubmissionStatusForTestCase
 }
 
-
 type SubmissionStatusForTestCase struct {
     Type string
     Graded TestCaseResultWithStdout
     GradedV2 *TestCaseGrade
     Traced TracedTestCase
 }
-
 
 type TracedTestCase struct {
     Result *TestCaseResultWithStdout `json:"result" url:"result"`
@@ -2917,6 +2926,18 @@ func (g *GetSubmissionStateResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return g.extraProperties
+}
+
+func (g *GetSubmissionStateResponse) MarshalJSON() ([]byte, error){
+    type embed GetSubmissionStateResponse
+    var marshaler = struct{
+        embed
+        TimeSubmitted *internal.DateTime `json:"timeSubmitted"`
+    }{
+        embed: embed(*g),
+        TimeSubmitted: internal.NewOptionalDateTime(g.TimeSubmitted),
+    }
+    return json.Marshal(marshaler)
 }
 
 func (g *GetSubmissionStateResponse) String() string{


### PR DESCRIPTION
This adds the custom `MarshalJSON` method implementation for all objects that need it. This includes objects that define any of the following:

1. Date
2. DateTime
3. Literals
4. Additional properties

With this, the `@fern-api/go-ast` library now supports generating anonymous `struct` types, which will also be used in the custom `UnmarshalJSON` method.