### PR TITLE
feat(go): Generate UnmarshalJSON methods in go-v2

### DIFF
--- a/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
+++ b/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
@@ -153,6 +153,14 @@ export abstract class AbstractGoGeneratorContext<
         });
     }
 
+    public newJsonRawMessage(arg: go.AstNode): go.FuncInvocation {
+        return go.invokeFunc({
+            func: go.typeReference({ name: "RawMessage", importPath: "encoding/json" }),
+            arguments_: [arg],
+            multiline: false
+        });
+    }
+
     public callFmtErrorf(format: string, args: go.AstNode[]): go.FuncInvocation {
         return go.invokeFunc({
             func: go.typeReference({ name: "Errorf", importPath: "fmt" }),
@@ -173,6 +181,22 @@ export abstract class AbstractGoGeneratorContext<
         return go.invokeFunc({
             func: go.typeReference({ name: "Marshal", importPath: "encoding/json" }),
             arguments_: [arg],
+            multiline: false
+        });
+    }
+
+    public callJsonUnmarshal({ data, value }: { data: go.AstNode; value: go.AstNode }): go.FuncInvocation {
+        return go.invokeFunc({
+            func: go.typeReference({ name: "Unmarshal", importPath: "encoding/json" }),
+            arguments_: [data, value],
+            multiline: false
+        });
+    }
+
+    public callExtractExtraProperties(args: go.AstNode[]): go.FuncInvocation {
+        return this.callInternalFunc({
+            name: "ExtractExtraProperties",
+            arguments_: args,
             multiline: false
         });
     }

--- a/generators/go-v2/model/src/object/ObjectGenerator.ts
+++ b/generators/go-v2/model/src/object/ObjectGenerator.ts
@@ -15,24 +15,30 @@ import { ModelGeneratorContext } from "../ModelGeneratorContext";
 import { AbstractModelGenerator } from "../AbstractModelGenerator";
 
 const EMBED_TYPE_NAME = "embed";
+const MARSHALER_TYPE_NAME = "marshaler";
+const UNMARSHALER_TYPE_NAME = "unmarshaler";
 const RAW_JSON_FIELD_NAME = "rawJSON";
 
 declare namespace ObjectGenerator {
-    interface Marshaler {
-        /* The field defined within the marshaler struct. */
+    interface Serde {
+        /* The field defined within the marshaler/unmarshaler struct. */
         field: go.Field;
         /* The mapper function used to map the field to the marshaler struct. */
-        mapper: go.AstNode;
+        marshal: go.AstNode;
+        /* The mapper function used to map the field from the unmarshaler struct. */
+        unmarshal: go.AstNode;
+        /* If this field represents a literal property. */
+        isLiteral?: boolean;
     }
 
-    interface FieldWithZeroValue {
-        field: go.Field;
+    interface Field {
+        node: go.Field;
         zeroValue: go.TypeInstantiation;
 
         // Some types require special [de]serialization logic, such
-        // as dates. These mappers are used in the MarshalJSON and
+        // as dates. This interface is used in the MarshalJSON and
         // UnmarshalJSON implementations.
-        marshaler?: Marshaler;
+        serde?: Serde;
     }
 }
 
@@ -53,43 +59,44 @@ export class ObjectGenerator extends AbstractModelGenerator {
             ...this.typeReference,
             docs: this.typeDeclaration.docs
         });
-        const fieldsWithZeroValue = this.getFieldsWithZeroValue();
-        struct_.addField(...fieldsWithZeroValue.map((field) => field.field));
-        struct_.addMethod(...this.getGetterMethods(fieldsWithZeroValue));
-        if (this.needsCustomMarshalJsonMethod(fieldsWithZeroValue)) {
-            struct_.addMethod(this.getMarshalJsonMethod(fieldsWithZeroValue));
+        const fields = this.getFields();
+        struct_.addField(...fields.map((field) => field.node));
+        struct_.addMethod(...this.getGetterMethods(fields));
+        struct_.addMethod(this.getUnmarshalJsonMethod(fields));
+        if (this.needsCustomMarshalJsonMethod(fields)) {
+            struct_.addMethod(this.getMarshalJsonMethod(fields));
         }
         struct_.addMethod(this.getStringMethod());
         return this.toFile(struct_);
     }
 
-    private getFieldsWithZeroValue(): ObjectGenerator.FieldWithZeroValue[] {
+    private getFields(): ObjectGenerator.Field[] {
         const properties = this.getAllObjectProperties();
         const fields = properties.map((property) => {
             return {
                 name: property.name,
-                field: this.context.goFieldMapper.convert({
+                node: this.context.goFieldMapper.convert({
                     name: property.name,
                     reference: property.valueType,
                     docs: property.docs
                 }),
                 zeroValue: this.context.goZeroValueMapper.convert({ reference: property.valueType }),
-                marshaler: this.getMarshaler({ name: property.name, typeReference: property.valueType })
+                serde: this.getSerde({ name: property.name, typeReference: property.valueType })
             };
         });
         return [...fields, this.getExtraPropertiesField(), this.getRawJsonField()];
     }
 
-    private getGetterMethods(fieldsWithZeroValue: ObjectGenerator.FieldWithZeroValue[]): go.Method[] {
-        return fieldsWithZeroValue
+    private getGetterMethods(fields: ObjectGenerator.Field[]): go.Method[] {
+        return fields
             .filter((fieldWithZeroValue) => !this.shouldExcludeGetterMethod(fieldWithZeroValue))
             .map((fieldWithZeroValue) => {
                 return go.method({
                     typeReference: this.typeReference,
-                    name: this.getGetterMethodName(fieldWithZeroValue.field),
+                    name: this.getGetterMethodName(fieldWithZeroValue.node),
                     receiver: this.receiver,
                     parameters: [],
-                    return_: [fieldWithZeroValue.field.type],
+                    return_: [fieldWithZeroValue.node.type],
                     body: go.codeblock((writer) => {
                         writer.writeLine(`if ${this.receiver} == nil {`);
                         writer.indent();
@@ -98,14 +105,14 @@ export class ObjectGenerator extends AbstractModelGenerator {
                         writer.newLine();
                         writer.dedent();
                         writer.writeLine("}");
-                        writer.writeLine(`return ${this.receiver}.${fieldWithZeroValue.field.name}`);
+                        writer.writeLine(`return ${this.receiver}.${fieldWithZeroValue.node.name}`);
                     }),
                     pointerReceiver: true
                 });
             });
     }
 
-    private getMarshalJsonMethod(fieldsWithZeroValue: ObjectGenerator.FieldWithZeroValue[]): go.Method {
+    private getMarshalJsonMethod(fields: ObjectGenerator.Field[]): go.Method {
         const marshalerType = go.struct({
             embeds: [
                 go.typeReference({
@@ -113,11 +120,11 @@ export class ObjectGenerator extends AbstractModelGenerator {
                 })
             ]
         });
-        for (const field of fieldsWithZeroValue) {
-            if (field.marshaler == null) {
+        for (const field of fields) {
+            if (field.serde == null) {
                 continue;
             }
-            marshalerType.addField(field.marshaler.field);
+            marshalerType.addField(field.serde.field);
         }
         const marshalerInstantiation = go.TypeInstantiation.struct({
             typeReference: marshalerType,
@@ -126,15 +133,15 @@ export class ObjectGenerator extends AbstractModelGenerator {
                     name: EMBED_TYPE_NAME,
                     value: go.TypeInstantiation.reference(go.identifier(`${EMBED_TYPE_NAME}(*${this.receiver})`))
                 },
-                ...fieldsWithZeroValue
+                ...fields
                     .map((field) => {
-                        const fieldMarshaler = field.marshaler;
-                        if (fieldMarshaler == null) {
+                        const serde = field.serde;
+                        if (serde == null) {
                             return undefined;
                         }
                         return {
-                            name: fieldMarshaler.field.name,
-                            value: go.TypeInstantiation.reference(fieldMarshaler.mapper)
+                            name: serde.field.name,
+                            value: go.TypeInstantiation.reference(serde.marshal)
                         };
                     })
                     .filter((field) => field != null)
@@ -157,19 +164,19 @@ export class ObjectGenerator extends AbstractModelGenerator {
                     })
                 );
                 writer.newLine();
-                writer.write("var marshaler = ");
+                writer.write(`var ${MARSHALER_TYPE_NAME} = `);
                 writer.writeNode(marshalerInstantiation);
                 writer.newLine();
                 writer.write("return ");
                 if (this.objectDeclaration.extraProperties) {
                     writer.writeNode(
                         this.context.callMarshalJsonWithExtraProperties([
-                            go.identifier("marshaler"),
+                            go.identifier(MARSHALER_TYPE_NAME),
                             this.getExtraPropertiesFieldReference()
                         ])
                     );
                 } else {
-                    writer.writeNode(this.context.callJsonMarshal(go.identifier("marshaler")));
+                    writer.writeNode(this.context.callJsonMarshal(go.identifier(MARSHALER_TYPE_NAME)));
                 }
                 writer.newLine();
             }),
@@ -177,16 +184,114 @@ export class ObjectGenerator extends AbstractModelGenerator {
         });
     }
 
-    private getUnmarshalJsonMethod(fieldsWithZeroValue: ObjectGenerator.FieldWithZeroValue[]): go.Method {
+    private getUnmarshalJsonMethod(fields: ObjectGenerator.Field[]): go.Method {
         return go.method({
             typeReference: this.typeReference,
             name: "UnmarshalJSON",
             parameters: [go.parameter({ name: "data", type: go.Type.bytes() })],
             return_: [go.Type.error()],
-            body: go.codeblock((writer) => {
-                writer.writeLine("return nil");
-            }),
+            body: this.getUnmarshalJsonMethodBody(fields),
             pointerReceiver: true
+        });
+    }
+
+    private getUnmarshalJsonMethodBody(fields: ObjectGenerator.Field[]): go.AstNode {
+        return this.needsCustomUnmarshalJsonMethodBody(fields)
+            ? this.getCustomUnmarshalJsonMethodBody(fields)
+            : this.getDefaultUnmarshalJsonMethodBody(fields);
+    }
+
+    private getCustomUnmarshalJsonMethodBody(fields: ObjectGenerator.Field[]): go.AstNode {
+        const typeName = go.Type.reference(
+            go.typeReference({
+                name: this.context.getClassName(this.typeDeclaration.name.name)
+            })
+        );
+        const unmarshalerType = go.struct({
+            embeds: [
+                go.typeReference({
+                    name: EMBED_TYPE_NAME
+                })
+            ]
+        });
+        for (const field of fields) {
+            if (field.serde == null) {
+                continue;
+            }
+            unmarshalerType.addField(field.serde.field);
+        }
+        const unmarshalerInstantiation = go.TypeInstantiation.struct({
+            typeReference: unmarshalerType,
+            fields: [
+                {
+                    name: EMBED_TYPE_NAME,
+                    value: go.TypeInstantiation.reference(go.identifier(`${EMBED_TYPE_NAME}(*${this.receiver})`))
+                }
+            ]
+        });
+        return go.codeblock((writer) => {
+            writer.writeNode(
+                go.typeDeclaration({
+                    name: EMBED_TYPE_NAME,
+                    type: typeName
+                })
+            );
+            writer.newLine();
+            writer.write("var unmarshaler = ");
+            writer.writeNode(unmarshalerInstantiation);
+            writer.newLine();
+            this.callJsonUnmarshalAndReturnValue({
+                writer,
+                data: go.identifier("data"),
+                value: go.identifier(`&${UNMARSHALER_TYPE_NAME}`)
+            });
+            writer.write(`*${this.receiver} = `);
+            writer.writeNode(typeName);
+            writer.writeLine(`(${UNMARSHALER_TYPE_NAME}.embed)`);
+            for (const field of fields) {
+                if (field.serde?.unmarshal == null) {
+                    continue;
+                }
+                writer.writeNode(field.serde.unmarshal);
+            }
+            this.callExtractExtraPropertiesAndReturnValue({
+                writer,
+                fields
+            });
+            this.setRawJsonField({ writer });
+            writer.writeLine("return nil");
+        });
+    }
+
+    private getDefaultUnmarshalJsonMethodBody(fields: ObjectGenerator.Field[]): go.AstNode {
+        const typeName = go.Type.reference(
+            go.typeReference({
+                name: this.context.getClassName(this.typeDeclaration.name.name)
+            })
+        );
+        return go.codeblock((writer) => {
+            writer.writeNode(
+                go.typeDeclaration({
+                    name: UNMARSHALER_TYPE_NAME,
+                    type: typeName
+                })
+            );
+            writer.newLine();
+            writer.writeLine(`var value ${UNMARSHALER_TYPE_NAME}`);
+            this.callJsonUnmarshalAndReturnValue({
+                writer,
+                data: go.identifier("data"),
+                value: go.identifier("&value")
+            });
+            writer.write(`*${this.receiver} = `);
+            writer.writeNode(typeName);
+            writer.writeLine("(value)");
+            this.callExtractExtraPropertiesAndReturnValue({
+                writer,
+                fields
+            });
+            this.setRawJsonField({ writer });
+            writer.writeLine("return nil");
         });
     }
 
@@ -228,10 +333,67 @@ export class ObjectGenerator extends AbstractModelGenerator {
         writer.writeLine("}");
     }
 
-    private getExtraPropertiesField(): ObjectGenerator.FieldWithZeroValue {
+    private callExtractExtraPropertiesAndReturnValue({
+        writer,
+        fields
+    }: {
+        writer: go.Writer;
+        fields: ObjectGenerator.Field[];
+    }): void {
+        writer.write("extraProperties, err := ");
+        writer.writeNode(
+            this.context.callExtractExtraProperties([
+                go.identifier("data"),
+                go.identifier(`*${this.receiver}`),
+                ...fields
+                    .filter((field) => field.serde?.isLiteral)
+                    .map((field) => go.TypeInstantiation.string(field.node.name))
+            ])
+        );
+        writer.newLine();
+        writer.writeLine("if err != nil {");
+        writer.indent();
+        writer.writeLine("return err");
+        writer.dedent();
+        writer.writeLine("}");
+        writer.writeNode(this.getExtraPropertiesFieldReference());
+        writer.writeLine(" = extraProperties");
+    }
+
+    private callJsonUnmarshalAndReturnValue({
+        writer,
+        data,
+        value
+    }: {
+        writer: go.Writer;
+        data: go.AstNode;
+        value: go.AstNode;
+    }): void {
+        writer.write("if err := ");
+        writer.writeNode(
+            this.context.callJsonUnmarshal({
+                data,
+                value
+            })
+        );
+        writer.writeLine("; err != nil {");
+        writer.indent();
+        writer.writeLine("return err");
+        writer.dedent();
+        writer.writeLine("}");
+    }
+
+    private setRawJsonField({ writer }: { writer: go.Writer }): void {
+        writer.writeNode(this.getRawJsonFieldReference());
+        writer.write(" = ");
+        writer.writeNode(this.context.newJsonRawMessage(go.identifier("data")));
+        writer.newLine();
+    }
+
+    private getExtraPropertiesField(): ObjectGenerator.Field {
         if (this.objectDeclaration.extraProperties) {
             return {
-                field: go.field({
+                node: go.field({
                     name: "ExtraProperties",
                     type: go.Type.map(go.Type.string(), go.Type.any()),
                     tags: [
@@ -249,7 +411,7 @@ export class ObjectGenerator extends AbstractModelGenerator {
             };
         }
         return {
-            field: go.field({
+            node: go.field({
                 name: "extraProperties",
                 type: go.Type.map(go.Type.string(), go.Type.any())
             }),
@@ -260,13 +422,17 @@ export class ObjectGenerator extends AbstractModelGenerator {
     private getExtraPropertiesFieldReference(): go.AstNode {
         return go.selector({
             on: go.identifier(this.receiver),
-            selector: go.identifier(this.getExtraPropertiesField().field.name)
+            selector: go.identifier(this.getExtraPropertiesFieldName())
         });
     }
 
-    private getRawJsonField(): ObjectGenerator.FieldWithZeroValue {
+    private getExtraPropertiesFieldName(): string {
+        return this.getExtraPropertiesField().node.name;
+    }
+
+    private getRawJsonField(): ObjectGenerator.Field {
         return {
-            field: go.field({
+            node: go.field({
                 name: RAW_JSON_FIELD_NAME,
                 type: go.Type.reference(this.context.getJsonRawMessageTypeReference())
             }),
@@ -281,27 +447,27 @@ export class ObjectGenerator extends AbstractModelGenerator {
         });
     }
 
-    private getMarshaler({
+    private getSerde({
         name,
         typeReference
     }: {
         name: NameAndWireValue;
         typeReference: TypeReference;
-    }): ObjectGenerator.Marshaler | undefined {
+    }): ObjectGenerator.Serde | undefined {
         const literal = this.context.maybeLiteral(typeReference);
         if (literal != null) {
-            return this.getLiteralMarshaler({ name, typeReference, literal });
+            return this.getLiteralSerde({ name, typeReference, literal });
         }
         if (this.context.isDate(typeReference)) {
-            return this.getDateMarshaler({ name, typeReference });
+            return this.getDateSerde({ name, typeReference });
         }
         if (this.context.isDateTime(typeReference)) {
-            return this.getDateTimeMarshaler({ name, typeReference });
+            return this.getDateTimeSerde({ name, typeReference });
         }
         return undefined;
     }
 
-    private getLiteralMarshaler({
+    private getLiteralSerde({
         name,
         typeReference,
         literal
@@ -309,7 +475,8 @@ export class ObjectGenerator extends AbstractModelGenerator {
         name: NameAndWireValue;
         typeReference: TypeReference;
         literal: Literal;
-    }): ObjectGenerator.Marshaler | undefined {
+    }): ObjectGenerator.Serde | undefined {
+        const unmarshalerFieldName = `${UNMARSHALER_TYPE_NAME}.${this.context.getFieldName(name.name)}`;
         return {
             field: go.field({
                 name: this.context.getFieldName(name.name),
@@ -321,17 +488,39 @@ export class ObjectGenerator extends AbstractModelGenerator {
                     }
                 ]
             }),
-            mapper: this.context.getLiteralValue(literal)
+            marshal: this.context.getLiteralValue(literal),
+            unmarshal: go.codeblock((writer) => {
+                writer.write(`if ${unmarshalerFieldName} != `);
+                writer.writeNode(this.context.getLiteralValue(literal));
+                writer.writeLine(` {`);
+                writer.indent();
+                writer.write("return ");
+                writer.writeNode(
+                    this.context.callFmtErrorf("unexpected value for literal on type %T; expected %v got %v", [
+                        go.identifier(this.receiver),
+                        this.context.getLiteralValue(literal),
+                        go.identifier(unmarshalerFieldName)
+                    ])
+                );
+                writer.newLine();
+                writer.dedent();
+                writer.writeLine("}");
+                writer.writeLine(
+                    `${this.receiver}.${this.context.getLiteralFieldName(name.name)} = ${unmarshalerFieldName}`
+                );
+            }),
+            isLiteral: true
         };
     }
 
-    private getDateMarshaler({
+    private getDateSerde({
         name,
         typeReference
     }: {
         name: NameAndWireValue;
         typeReference: TypeReference;
-    }): ObjectGenerator.Marshaler | undefined {
+    }): ObjectGenerator.Serde | undefined {
+        const unmarshalerFieldName = `${UNMARSHALER_TYPE_NAME}.${this.context.getFieldName(name.name)}`;
         const fieldReference = this.getFieldReference(name.name);
         const isOptional = this.context.isOptional(typeReference);
         return {
@@ -345,19 +534,23 @@ export class ObjectGenerator extends AbstractModelGenerator {
                     }
                 ]
             }),
-            mapper: isOptional
+            marshal: isOptional
                 ? this.context.callNewOptionalDate(fieldReference)
-                : this.context.callNewDate(fieldReference)
+                : this.context.callNewDate(fieldReference),
+            unmarshal: isOptional
+                ? this.callTimePtrMethod({ fieldReference, unmarshalerFieldName })
+                : this.callTimeMethod({ fieldReference, unmarshalerFieldName })
         };
     }
 
-    private getDateTimeMarshaler({
+    private getDateTimeSerde({
         name,
         typeReference
     }: {
         name: NameAndWireValue;
         typeReference: TypeReference;
-    }): ObjectGenerator.Marshaler | undefined {
+    }): ObjectGenerator.Serde | undefined {
+        const unmarshalerFieldName = `${UNMARSHALER_TYPE_NAME}.${this.context.getFieldName(name.name)}`;
         const fieldReference = this.getFieldReference(name.name);
         const isOptional = this.context.isOptional(typeReference);
         return {
@@ -371,10 +564,53 @@ export class ObjectGenerator extends AbstractModelGenerator {
                     }
                 ]
             }),
-            mapper: isOptional
+            marshal: isOptional
                 ? this.context.callNewOptionalDateTime(fieldReference)
-                : this.context.callNewDateTime(fieldReference)
+                : this.context.callNewDateTime(fieldReference),
+            unmarshal: isOptional
+                ? this.callTimePtrMethod({ fieldReference, unmarshalerFieldName })
+                : this.callTimeMethod({ fieldReference, unmarshalerFieldName })
         };
+    }
+
+    private callTimeMethod({
+        fieldReference,
+        unmarshalerFieldName
+    }: {
+        fieldReference: go.AstNode;
+        unmarshalerFieldName: string;
+    }): go.AstNode {
+        return go.codeblock((writer) => {
+            writer.writeNode(fieldReference);
+            writer.write(" = ");
+            writer.writeNode(
+                go.selector({
+                    on: go.identifier(unmarshalerFieldName),
+                    selector: go.identifier("Time()")
+                })
+            );
+            writer.newLine();
+        });
+    }
+
+    private callTimePtrMethod({
+        fieldReference,
+        unmarshalerFieldName
+    }: {
+        fieldReference: go.AstNode;
+        unmarshalerFieldName: string;
+    }): go.AstNode {
+        return go.codeblock((writer) => {
+            writer.writeNode(fieldReference);
+            writer.write(" = ");
+            writer.writeNode(
+                go.selector({
+                    on: go.identifier(unmarshalerFieldName),
+                    selector: go.identifier("TimePtr()")
+                })
+            );
+            writer.newLine();
+        });
     }
 
     private getGetterMethodName(field: go.Field): string {
@@ -388,16 +624,16 @@ export class ObjectGenerator extends AbstractModelGenerator {
         });
     }
 
-    private shouldExcludeGetterMethod(fieldWithZeroValue: ObjectGenerator.FieldWithZeroValue): boolean {
-        return fieldWithZeroValue.field.name === RAW_JSON_FIELD_NAME;
+    private shouldExcludeGetterMethod(field: ObjectGenerator.Field): boolean {
+        return field.node.name === RAW_JSON_FIELD_NAME;
     }
 
-    private needsCustomMarshalJsonMethod(fields: ObjectGenerator.FieldWithZeroValue[]): boolean {
-        return this.objectDeclaration.extraProperties || fields.some((field) => field.marshaler != null);
+    private needsCustomMarshalJsonMethod(fields: ObjectGenerator.Field[]): boolean {
+        return this.objectDeclaration.extraProperties || fields.some((field) => field.serde?.marshal != null);
     }
 
-    private needsCustomUnmarshalJsonMethod(fields: ObjectGenerator.FieldWithZeroValue[]): boolean {
-        return fields.some((field) => field.marshaler != null);
+    private needsCustomUnmarshalJsonMethodBody(fields: ObjectGenerator.Field[]): boolean {
+        return this.objectDeclaration.extraProperties || fields.some((field) => field.serde?.unmarshal != null);
     }
 
     private getAllObjectProperties(): ObjectProperty[] {

--- a/seed/go-model/alias-extends/types.go
+++ b/seed/go-model/alias-extends/types.go
@@ -31,6 +31,24 @@ func (p *Parent) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Parent) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Parent
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = Parent(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *Parent) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -70,6 +88,24 @@ func (c *Child) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *Child) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Child
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = Child(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *Child) String() string {

--- a/seed/go-model/alias/types.go
+++ b/seed/go-model/alias/types.go
@@ -41,6 +41,24 @@ func (t *Type) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *Type) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Type
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = Type(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *Type) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/any-auth/auth.go
+++ b/seed/go-model/any-auth/auth.go
@@ -46,6 +46,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/any-auth/user.go
+++ b/seed/go-model/any-auth/user.go
@@ -37,6 +37,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/audiences/foldera/service.go
+++ b/seed/go-model/audiences/foldera/service.go
@@ -30,6 +30,24 @@ func (r *Response) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *Response) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Response
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Response(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {

--- a/seed/go-model/audiences/folderb/common.go
+++ b/seed/go-model/audiences/folderb/common.go
@@ -30,6 +30,24 @@ func (f *Foo) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *Foo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Foo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Foo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *Foo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {

--- a/seed/go-model/audiences/folderc/common.go
+++ b/seed/go-model/audiences/folderc/common.go
@@ -30,6 +30,24 @@ func (f *FolderCFoo) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *FolderCFoo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FolderCFoo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FolderCFoo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *FolderCFoo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {

--- a/seed/go-model/audiences/folderd/service.go
+++ b/seed/go-model/audiences/folderd/service.go
@@ -29,6 +29,24 @@ func (r *Response) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *Response) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Response
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Response(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {

--- a/seed/go-model/audiences/foo.go
+++ b/seed/go-model/audiences/foo.go
@@ -29,6 +29,24 @@ func (i *ImportingType) GetExtraProperties() map[string]any {
 	return i.extraProperties
 }
 
+func (i *ImportingType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ImportingType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*i = ImportingType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *i)
+	if err != nil {
+		return err
+	}
+	i.extraProperties = extraProperties
+	i.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (i *ImportingType) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -70,6 +88,24 @@ func (f *FilteredType) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FilteredType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FilteredType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FilteredType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FilteredType) String() string {

--- a/seed/go-model/basic-auth-environment-variables/errors.go
+++ b/seed/go-model/basic-auth-environment-variables/errors.go
@@ -29,6 +29,24 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UnauthorizedRequestErrorBody
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UnauthorizedRequestErrorBody(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UnauthorizedRequestErrorBody) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/basic-auth/errors.go
+++ b/seed/go-model/basic-auth/errors.go
@@ -29,6 +29,24 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UnauthorizedRequestErrorBody
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UnauthorizedRequestErrorBody(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UnauthorizedRequestErrorBody) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/circular-references-advanced/a.go
+++ b/seed/go-model/circular-references-advanced/a.go
@@ -29,6 +29,24 @@ func (a *A) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *A) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler A
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = A(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (a *A) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {

--- a/seed/go-model/circular-references-advanced/ast.go
+++ b/seed/go-model/circular-references-advanced/ast.go
@@ -44,6 +44,24 @@ func (c *Cat) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *Cat) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Cat
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = Cat(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *Cat) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -75,6 +93,24 @@ func (d *Dog) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *Dog) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Dog
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = Dog(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *Dog) String() string {
@@ -110,6 +146,24 @@ func (a *Acai) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Acai) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Acai
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = Acai(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (a *Acai) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -141,6 +195,24 @@ func (f *Fig) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *Fig) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Fig
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Fig(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *Fig) String() string {
@@ -176,6 +248,24 @@ func (b *Berry) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *Berry) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Berry
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = Berry(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *Berry) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -209,6 +299,24 @@ func (b *BranchNode) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BranchNode) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BranchNode
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BranchNode(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BranchNode) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -231,6 +339,24 @@ func (l *LeafNode) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return l.extraProperties
+}
+
+func (l *LeafNode) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler LeafNode
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = LeafNode(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (l *LeafNode) String() string {
@@ -264,6 +390,24 @@ func (n *NodesWrapper) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NodesWrapper) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NodesWrapper
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NodesWrapper(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NodesWrapper) String() string {
@@ -318,6 +462,24 @@ func (o *ObjectValue) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *ObjectValue) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ObjectValue
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = ObjectValue(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *ObjectValue) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -367,6 +529,24 @@ func (o *ObjectFieldValue) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return o.extraProperties
+}
+
+func (o *ObjectFieldValue) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ObjectFieldValue
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = ObjectFieldValue(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (o *ObjectFieldValue) String() string {

--- a/seed/go-model/circular-references-advanced/types.go
+++ b/seed/go-model/circular-references-advanced/types.go
@@ -29,6 +29,24 @@ func (i *ImportingA) GetExtraProperties() map[string]any {
 	return i.extraProperties
 }
 
+func (i *ImportingA) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ImportingA
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*i = ImportingA(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *i)
+	if err != nil {
+		return err
+	}
+	i.extraProperties = extraProperties
+	i.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (i *ImportingA) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -60,6 +78,24 @@ func (r *RootType) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *RootType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler RootType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = RootType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *RootType) String() string {

--- a/seed/go-model/circular-references/a.go
+++ b/seed/go-model/circular-references/a.go
@@ -29,6 +29,24 @@ func (a *A) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *A) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler A
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = A(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (a *A) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {

--- a/seed/go-model/circular-references/ast.go
+++ b/seed/go-model/circular-references/ast.go
@@ -34,6 +34,24 @@ func (t *T) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *T) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler T
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = T(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *T) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -65,6 +83,24 @@ func (u *U) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *U) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler U
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = U(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *U) String() string {
@@ -124,6 +160,24 @@ func (o *ObjectValue) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return o.extraProperties
+}
+
+func (o *ObjectValue) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ObjectValue
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = ObjectValue(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (o *ObjectValue) String() string {

--- a/seed/go-model/circular-references/types.go
+++ b/seed/go-model/circular-references/types.go
@@ -29,6 +29,24 @@ func (i *ImportingA) GetExtraProperties() map[string]any {
 	return i.extraProperties
 }
 
+func (i *ImportingA) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ImportingA
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*i = ImportingA(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *i)
+	if err != nil {
+		return err
+	}
+	i.extraProperties = extraProperties
+	i.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (i *ImportingA) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -60,6 +78,24 @@ func (r *RootType) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *RootType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler RootType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = RootType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *RootType) String() string {

--- a/seed/go-model/cross-package-type-names/foldera/service.go
+++ b/seed/go-model/cross-package-type-names/foldera/service.go
@@ -30,6 +30,24 @@ func (r *Response) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *Response) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Response
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Response(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {

--- a/seed/go-model/cross-package-type-names/folderb/common.go
+++ b/seed/go-model/cross-package-type-names/folderb/common.go
@@ -30,6 +30,24 @@ func (f *Foo) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *Foo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Foo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Foo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *Foo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {

--- a/seed/go-model/cross-package-type-names/folderc/common.go
+++ b/seed/go-model/cross-package-type-names/folderc/common.go
@@ -30,6 +30,24 @@ func (f *Foo) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *Foo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Foo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Foo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *Foo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {

--- a/seed/go-model/cross-package-type-names/folderd/service.go
+++ b/seed/go-model/cross-package-type-names/folderd/service.go
@@ -30,6 +30,24 @@ func (r *Response) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *Response) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Response
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Response(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {

--- a/seed/go-model/cross-package-type-names/foo.go
+++ b/seed/go-model/cross-package-type-names/foo.go
@@ -29,6 +29,24 @@ func (i *ImportingType) GetExtraProperties() map[string]any {
 	return i.extraProperties
 }
 
+func (i *ImportingType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ImportingType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*i = ImportingType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *i)
+	if err != nil {
+		return err
+	}
+	i.extraProperties = extraProperties
+	i.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (i *ImportingType) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {

--- a/seed/go-model/custom-auth/errors.go
+++ b/seed/go-model/custom-auth/errors.go
@@ -29,6 +29,24 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UnauthorizedRequestErrorBody
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UnauthorizedRequestErrorBody(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UnauthorizedRequestErrorBody) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/error-property/errors.go
+++ b/seed/go-model/error-property/errors.go
@@ -29,6 +29,24 @@ func (p *PropertyBasedErrorTestBody) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *PropertyBasedErrorTestBody) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler PropertyBasedErrorTestBody
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = PropertyBasedErrorTestBody(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *PropertyBasedErrorTestBody) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {

--- a/seed/go-model/examples/commons/types.go
+++ b/seed/go-model/examples/commons/types.go
@@ -47,6 +47,24 @@ func (m *Metadata) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Metadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Metadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Metadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Metadata) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {

--- a/seed/go-model/examples/types.go
+++ b/seed/go-model/examples/types.go
@@ -53,6 +53,24 @@ func (i *Identifier) GetExtraProperties() map[string]any {
 	return i.extraProperties
 }
 
+func (i *Identifier) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Identifier
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*i = Identifier(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *i)
+	if err != nil {
+		return err
+	}
+	i.extraProperties = extraProperties
+	i.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (i *Identifier) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -208,6 +226,33 @@ func (m *Movie) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Movie) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed Movie
+	var unmarshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*m),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*m = Movie(unmarshaler.embed)
+	if unmarshaler.Type != "movie" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", m, "movie", unmarshaler.Type)
+	}
+	m.type_ = unmarshaler.Type
+	extraProperties, err := internal.ExtractExtraProperties(data, *m, "type_")
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Movie) MarshalJSON() ([]byte, error) {
 	type embed Movie
 	var marshaler = struct {
@@ -267,6 +312,24 @@ func (a *Actor) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Actor) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Actor
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = Actor(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -308,6 +371,24 @@ func (a *Actress) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Actress) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Actress
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = Actress(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -347,6 +428,24 @@ func (s *StuntDouble) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *StuntDouble) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StuntDouble
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StuntDouble(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *StuntDouble) String() string {
@@ -463,6 +562,33 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]any {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed ExtendedMovie
+	var unmarshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*e),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*e = ExtendedMovie(unmarshaler.embed)
+	if unmarshaler.Type != "movie" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", e, "movie", unmarshaler.Type)
+	}
+	e.type_ = unmarshaler.Type
+	extraProperties, err := internal.ExtractExtraProperties(data, *e, "type_")
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 	type embed ExtendedMovie
 	var marshaler = struct {
@@ -524,6 +650,32 @@ func (m *Moment) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Moment) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed Moment
+	var unmarshaler = struct {
+		embed
+		Date     *internal.Date     `json:"date"`
+		Datetime *internal.DateTime `json:"datetime"`
+	}{
+		embed: embed(*m),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*m = Moment(unmarshaler.embed)
+	m.Date = unmarshaler.Date.Time()
+	m.Datetime = unmarshaler.Datetime.Time()
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Moment) MarshalJSON() ([]byte, error) {
 	type embed Moment
 	var marshaler = struct {
@@ -579,6 +731,24 @@ func (f *File) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *File) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler File
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = File(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *File) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -626,6 +796,24 @@ func (d *Directory) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *Directory) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Directory
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = Directory(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *Directory) String() string {
@@ -677,6 +865,24 @@ func (n *Node) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *Node) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Node
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = Node(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -708,6 +914,24 @@ func (t *Tree) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *Tree) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Tree
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = Tree(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *Tree) String() string {
@@ -771,6 +995,24 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return e.extraProperties
+}
+
+func (e *ExceptionInfo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ExceptionInfo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = ExceptionInfo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *e)
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (e *ExceptionInfo) String() string {
@@ -841,6 +1083,24 @@ func (m *Migration) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Migration) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Migration
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Migration(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Migration) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -872,6 +1132,24 @@ func (r *Request) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *Request) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Request
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Request(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *Request) String() string {
@@ -915,6 +1193,24 @@ func (r *Response) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *Response) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Response
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Response(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -946,6 +1242,24 @@ func (r *ResponseType) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *ResponseType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ResponseType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = ResponseType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *ResponseType) String() string {
@@ -993,6 +1307,24 @@ func (e *Entity) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return e.extraProperties
+}
+
+func (e *Entity) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Entity
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = Entity(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *e)
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (e *Entity) String() string {
@@ -1124,6 +1456,24 @@ func (b *BigEntity) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BigEntity) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BigEntity
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BigEntity(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BigEntity) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -1155,6 +1505,24 @@ func (c *CronJob) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *CronJob) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CronJob
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CronJob(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *CronJob) String() string {

--- a/seed/go-model/exhaustive/endpoints/put.go
+++ b/seed/go-model/exhaustive/endpoints/put.go
@@ -53,6 +53,24 @@ func (e *Error) GetExtraProperties() map[string]any {
 	return e.extraProperties
 }
 
+func (e *Error) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Error
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = Error(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *e)
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (e *Error) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -158,6 +176,24 @@ func (p *PutResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return p.extraProperties
+}
+
+func (p *PutResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler PutResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = PutResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (p *PutResponse) String() string {

--- a/seed/go-model/exhaustive/general_errors.go
+++ b/seed/go-model/exhaustive/general_errors.go
@@ -29,6 +29,24 @@ func (b *BadObjectRequestInfo) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BadObjectRequestInfo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BadObjectRequestInfo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BadObjectRequestInfo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BadObjectRequestInfo) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {

--- a/seed/go-model/exhaustive/types/docs.go
+++ b/seed/go-model/exhaustive/types/docs.go
@@ -84,6 +84,24 @@ func (o *ObjectWithDocs) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *ObjectWithDocs) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ObjectWithDocs
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = ObjectWithDocs(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *ObjectWithDocs) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {

--- a/seed/go-model/exhaustive/types/object.go
+++ b/seed/go-model/exhaustive/types/object.go
@@ -128,6 +128,32 @@ func (o *ObjectWithOptionalField) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *ObjectWithOptionalField) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed ObjectWithOptionalField
+	var unmarshaler = struct {
+		embed
+		Datetime *internal.DateTime `json:"datetime"`
+		Date     *internal.Date     `json:"date"`
+	}{
+		embed: embed(*o),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*o = ObjectWithOptionalField(unmarshaler.embed)
+	o.Datetime = unmarshaler.Datetime.TimePtr()
+	o.Date = unmarshaler.Date.TimePtr()
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *ObjectWithOptionalField) MarshalJSON() ([]byte, error) {
 	type embed ObjectWithOptionalField
 	var marshaler = struct {
@@ -175,6 +201,24 @@ func (o *ObjectWithRequiredField) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *ObjectWithRequiredField) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ObjectWithRequiredField
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = ObjectWithRequiredField(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *ObjectWithRequiredField) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -206,6 +250,24 @@ func (o *ObjectWithMapOfMap) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return o.extraProperties
+}
+
+func (o *ObjectWithMapOfMap) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ObjectWithMapOfMap
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = ObjectWithMapOfMap(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (o *ObjectWithMapOfMap) String() string {
@@ -249,6 +311,24 @@ func (n *NestedObjectWithOptionalField) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NestedObjectWithOptionalField) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedObjectWithOptionalField
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedObjectWithOptionalField(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NestedObjectWithOptionalField) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -290,6 +370,24 @@ func (n *NestedObjectWithRequiredField) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NestedObjectWithRequiredField) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedObjectWithRequiredField
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedObjectWithRequiredField(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NestedObjectWithRequiredField) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -321,6 +419,24 @@ func (d *DoubleOptional) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DoubleOptional) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DoubleOptional
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DoubleOptional(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DoubleOptional) String() string {

--- a/seed/go-model/exhaustive/types/union.go
+++ b/seed/go-model/exhaustive/types/union.go
@@ -43,6 +43,24 @@ func (d *Dog) GetExtraProperties() map[string]any {
 	return d.extraProperties
 }
 
+func (d *Dog) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Dog
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = Dog(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (d *Dog) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -82,6 +100,24 @@ func (c *Cat) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *Cat) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Cat
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = Cat(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *Cat) String() string {

--- a/seed/go-model/extends/types.go
+++ b/seed/go-model/extends/types.go
@@ -37,6 +37,24 @@ func (e *ExampleType) GetExtraProperties() map[string]any {
 	return e.extraProperties
 }
 
+func (e *ExampleType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ExampleType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = ExampleType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *e)
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (e *ExampleType) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -86,6 +104,24 @@ func (n *NestedType) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NestedType) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedType
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedType(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NestedType) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -117,6 +153,24 @@ func (d *Docs) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *Docs) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Docs
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = Docs(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *Docs) String() string {
@@ -158,6 +212,24 @@ func (j *Json) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return j.extraProperties
+}
+
+func (j *Json) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Json
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*j = Json(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *j)
+	if err != nil {
+		return err
+	}
+	j.extraProperties = extraProperties
+	j.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (j *Json) String() string {

--- a/seed/go-model/extra-properties/user.go
+++ b/seed/go-model/extra-properties/user.go
@@ -29,6 +29,28 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.ExtraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed User
+	var unmarshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*u = User(unmarshaler.embed)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.ExtraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) MarshalJSON() ([]byte, error) {
 	type embed User
 	var marshaler = struct {

--- a/seed/go-model/file-upload/service.go
+++ b/seed/go-model/file-upload/service.go
@@ -39,6 +39,24 @@ func (m *MyObjectWithOptional) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *MyObjectWithOptional) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler MyObjectWithOptional
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = MyObjectWithOptional(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *MyObjectWithOptional) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -74,6 +92,24 @@ func (m *MyObject) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return m.extraProperties
+}
+
+func (m *MyObject) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler MyObject
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = MyObject(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (m *MyObject) String() string {

--- a/seed/go-model/go-content-type/imdb.go
+++ b/seed/go-model/go-content-type/imdb.go
@@ -37,6 +37,24 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CreateMovieRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CreateMovieRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *CreateMovieRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {

--- a/seed/go-model/http-head/user.go
+++ b/seed/go-model/http-head/user.go
@@ -37,6 +37,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/imdb/imdb.go
+++ b/seed/go-model/imdb/imdb.go
@@ -48,6 +48,24 @@ func (m *Movie) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Movie) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Movie
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Movie(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Movie) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -87,6 +105,24 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *CreateMovieRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CreateMovieRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CreateMovieRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *CreateMovieRequest) String() string {

--- a/seed/go-model/license/types.go
+++ b/seed/go-model/license/types.go
@@ -30,6 +30,24 @@ func (t *Type) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *Type) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Type
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = Type(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *Type) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/literal/types.go
+++ b/seed/go-model/literal/types.go
@@ -45,6 +45,33 @@ func (s *SendResponse) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SendResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed SendResponse
+	var unmarshaler = struct {
+		embed
+		Success bool `json:"success"`
+	}{
+		embed: embed(*s),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*s = SendResponse(unmarshaler.embed)
+	if unmarshaler.Success != true {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", s, true, unmarshaler.Success)
+	}
+	s.success = unmarshaler.Success
+	extraProperties, err := internal.ExtractExtraProperties(data, *s, "success")
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *SendResponse) MarshalJSON() ([]byte, error) {
 	type embed SendResponse
 	var marshaler = struct {

--- a/seed/go-model/mixed-case/service.go
+++ b/seed/go-model/mixed-case/service.go
@@ -29,6 +29,24 @@ func (o *Organization) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *Organization) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Organization
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = Organization(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *Organization) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -78,6 +96,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -117,6 +153,24 @@ func (n *NestedUser) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NestedUser) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedUser
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedUser(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NestedUser) String() string {

--- a/seed/go-model/mixed-file-directory/organization.go
+++ b/seed/go-model/mixed-file-directory/organization.go
@@ -45,6 +45,24 @@ func (o *Organization) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *Organization) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Organization
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = Organization(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *Organization) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -76,6 +94,24 @@ func (c *CreateOrganizationRequest) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *CreateOrganizationRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CreateOrganizationRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CreateOrganizationRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *CreateOrganizationRequest) String() string {

--- a/seed/go-model/mixed-file-directory/user.go
+++ b/seed/go-model/mixed-file-directory/user.go
@@ -45,6 +45,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/mixed-file-directory/user/events.go
+++ b/seed/go-model/mixed-file-directory/user/events.go
@@ -38,6 +38,24 @@ func (e *Event) GetExtraProperties() map[string]any {
 	return e.extraProperties
 }
 
+func (e *Event) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Event
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = Event(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *e)
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (e *Event) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {

--- a/seed/go-model/mixed-file-directory/user/events/metadata.go
+++ b/seed/go-model/mixed-file-directory/user/events/metadata.go
@@ -38,6 +38,24 @@ func (m *Metadata) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Metadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Metadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Metadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Metadata) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {

--- a/seed/go-model/multi-line-docs/user.go
+++ b/seed/go-model/multi-line-docs/user.go
@@ -53,6 +53,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/oauth-client-credentials-custom/auth.go
+++ b/seed/go-model/oauth-client-credentials-custom/auth.go
@@ -46,6 +46,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/oauth-client-credentials-default/auth.go
+++ b/seed/go-model/oauth-client-credentials-default/auth.go
@@ -38,6 +38,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/oauth-client-credentials-environment-variables/auth.go
+++ b/seed/go-model/oauth-client-credentials-environment-variables/auth.go
@@ -46,6 +46,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/oauth-client-credentials-nested-root/auth/types.go
+++ b/seed/go-model/oauth-client-credentials-nested-root/auth/types.go
@@ -46,6 +46,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/oauth-client-credentials-with-variables/auth.go
+++ b/seed/go-model/oauth-client-credentials-with-variables/auth.go
@@ -46,6 +46,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/oauth-client-credentials/auth.go
+++ b/seed/go-model/oauth-client-credentials/auth.go
@@ -46,6 +46,24 @@ func (t *TokenResponse) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TokenResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TokenResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TokenResponse) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/objects-with-imports/commons/metadata.go
+++ b/seed/go-model/objects-with-imports/commons/metadata.go
@@ -37,6 +37,24 @@ func (m *Metadata) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Metadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Metadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Metadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Metadata) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {

--- a/seed/go-model/objects-with-imports/file.go
+++ b/seed/go-model/objects-with-imports/file.go
@@ -45,6 +45,24 @@ func (f *File) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *File) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler File
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = File(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *File) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {

--- a/seed/go-model/objects-with-imports/file/directory.go
+++ b/seed/go-model/objects-with-imports/file/directory.go
@@ -46,6 +46,24 @@ func (d *Directory) GetExtraProperties() map[string]any {
 	return d.extraProperties
 }
 
+func (d *Directory) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Directory
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = Directory(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {

--- a/seed/go-model/objects-with-imports/types.go
+++ b/seed/go-model/objects-with-imports/types.go
@@ -46,6 +46,24 @@ func (n *Node) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *Node) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Node
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = Node(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -77,6 +95,24 @@ func (t *Tree) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *Tree) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Tree
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = Tree(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *Tree) String() string {

--- a/seed/go-model/package-yml/types.go
+++ b/seed/go-model/package-yml/types.go
@@ -37,6 +37,24 @@ func (e *EchoRequest) GetExtraProperties() map[string]any {
 	return e.extraProperties
 }
 
+func (e *EchoRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler EchoRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = EchoRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *e)
+	if err != nil {
+		return err
+	}
+	e.extraProperties = extraProperties
+	e.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (e *EchoRequest) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {

--- a/seed/go-model/pagination-custom/types.go
+++ b/seed/go-model/pagination-custom/types.go
@@ -29,6 +29,24 @@ func (u *UsernameCursor) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UsernameCursor) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UsernameCursor
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UsernameCursor(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UsernameCursor) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -68,6 +86,24 @@ func (u *UsernamePage) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *UsernamePage) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UsernamePage
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UsernamePage(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *UsernamePage) String() string {

--- a/seed/go-model/pagination/complex.go
+++ b/seed/go-model/pagination/complex.go
@@ -42,6 +42,24 @@ func (m *MultipleFilterSearchRequest) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *MultipleFilterSearchRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler MultipleFilterSearchRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = MultipleFilterSearchRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *MultipleFilterSearchRequest) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -116,6 +134,24 @@ func (s *SingleFilterSearchRequest) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *SingleFilterSearchRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SingleFilterSearchRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SingleFilterSearchRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *SingleFilterSearchRequest) String() string {
@@ -205,6 +241,24 @@ func (s *SearchRequest) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SearchRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SearchRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SearchRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *SearchRequest) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -260,6 +314,33 @@ func (p *PaginatedConversationResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return p.extraProperties
+}
+
+func (p *PaginatedConversationResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed PaginatedConversationResponse
+	var unmarshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*p),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*p = PaginatedConversationResponse(unmarshaler.embed)
+	if unmarshaler.Type != "conversation.list" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", p, "conversation.list", unmarshaler.Type)
+	}
+	p.type_ = unmarshaler.Type
+	extraProperties, err := internal.ExtractExtraProperties(data, *p, "type_")
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (p *PaginatedConversationResponse) MarshalJSON() ([]byte, error) {
@@ -339,6 +420,33 @@ func (c *CursorPages) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *CursorPages) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed CursorPages
+	var unmarshaler = struct {
+		embed
+		Type string `json:"type"`
+	}{
+		embed: embed(*c),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*c = CursorPages(unmarshaler.embed)
+	if unmarshaler.Type != "pages" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", c, "pages", unmarshaler.Type)
+	}
+	c.type_ = unmarshaler.Type
+	extraProperties, err := internal.ExtractExtraProperties(data, *c, "type_")
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *CursorPages) MarshalJSON() ([]byte, error) {
 	type embed CursorPages
 	var marshaler = struct {
@@ -392,6 +500,24 @@ func (s *StartingAfterPaging) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *StartingAfterPaging) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StartingAfterPaging
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StartingAfterPaging(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *StartingAfterPaging) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -423,6 +549,24 @@ func (c *Conversation) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *Conversation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Conversation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = Conversation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *Conversation) String() string {

--- a/seed/go-model/pagination/types.go
+++ b/seed/go-model/pagination/types.go
@@ -29,6 +29,24 @@ func (u *UsernameCursor) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UsernameCursor) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UsernameCursor
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UsernameCursor(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UsernameCursor) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -68,6 +86,24 @@ func (u *UsernamePage) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *UsernamePage) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UsernamePage
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UsernamePage(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *UsernamePage) String() string {

--- a/seed/go-model/pagination/users.go
+++ b/seed/go-model/pagination/users.go
@@ -52,6 +52,24 @@ func (w *WithPage) GetExtraProperties() map[string]any {
 	return w.extraProperties
 }
 
+func (w *WithPage) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler WithPage
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*w = WithPage(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *w)
+	if err != nil {
+		return err
+	}
+	w.extraProperties = extraProperties
+	w.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (w *WithPage) String() string {
 	if len(w.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -85,6 +103,24 @@ func (w *WithCursor) GetExtraProperties() map[string]any {
 	return w.extraProperties
 }
 
+func (w *WithCursor) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler WithCursor
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*w = WithCursor(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *w)
+	if err != nil {
+		return err
+	}
+	w.extraProperties = extraProperties
+	w.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (w *WithCursor) String() string {
 	if len(w.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -116,6 +152,24 @@ func (u *UserListContainer) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *UserListContainer) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UserListContainer
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UserListContainer(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *UserListContainer) String() string {
@@ -159,6 +213,24 @@ func (u *UserPage) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UserPage) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UserPage
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UserPage(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UserPage) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -190,6 +262,24 @@ func (u *UserOptionalListContainer) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *UserOptionalListContainer) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UserOptionalListContainer
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UserOptionalListContainer(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *UserOptionalListContainer) String() string {
@@ -233,6 +323,24 @@ func (u *UserOptionalListPage) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UserOptionalListPage) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UserOptionalListPage
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UserOptionalListPage(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UserOptionalListPage) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -264,6 +372,24 @@ func (u *UsernameContainer) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *UsernameContainer) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UsernameContainer
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UsernameContainer(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *UsernameContainer) String() string {
@@ -316,6 +442,24 @@ func (l *ListUsersExtendedResponse) GetExtraProperties() map[string]any {
 	return l.extraProperties
 }
 
+func (l *ListUsersExtendedResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ListUsersExtendedResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = ListUsersExtendedResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (l *ListUsersExtendedResponse) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -364,6 +508,24 @@ func (l *ListUsersExtendedOptionalListResponse) GetExtraProperties() map[string]
 		return nil
 	}
 	return l.extraProperties
+}
+
+func (l *ListUsersExtendedOptionalListResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ListUsersExtendedOptionalListResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = ListUsersExtendedOptionalListResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (l *ListUsersExtendedOptionalListResponse) String() string {
@@ -424,6 +586,24 @@ func (l *ListUsersPaginationResponse) GetExtraProperties() map[string]any {
 	return l.extraProperties
 }
 
+func (l *ListUsersPaginationResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ListUsersPaginationResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = ListUsersPaginationResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (l *ListUsersPaginationResponse) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -463,6 +643,24 @@ func (l *ListUsersMixedTypePaginationResponse) GetExtraProperties() map[string]a
 		return nil
 	}
 	return l.extraProperties
+}
+
+func (l *ListUsersMixedTypePaginationResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ListUsersMixedTypePaginationResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = ListUsersMixedTypePaginationResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (l *ListUsersMixedTypePaginationResponse) String() string {
@@ -523,6 +721,24 @@ func (p *Page) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Page) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Page
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = Page(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *Page) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -564,6 +780,24 @@ func (n *NextPage) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NextPage) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NextPage
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NextPage(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NextPage) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -603,6 +837,24 @@ func (u *User) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *User) String() string {

--- a/seed/go-model/path-parameters/organizations.go
+++ b/seed/go-model/path-parameters/organizations.go
@@ -37,6 +37,24 @@ func (o *Organization) GetExtraProperties() map[string]any {
 	return o.extraProperties
 }
 
+func (o *Organization) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Organization
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = Organization(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *o)
+	if err != nil {
+		return err
+	}
+	o.extraProperties = extraProperties
+	o.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (o *Organization) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {

--- a/seed/go-model/path-parameters/user.go
+++ b/seed/go-model/path-parameters/user.go
@@ -37,6 +37,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/query-parameters-openapi-as-objects/types.go
+++ b/seed/go-model/query-parameters-openapi-as-objects/types.go
@@ -43,6 +43,24 @@ func (s *SearchResponse) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SearchResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SearchResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SearchResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *SearchResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -84,6 +102,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -123,6 +159,24 @@ func (n *NestedUser) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NestedUser) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedUser
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedUser(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NestedUser) String() string {

--- a/seed/go-model/query-parameters-openapi/types.go
+++ b/seed/go-model/query-parameters-openapi/types.go
@@ -36,6 +36,24 @@ func (s *SearchResponse) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SearchResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SearchResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SearchResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *SearchResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -77,6 +95,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -116,6 +152,24 @@ func (n *NestedUser) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NestedUser) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedUser
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedUser(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NestedUser) String() string {

--- a/seed/go-model/query-parameters/user.go
+++ b/seed/go-model/query-parameters/user.go
@@ -37,6 +37,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -76,6 +94,24 @@ func (n *NestedUser) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NestedUser) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedUser
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedUser(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NestedUser) String() string {

--- a/seed/go-model/request-parameters/user.go
+++ b/seed/go-model/request-parameters/user.go
@@ -37,6 +37,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -76,6 +94,24 @@ func (n *NestedUser) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NestedUser) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NestedUser
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NestedUser(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NestedUser) String() string {

--- a/seed/go-model/reserved-keywords/package.go
+++ b/seed/go-model/reserved-keywords/package.go
@@ -30,6 +30,24 @@ func (p *Package) GetExtraProperties() map[string]any{
     return p.extraProperties
 }
 
+func (p *Package) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler Package
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *p = Package(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *p)
+    if err != nil {
+        return err
+    }
+    p.extraProperties = extraProperties
+    p.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (p *Package) String() string{
     if len(p.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -70,6 +88,24 @@ func (r *Record) GetExtraProperties() map[string]any{
         return nil
     }
     return r.extraProperties
+}
+
+func (r *Record) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler Record
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *r = Record(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *r)
+    if err != nil {
+        return err
+    }
+    r.extraProperties = extraProperties
+    r.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (r *Record) String() string{

--- a/seed/go-model/response-property/service.go
+++ b/seed/go-model/response-property/service.go
@@ -29,6 +29,24 @@ func (w *WithDocs) GetExtraProperties() map[string]any {
 	return w.extraProperties
 }
 
+func (w *WithDocs) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler WithDocs
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*w = WithDocs(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *w)
+	if err != nil {
+		return err
+	}
+	w.extraProperties = extraProperties
+	w.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (w *WithDocs) String() string {
 	if len(w.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -70,6 +88,24 @@ func (m *Movie) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return m.extraProperties
+}
+
+func (m *Movie) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Movie
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Movie(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (m *Movie) String() string {
@@ -119,6 +155,24 @@ func (r *Response) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *Response) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Response
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Response(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *Response) String() string {

--- a/seed/go-model/response-property/types.go
+++ b/seed/go-model/response-property/types.go
@@ -29,6 +29,24 @@ func (s *StringResponse) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *StringResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StringResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StringResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *StringResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -62,6 +80,24 @@ func (w *WithMetadata) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return w.extraProperties
+}
+
+func (w *WithMetadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler WithMetadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*w = WithMetadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *w)
+	if err != nil {
+		return err
+	}
+	w.extraProperties = extraProperties
+	w.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (w *WithMetadata) String() string {

--- a/seed/go-model/server-sent-event-examples/completions.go
+++ b/seed/go-model/server-sent-event-examples/completions.go
@@ -37,6 +37,24 @@ func (s *StreamedCompletion) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *StreamedCompletion) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StreamedCompletion
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StreamedCompletion(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *StreamedCompletion) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {

--- a/seed/go-model/server-sent-events/completions.go
+++ b/seed/go-model/server-sent-events/completions.go
@@ -37,6 +37,24 @@ func (s *StreamedCompletion) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *StreamedCompletion) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StreamedCompletion
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StreamedCompletion(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *StreamedCompletion) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {

--- a/seed/go-model/simple-fhir/types.go
+++ b/seed/go-model/simple-fhir/types.go
@@ -37,6 +37,24 @@ func (m *Memo) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *Memo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Memo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Memo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *Memo) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -84,6 +102,24 @@ func (b *BaseResource) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return b.extraProperties
+}
+
+func (b *BaseResource) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BaseResource
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BaseResource(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (b *BaseResource) String() string {
@@ -174,6 +210,33 @@ func (a *Account) GetExtraProperties() map[string]any {
 	return a.extraProperties
 }
 
+func (a *Account) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed Account
+	var unmarshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed: embed(*a),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*a = Account(unmarshaler.embed)
+	if unmarshaler.ResourceType != "Account" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", a, "Account", unmarshaler.ResourceType)
+	}
+	a.resourceType = unmarshaler.ResourceType
+	extraProperties, err := internal.ExtractExtraProperties(data, *a, "resourceType")
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (a *Account) MarshalJSON() ([]byte, error) {
 	type embed Account
 	var marshaler = struct {
@@ -259,6 +322,33 @@ func (p *Patient) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Patient) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed Patient
+	var unmarshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed: embed(*p),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*p = Patient(unmarshaler.embed)
+	if unmarshaler.ResourceType != "Patient" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", p, "Patient", unmarshaler.ResourceType)
+	}
+	p.resourceType = unmarshaler.ResourceType
+	extraProperties, err := internal.ExtractExtraProperties(data, *p, "resourceType")
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *Patient) MarshalJSON() ([]byte, error) {
 	type embed Patient
 	var marshaler = struct {
@@ -336,6 +426,33 @@ func (p *Practitioner) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Practitioner) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed Practitioner
+	var unmarshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed: embed(*p),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*p = Practitioner(unmarshaler.embed)
+	if unmarshaler.ResourceType != "Practitioner" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", p, "Practitioner", unmarshaler.ResourceType)
+	}
+	p.resourceType = unmarshaler.ResourceType
+	extraProperties, err := internal.ExtractExtraProperties(data, *p, "resourceType")
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *Practitioner) MarshalJSON() ([]byte, error) {
 	type embed Practitioner
 	var marshaler = struct {
@@ -411,6 +528,33 @@ func (s *Script) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *Script) UnmarshalJSON(
+	data []byte,
+) error {
+	type embed Script
+	var unmarshaler = struct {
+		embed
+		ResourceType string `json:"resource_type"`
+	}{
+		embed: embed(*s),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*s = Script(unmarshaler.embed)
+	if unmarshaler.ResourceType != "Script" {
+		return fmt.Errorf("unexpected value for literal on type %T; expected %v got %v", s, "Script", unmarshaler.ResourceType)
+	}
+	s.resourceType = unmarshaler.ResourceType
+	extraProperties, err := internal.ExtractExtraProperties(data, *s, "resourceType")
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *Script) MarshalJSON() ([]byte, error) {

--- a/seed/go-model/streaming-parameter/dummy.go
+++ b/seed/go-model/streaming-parameter/dummy.go
@@ -37,6 +37,24 @@ func (r *RegularResponse) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *RegularResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler RegularResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = RegularResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *RegularResponse) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -76,6 +94,24 @@ func (s *StreamResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *StreamResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StreamResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StreamResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *StreamResponse) String() string {

--- a/seed/go-model/streaming/dummy.go
+++ b/seed/go-model/streaming/dummy.go
@@ -37,6 +37,24 @@ func (s *StreamResponse) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *StreamResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler StreamResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = StreamResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *StreamResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {

--- a/seed/go-model/trace/commons.go
+++ b/seed/go-model/trace/commons.go
@@ -59,6 +59,24 @@ func (l *ListType) GetExtraProperties() map[string]any{
     return l.extraProperties
 }
 
+func (l *ListType) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ListType
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *l = ListType(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *l)
+    if err != nil {
+        return err
+    }
+    l.extraProperties = extraProperties
+    l.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (l *ListType) String() string{
     if len(l.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -99,6 +117,24 @@ func (m *MapType) GetExtraProperties() map[string]any{
         return nil
     }
     return m.extraProperties
+}
+
+func (m *MapType) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler MapType
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *m = MapType(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *m)
+    if err != nil {
+        return err
+    }
+    m.extraProperties = extraProperties
+    m.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (m *MapType) String() string{
@@ -175,6 +211,24 @@ func (g *GenericValue) GetExtraProperties() map[string]any{
     return g.extraProperties
 }
 
+func (g *GenericValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GenericValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GenericValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (g *GenericValue) String() string{
     if len(g.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -207,6 +261,24 @@ func (m *MapValue) GetExtraProperties() map[string]any{
         return nil
     }
     return m.extraProperties
+}
+
+func (m *MapValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler MapValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *m = MapValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *m)
+    if err != nil {
+        return err
+    }
+    m.extraProperties = extraProperties
+    m.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (m *MapValue) String() string{
@@ -251,6 +323,24 @@ func (k *KeyValuePair) GetExtraProperties() map[string]any{
     return k.extraProperties
 }
 
+func (k *KeyValuePair) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler KeyValuePair
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *k = KeyValuePair(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *k)
+    if err != nil {
+        return err
+    }
+    k.extraProperties = extraProperties
+    k.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (k *KeyValuePair) String() string{
     if len(k.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(k.rawJSON); err == nil {
@@ -291,6 +381,24 @@ func (b *BinaryTreeValue) GetExtraProperties() map[string]any{
         return nil
     }
     return b.extraProperties
+}
+
+func (b *BinaryTreeValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler BinaryTreeValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *b = BinaryTreeValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *b)
+    if err != nil {
+        return err
+    }
+    b.extraProperties = extraProperties
+    b.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (b *BinaryTreeValue) String() string{
@@ -351,6 +459,24 @@ func (b *BinaryTreeNodeValue) GetExtraProperties() map[string]any{
     return b.extraProperties
 }
 
+func (b *BinaryTreeNodeValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler BinaryTreeNodeValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *b = BinaryTreeNodeValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *b)
+    if err != nil {
+        return err
+    }
+    b.extraProperties = extraProperties
+    b.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (b *BinaryTreeNodeValue) String() string{
     if len(b.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -393,6 +519,24 @@ func (b *BinaryTreeNodeAndTreeValue) GetExtraProperties() map[string]any{
     return b.extraProperties
 }
 
+func (b *BinaryTreeNodeAndTreeValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler BinaryTreeNodeAndTreeValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *b = BinaryTreeNodeAndTreeValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *b)
+    if err != nil {
+        return err
+    }
+    b.extraProperties = extraProperties
+    b.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (b *BinaryTreeNodeAndTreeValue) String() string{
     if len(b.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -433,6 +577,24 @@ func (s *SinglyLinkedListValue) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *SinglyLinkedListValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler SinglyLinkedListValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = SinglyLinkedListValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *SinglyLinkedListValue) String() string{
@@ -485,6 +647,24 @@ func (s *SinglyLinkedListNodeValue) GetExtraProperties() map[string]any{
     return s.extraProperties
 }
 
+func (s *SinglyLinkedListNodeValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler SinglyLinkedListNodeValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = SinglyLinkedListNodeValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (s *SinglyLinkedListNodeValue) String() string{
     if len(s.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -527,6 +707,24 @@ func (s *SinglyLinkedListNodeAndListValue) GetExtraProperties() map[string]any{
     return s.extraProperties
 }
 
+func (s *SinglyLinkedListNodeAndListValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler SinglyLinkedListNodeAndListValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = SinglyLinkedListNodeAndListValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (s *SinglyLinkedListNodeAndListValue) String() string{
     if len(s.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -567,6 +765,24 @@ func (d *DoublyLinkedListValue) GetExtraProperties() map[string]any{
         return nil
     }
     return d.extraProperties
+}
+
+func (d *DoublyLinkedListValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler DoublyLinkedListValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *d = DoublyLinkedListValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *d)
+    if err != nil {
+        return err
+    }
+    d.extraProperties = extraProperties
+    d.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (d *DoublyLinkedListValue) String() string{
@@ -627,6 +843,24 @@ func (d *DoublyLinkedListNodeValue) GetExtraProperties() map[string]any{
     return d.extraProperties
 }
 
+func (d *DoublyLinkedListNodeValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler DoublyLinkedListNodeValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *d = DoublyLinkedListNodeValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *d)
+    if err != nil {
+        return err
+    }
+    d.extraProperties = extraProperties
+    d.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (d *DoublyLinkedListNodeValue) String() string{
     if len(d.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -669,6 +903,24 @@ func (d *DoublyLinkedListNodeAndListValue) GetExtraProperties() map[string]any{
     return d.extraProperties
 }
 
+func (d *DoublyLinkedListNodeAndListValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler DoublyLinkedListNodeAndListValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *d = DoublyLinkedListNodeAndListValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *d)
+    if err != nil {
+        return err
+    }
+    d.extraProperties = extraProperties
+    d.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (d *DoublyLinkedListNodeAndListValue) String() string{
     if len(d.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -701,6 +953,24 @@ func (d *DebugMapValue) GetExtraProperties() map[string]any{
         return nil
     }
     return d.extraProperties
+}
+
+func (d *DebugMapValue) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler DebugMapValue
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *d = DebugMapValue(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *d)
+    if err != nil {
+        return err
+    }
+    d.extraProperties = extraProperties
+    d.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (d *DebugMapValue) String() string{
@@ -745,6 +1015,24 @@ func (d *DebugKeyValuePairs) GetExtraProperties() map[string]any{
     return d.extraProperties
 }
 
+func (d *DebugKeyValuePairs) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler DebugKeyValuePairs
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *d = DebugKeyValuePairs(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *d)
+    if err != nil {
+        return err
+    }
+    d.extraProperties = extraProperties
+    d.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (d *DebugKeyValuePairs) String() string{
     if len(d.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -785,6 +1073,24 @@ func (t *TestCase) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TestCase) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestCase
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestCase(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TestCase) String() string{
@@ -829,6 +1135,24 @@ func (t *TestCaseWithExpectedResult) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TestCaseWithExpectedResult) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestCaseWithExpectedResult
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestCaseWithExpectedResult(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TestCaseWithExpectedResult) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -869,6 +1193,24 @@ func (f *FileInfo) GetExtraProperties() map[string]any{
         return nil
     }
     return f.extraProperties
+}
+
+func (f *FileInfo) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler FileInfo
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *f = FileInfo(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *f)
+    if err != nil {
+        return err
+    }
+    f.extraProperties = extraProperties
+    f.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (f *FileInfo) String() string{

--- a/seed/go-model/trace/lang_server.go
+++ b/seed/go-model/trace/lang_server.go
@@ -30,6 +30,24 @@ func (l *LangServerRequest) GetExtraProperties() map[string]any{
     return l.extraProperties
 }
 
+func (l *LangServerRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler LangServerRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *l = LangServerRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *l)
+    if err != nil {
+        return err
+    }
+    l.extraProperties = extraProperties
+    l.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (l *LangServerRequest) String() string{
     if len(l.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -62,6 +80,24 @@ func (l *LangServerResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return l.extraProperties
+}
+
+func (l *LangServerResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler LangServerResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *l = LangServerResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *l)
+    if err != nil {
+        return err
+    }
+    l.extraProperties = extraProperties
+    l.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (l *LangServerResponse) String() string{

--- a/seed/go-model/trace/migration.go
+++ b/seed/go-model/trace/migration.go
@@ -65,6 +65,24 @@ func (m *Migration) GetExtraProperties() map[string]any{
     return m.extraProperties
 }
 
+func (m *Migration) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler Migration
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *m = Migration(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *m)
+    if err != nil {
+        return err
+    }
+    m.extraProperties = extraProperties
+    m.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (m *Migration) String() string{
     if len(m.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(m.rawJSON); err == nil {

--- a/seed/go-model/trace/playlist.go
+++ b/seed/go-model/trace/playlist.go
@@ -56,6 +56,24 @@ func (p *Playlist) GetExtraProperties() map[string]any{
     return p.extraProperties
 }
 
+func (p *Playlist) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler Playlist
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *p = Playlist(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *p)
+    if err != nil {
+        return err
+    }
+    p.extraProperties = extraProperties
+    p.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (p *Playlist) String() string{
     if len(p.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -96,6 +114,24 @@ func (p *PlaylistCreateRequest) GetExtraProperties() map[string]any{
         return nil
     }
     return p.extraProperties
+}
+
+func (p *PlaylistCreateRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler PlaylistCreateRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *p = PlaylistCreateRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *p)
+    if err != nil {
+        return err
+    }
+    p.extraProperties = extraProperties
+    p.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (p *PlaylistCreateRequest) String() string{
@@ -139,6 +175,24 @@ func (u *UpdatePlaylistRequest) GetExtraProperties() map[string]any{
         return nil
     }
     return u.extraProperties
+}
+
+func (u *UpdatePlaylistRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler UpdatePlaylistRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *u = UpdatePlaylistRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *u)
+    if err != nil {
+        return err
+    }
+    u.extraProperties = extraProperties
+    u.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (u *UpdatePlaylistRequest) String() string{

--- a/seed/go-model/trace/problem.go
+++ b/seed/go-model/trace/problem.go
@@ -102,6 +102,24 @@ func (p *ProblemInfo) GetExtraProperties() map[string]any{
     return p.extraProperties
 }
 
+func (p *ProblemInfo) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ProblemInfo
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *p = ProblemInfo(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *p)
+    if err != nil {
+        return err
+    }
+    p.extraProperties = extraProperties
+    p.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (p *ProblemInfo) String() string{
     if len(p.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -134,6 +152,24 @@ func (p *ProblemDescription) GetExtraProperties() map[string]any{
         return nil
     }
     return p.extraProperties
+}
+
+func (p *ProblemDescription) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ProblemDescription
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *p = ProblemDescription(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *p)
+    if err != nil {
+        return err
+    }
+    p.extraProperties = extraProperties
+    p.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (p *ProblemDescription) String() string{
@@ -185,6 +221,24 @@ func (p *ProblemFiles) GetExtraProperties() map[string]any{
     return p.extraProperties
 }
 
+func (p *ProblemFiles) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ProblemFiles
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *p = ProblemFiles(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *p)
+    if err != nil {
+        return err
+    }
+    p.extraProperties = extraProperties
+    p.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (p *ProblemFiles) String() string{
     if len(p.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -225,6 +279,24 @@ func (v *VariableTypeAndName) GetExtraProperties() map[string]any{
         return nil
     }
     return v.extraProperties
+}
+
+func (v *VariableTypeAndName) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler VariableTypeAndName
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *v = VariableTypeAndName(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *v)
+    if err != nil {
+        return err
+    }
+    v.extraProperties = extraProperties
+    v.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (v *VariableTypeAndName) String() string{
@@ -309,6 +381,24 @@ func (c *CreateProblemRequest) GetExtraProperties() map[string]any{
     return c.extraProperties
 }
 
+func (c *CreateProblemRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler CreateProblemRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *c = CreateProblemRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *c)
+    if err != nil {
+        return err
+    }
+    c.extraProperties = extraProperties
+    c.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (c *CreateProblemRequest) String() string{
     if len(c.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -347,6 +437,24 @@ func (u *UpdateProblemResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return u.extraProperties
+}
+
+func (u *UpdateProblemResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler UpdateProblemResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *u = UpdateProblemResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *u)
+    if err != nil {
+        return err
+    }
+    u.extraProperties = extraProperties
+    u.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (u *UpdateProblemResponse) String() string{
@@ -404,6 +512,24 @@ func (g *GenericCreateProblemError) GetExtraProperties() map[string]any{
     return g.extraProperties
 }
 
+func (g *GenericCreateProblemError) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GenericCreateProblemError
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GenericCreateProblemError(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (g *GenericCreateProblemError) String() string{
     if len(g.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -436,6 +562,24 @@ func (g *GetDefaultStarterFilesResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return g.extraProperties
+}
+
+func (g *GetDefaultStarterFilesResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GetDefaultStarterFilesResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GetDefaultStarterFilesResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (g *GetDefaultStarterFilesResponse) String() string{

--- a/seed/go-model/trace/submission.go
+++ b/seed/go-model/trace/submission.go
@@ -54,6 +54,24 @@ func (i *InitializeProblemRequest) GetExtraProperties() map[string]any{
     return i.extraProperties
 }
 
+func (i *InitializeProblemRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler InitializeProblemRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *i = InitializeProblemRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *i)
+    if err != nil {
+        return err
+    }
+    i.extraProperties = extraProperties
+    i.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (i *InitializeProblemRequest) String() string{
     if len(i.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -128,6 +146,24 @@ func (s *SubmitRequestV2) GetExtraProperties() map[string]any{
     return s.extraProperties
 }
 
+func (s *SubmitRequestV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler SubmitRequestV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = SubmitRequestV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (s *SubmitRequestV2) String() string{
     if len(s.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -186,6 +222,24 @@ func (w *WorkspaceSubmitRequest) GetExtraProperties() map[string]any{
     return w.extraProperties
 }
 
+func (w *WorkspaceSubmitRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceSubmitRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceSubmitRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (w *WorkspaceSubmitRequest) String() string{
     if len(w.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -234,6 +288,24 @@ func (s *SubmissionFileInfo) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *SubmissionFileInfo) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler SubmissionFileInfo
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = SubmissionFileInfo(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *SubmissionFileInfo) String() string{
@@ -288,6 +360,24 @@ func (s *StopRequest) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *StopRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler StopRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = StopRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *StopRequest) String() string{
@@ -357,6 +447,24 @@ func (b *BuildingExecutorResponse) GetExtraProperties() map[string]any{
     return b.extraProperties
 }
 
+func (b *BuildingExecutorResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler BuildingExecutorResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *b = BuildingExecutorResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *b)
+    if err != nil {
+        return err
+    }
+    b.extraProperties = extraProperties
+    b.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (b *BuildingExecutorResponse) String() string{
     if len(b.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -397,6 +505,24 @@ func (r *RunningResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return r.extraProperties
+}
+
+func (r *RunningResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler RunningResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *r = RunningResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *r)
+    if err != nil {
+        return err
+    }
+    r.extraProperties = extraProperties
+    r.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (r *RunningResponse) String() string{
@@ -472,6 +598,24 @@ func (e *ErroredResponse) GetExtraProperties() map[string]any{
     return e.extraProperties
 }
 
+func (e *ErroredResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ErroredResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *e = ErroredResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *e)
+    if err != nil {
+        return err
+    }
+    e.extraProperties = extraProperties
+    e.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (e *ErroredResponse) String() string{
     if len(e.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -513,6 +657,24 @@ func (c *CompileError) GetExtraProperties() map[string]any{
     return c.extraProperties
 }
 
+func (c *CompileError) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler CompileError
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *c = CompileError(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *c)
+    if err != nil {
+        return err
+    }
+    c.extraProperties = extraProperties
+    c.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (c *CompileError) String() string{
     if len(c.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -545,6 +707,24 @@ func (r *RuntimeError) GetExtraProperties() map[string]any{
         return nil
     }
     return r.extraProperties
+}
+
+func (r *RuntimeError) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler RuntimeError
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *r = RuntimeError(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *r)
+    if err != nil {
+        return err
+    }
+    r.extraProperties = extraProperties
+    r.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (r *RuntimeError) String() string{
@@ -581,6 +761,24 @@ func (i *InternalError) GetExtraProperties() map[string]any{
     return i.extraProperties
 }
 
+func (i *InternalError) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler InternalError
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *i = InternalError(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *i)
+    if err != nil {
+        return err
+    }
+    i.extraProperties = extraProperties
+    i.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (i *InternalError) String() string{
     if len(i.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -613,6 +811,24 @@ func (s *StoppedResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *StoppedResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler StoppedResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = StoppedResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *StoppedResponse) String() string{
@@ -655,6 +871,24 @@ func (w *WorkspaceRanResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceRanResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceRanResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceRanResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceRanResponse) String() string{
@@ -707,6 +941,24 @@ func (w *WorkspaceRunDetails) GetExtraProperties() map[string]any{
     return w.extraProperties
 }
 
+func (w *WorkspaceRunDetails) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceRunDetails
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceRunDetails(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (w *WorkspaceRunDetails) String() string{
     if len(w.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -747,6 +999,24 @@ func (g *GradedResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return g.extraProperties
+}
+
+func (g *GradedResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GradedResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GradedResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (g *GradedResponse) String() string{
@@ -791,6 +1061,24 @@ func (g *GradedResponseV2) GetExtraProperties() map[string]any{
     return g.extraProperties
 }
 
+func (g *GradedResponseV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GradedResponseV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GradedResponseV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (g *GradedResponseV2) String() string{
     if len(g.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -829,6 +1117,24 @@ func (t *TestCaseHiddenGrade) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TestCaseHiddenGrade) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestCaseHiddenGrade
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestCaseHiddenGrade(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TestCaseHiddenGrade) String() string{
@@ -889,6 +1195,24 @@ func (t *TestCaseNonHiddenGrade) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TestCaseNonHiddenGrade) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestCaseNonHiddenGrade
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestCaseNonHiddenGrade(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TestCaseNonHiddenGrade) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -937,6 +1261,24 @@ func (r *RecordedResponseNotification) GetExtraProperties() map[string]any{
         return nil
     }
     return r.extraProperties
+}
+
+func (r *RecordedResponseNotification) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler RecordedResponseNotification
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *r = RecordedResponseNotification(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *r)
+    if err != nil {
+        return err
+    }
+    r.extraProperties = extraProperties
+    r.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (r *RecordedResponseNotification) String() string{
@@ -1005,6 +1347,24 @@ func (r *RecordingResponseNotification) GetExtraProperties() map[string]any{
     return r.extraProperties
 }
 
+func (r *RecordingResponseNotification) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler RecordingResponseNotification
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *r = RecordingResponseNotification(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *r)
+    if err != nil {
+        return err
+    }
+    r.extraProperties = extraProperties
+    r.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (r *RecordingResponseNotification) String() string{
     if len(r.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1047,6 +1407,24 @@ func (l *LightweightStackframeInformation) GetExtraProperties() map[string]any{
     return l.extraProperties
 }
 
+func (l *LightweightStackframeInformation) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler LightweightStackframeInformation
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *l = LightweightStackframeInformation(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *l)
+    if err != nil {
+        return err
+    }
+    l.extraProperties = extraProperties
+    l.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (l *LightweightStackframeInformation) String() string{
     if len(l.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -1087,6 +1465,24 @@ func (t *TestCaseResultWithStdout) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TestCaseResultWithStdout) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestCaseResultWithStdout
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestCaseResultWithStdout(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TestCaseResultWithStdout) String() string{
@@ -1137,6 +1533,24 @@ func (t *TestCaseResult) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TestCaseResult) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestCaseResult
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestCaseResult(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TestCaseResult) String() string{
@@ -1202,6 +1616,24 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]any{
     return e.extraProperties
 }
 
+func (e *ExceptionInfo) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ExceptionInfo
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *e = ExceptionInfo(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *e)
+    if err != nil {
+        return err
+    }
+    e.extraProperties = extraProperties
+    e.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (e *ExceptionInfo) String() string{
     if len(e.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -1242,6 +1674,24 @@ func (i *InvalidRequestResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return i.extraProperties
+}
+
+func (i *InvalidRequestResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler InvalidRequestResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *i = InvalidRequestResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *i)
+    if err != nil {
+        return err
+    }
+    i.extraProperties = extraProperties
+    i.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (i *InvalidRequestResponse) String() string{
@@ -1285,6 +1735,24 @@ func (e *ExistingSubmissionExecuting) GetExtraProperties() map[string]any{
     return e.extraProperties
 }
 
+func (e *ExistingSubmissionExecuting) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ExistingSubmissionExecuting
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *e = ExistingSubmissionExecuting(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *e)
+    if err != nil {
+        return err
+    }
+    e.extraProperties = extraProperties
+    e.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (e *ExistingSubmissionExecuting) String() string{
     if len(e.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -1317,6 +1785,24 @@ func (s *SubmissionIdNotFound) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *SubmissionIdNotFound) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler SubmissionIdNotFound
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = SubmissionIdNotFound(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *SubmissionIdNotFound) String() string{
@@ -1361,6 +1847,24 @@ func (c *CustomTestCasesUnsupported) GetExtraProperties() map[string]any{
     return c.extraProperties
 }
 
+func (c *CustomTestCasesUnsupported) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler CustomTestCasesUnsupported
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *c = CustomTestCasesUnsupported(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *c)
+    if err != nil {
+        return err
+    }
+    c.extraProperties = extraProperties
+    c.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (c *CustomTestCasesUnsupported) String() string{
     if len(c.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -1403,6 +1907,24 @@ func (u *UnexpectedLanguageError) GetExtraProperties() map[string]any{
     return u.extraProperties
 }
 
+func (u *UnexpectedLanguageError) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler UnexpectedLanguageError
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *u = UnexpectedLanguageError(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *u)
+    if err != nil {
+        return err
+    }
+    u.extraProperties = extraProperties
+    u.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (u *UnexpectedLanguageError) String() string{
     if len(u.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -1426,6 +1948,24 @@ func (t *TerminatedResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TerminatedResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TerminatedResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TerminatedResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TerminatedResponse) String() string{
@@ -1460,6 +2000,24 @@ func (f *FinishedResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return f.extraProperties
+}
+
+func (f *FinishedResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler FinishedResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *f = FinishedResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *f)
+    if err != nil {
+        return err
+    }
+    f.extraProperties = extraProperties
+    f.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (f *FinishedResponse) String() string{
@@ -1504,6 +2062,24 @@ func (s *StdoutResponse) GetExtraProperties() map[string]any{
     return s.extraProperties
 }
 
+func (s *StdoutResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler StdoutResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = StdoutResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (s *StdoutResponse) String() string{
     if len(s.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -1544,6 +2120,24 @@ func (s *StderrResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *StderrResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler StderrResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = StderrResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *StderrResponse) String() string{
@@ -1618,6 +2212,24 @@ func (t *TraceResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TraceResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TraceResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TraceResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TraceResponse) String() string{
@@ -1702,6 +2314,24 @@ func (t *TraceResponseV2) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TraceResponseV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TraceResponseV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TraceResponseV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TraceResponseV2) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -1742,6 +2372,24 @@ func (t *TracedFile) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TracedFile) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TracedFile
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TracedFile(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TracedFile) String() string{
@@ -1786,6 +2434,24 @@ func (e *ExpressionLocation) GetExtraProperties() map[string]any{
     return e.extraProperties
 }
 
+func (e *ExpressionLocation) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ExpressionLocation
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *e = ExpressionLocation(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *e)
+    if err != nil {
+        return err
+    }
+    e.extraProperties = extraProperties
+    e.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (e *ExpressionLocation) String() string{
     if len(e.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -1826,6 +2492,24 @@ func (s *StackInformation) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *StackInformation) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler StackInformation
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = StackInformation(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *StackInformation) String() string{
@@ -1878,6 +2562,24 @@ func (s *StackFrame) GetExtraProperties() map[string]any{
     return s.extraProperties
 }
 
+func (s *StackFrame) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler StackFrame
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = StackFrame(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (s *StackFrame) String() string{
     if len(s.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -1910,6 +2612,24 @@ func (s *Scope) GetExtraProperties() map[string]any{
         return nil
     }
     return s.extraProperties
+}
+
+func (s *Scope) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler Scope
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *s = Scope(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *s)
+    if err != nil {
+        return err
+    }
+    s.extraProperties = extraProperties
+    s.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (s *Scope) String() string{
@@ -1968,6 +2688,24 @@ func (e *ExecutionSessionResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return e.extraProperties
+}
+
+func (e *ExecutionSessionResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ExecutionSessionResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *e = ExecutionSessionResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *e)
+    if err != nil {
+        return err
+    }
+    e.extraProperties = extraProperties
+    e.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (e *ExecutionSessionResponse) String() string{
@@ -2068,6 +2806,24 @@ func (t *TestSubmissionStatusV2) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TestSubmissionStatusV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestSubmissionStatusV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestSubmissionStatusV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TestSubmissionStatusV2) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2100,6 +2856,24 @@ func (w *WorkspaceSubmissionStatusV2) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceSubmissionStatusV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceSubmissionStatusV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceSubmissionStatusV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceSubmissionStatusV2) String() string{
@@ -2142,6 +2916,30 @@ func (t *TestSubmissionUpdate) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TestSubmissionUpdate) UnmarshalJSON(
+    data []byte,
+) error{
+    type embed TestSubmissionUpdate
+    var unmarshaler = struct{
+        embed
+        UpdateTime *internal.DateTime `json:"updateTime"`
+    }{
+        embed: embed(*t),
+    }
+    if err := json.Unmarshal(data, &unmarshaler); err != nil {
+        return err
+    }
+    *t = TestSubmissionUpdate(unmarshaler.embed)
+    t.UpdateTime = unmarshaler.UpdateTime.Time()
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TestSubmissionUpdate) MarshalJSON() ([]byte, error){
@@ -2206,6 +3004,30 @@ func (w *WorkspaceSubmissionUpdate) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceSubmissionUpdate) UnmarshalJSON(
+    data []byte,
+) error{
+    type embed WorkspaceSubmissionUpdate
+    var unmarshaler = struct{
+        embed
+        UpdateTime *internal.DateTime `json:"updateTime"`
+    }{
+        embed: embed(*w),
+    }
+    if err := json.Unmarshal(data, &unmarshaler); err != nil {
+        return err
+    }
+    *w = WorkspaceSubmissionUpdate(unmarshaler.embed)
+    w.UpdateTime = unmarshaler.UpdateTime.Time()
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceSubmissionUpdate) MarshalJSON() ([]byte, error){
@@ -2273,6 +3095,24 @@ func (g *GradedTestCaseUpdate) GetExtraProperties() map[string]any{
     return g.extraProperties
 }
 
+func (g *GradedTestCaseUpdate) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GradedTestCaseUpdate
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GradedTestCaseUpdate(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (g *GradedTestCaseUpdate) String() string{
     if len(g.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -2315,6 +3155,24 @@ func (r *RecordedTestCaseUpdate) GetExtraProperties() map[string]any{
     return r.extraProperties
 }
 
+func (r *RecordedTestCaseUpdate) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler RecordedTestCaseUpdate
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *r = RecordedTestCaseUpdate(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *r)
+    if err != nil {
+        return err
+    }
+    r.extraProperties = extraProperties
+    r.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (r *RecordedTestCaseUpdate) String() string{
     if len(r.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -2347,6 +3205,24 @@ func (w *WorkspaceTracedUpdate) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceTracedUpdate) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceTracedUpdate
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceTracedUpdate(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceTracedUpdate) String() string{
@@ -2387,6 +3263,24 @@ func (w *WorkspaceSubmissionState) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceSubmissionState) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceSubmissionState
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceSubmissionState(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceSubmissionState) String() string{
@@ -2456,6 +3350,24 @@ func (t *TestSubmissionState) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TestSubmissionState) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TestSubmissionState
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TestSubmissionState(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TestSubmissionState) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2513,6 +3425,24 @@ func (t *TracedTestCase) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TracedTestCase) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TracedTestCase
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TracedTestCase(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TracedTestCase) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2555,6 +3485,24 @@ func (t *TraceResponsesPage) GetExtraProperties() map[string]any{
         return nil
     }
     return t.extraProperties
+}
+
+func (t *TraceResponsesPage) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TraceResponsesPage
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TraceResponsesPage(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (t *TraceResponsesPage) String() string{
@@ -2601,6 +3549,24 @@ func (t *TraceResponsesPageV2) GetExtraProperties() map[string]any{
     return t.extraProperties
 }
 
+func (t *TraceResponsesPageV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler TraceResponsesPageV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *t = TraceResponsesPageV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *t)
+    if err != nil {
+        return err
+    }
+    t.extraProperties = extraProperties
+    t.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (t *TraceResponsesPageV2) String() string{
     if len(t.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2633,6 +3599,24 @@ func (g *GetTraceResponsesPageRequest) GetExtraProperties() map[string]any{
         return nil
     }
     return g.extraProperties
+}
+
+func (g *GetTraceResponsesPageRequest) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GetTraceResponsesPageRequest
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GetTraceResponsesPageRequest(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (g *GetTraceResponsesPageRequest) String() string{
@@ -2669,6 +3653,24 @@ func (w *WorkspaceStarterFilesResponse) GetExtraProperties() map[string]any{
     return w.extraProperties
 }
 
+func (w *WorkspaceStarterFilesResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceStarterFilesResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceStarterFilesResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (w *WorkspaceStarterFilesResponse) String() string{
     if len(w.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -2701,6 +3703,24 @@ func (w *WorkspaceStarterFilesResponseV2) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceStarterFilesResponseV2) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceStarterFilesResponseV2
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceStarterFilesResponseV2(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceStarterFilesResponseV2) String() string{
@@ -2743,6 +3763,24 @@ func (w *WorkspaceFiles) GetExtraProperties() map[string]any{
         return nil
     }
     return w.extraProperties
+}
+
+func (w *WorkspaceFiles) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler WorkspaceFiles
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *w = WorkspaceFiles(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *w)
+    if err != nil {
+        return err
+    }
+    w.extraProperties = extraProperties
+    w.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (w *WorkspaceFiles) String() string{
@@ -2820,6 +3858,24 @@ func (e *ExecutionSessionState) GetExtraProperties() map[string]any{
     return e.extraProperties
 }
 
+func (e *ExecutionSessionState) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler ExecutionSessionState
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *e = ExecutionSessionState(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *e)
+    if err != nil {
+        return err
+    }
+    e.extraProperties = extraProperties
+    e.rawJSON = json.RawMessage(data)
+    return nil
+}
+
 func (e *ExecutionSessionState) String() string{
     if len(e.rawJSON) > 0 {
         if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -2868,6 +3924,24 @@ func (g *GetExecutionSessionStateResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return g.extraProperties
+}
+
+func (g *GetExecutionSessionStateResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type unmarshaler GetExecutionSessionStateResponse
+    var value unmarshaler
+    if err := json.Unmarshal(data, &value); err != nil {
+        return err
+    }
+    *g = GetExecutionSessionStateResponse(value)
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (g *GetExecutionSessionStateResponse) String() string{
@@ -2926,6 +4000,30 @@ func (g *GetSubmissionStateResponse) GetExtraProperties() map[string]any{
         return nil
     }
     return g.extraProperties
+}
+
+func (g *GetSubmissionStateResponse) UnmarshalJSON(
+    data []byte,
+) error{
+    type embed GetSubmissionStateResponse
+    var unmarshaler = struct{
+        embed
+        TimeSubmitted *internal.DateTime `json:"timeSubmitted"`
+    }{
+        embed: embed(*g),
+    }
+    if err := json.Unmarshal(data, &unmarshaler); err != nil {
+        return err
+    }
+    *g = GetSubmissionStateResponse(unmarshaler.embed)
+    g.TimeSubmitted = unmarshaler.TimeSubmitted.TimePtr()
+    extraProperties, err := internal.ExtractExtraProperties(data, *g)
+    if err != nil {
+        return err
+    }
+    g.extraProperties = extraProperties
+    g.rawJSON = json.RawMessage(data)
+    return nil
 }
 
 func (g *GetSubmissionStateResponse) MarshalJSON() ([]byte, error){

--- a/seed/go-model/trace/v2/problem.go
+++ b/seed/go-model/trace/v2/problem.go
@@ -108,6 +108,24 @@ func (p *ProblemInfoV2) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *ProblemInfoV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ProblemInfoV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = ProblemInfoV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *ProblemInfoV2) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -163,6 +181,24 @@ func (l *LightweightProblemInfoV2) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return l.extraProperties
+}
+
+func (l *LightweightProblemInfoV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler LightweightProblemInfoV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = LightweightProblemInfoV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (l *LightweightProblemInfoV2) String() string {
@@ -246,6 +282,24 @@ func (c *CreateProblemRequestV2) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *CreateProblemRequestV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CreateProblemRequestV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CreateProblemRequestV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *CreateProblemRequestV2) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -303,6 +357,24 @@ func (t *TestCaseV2) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TestCaseV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseV2) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -334,6 +406,24 @@ func (t *TestCaseExpects) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TestCaseExpects) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseExpects
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseExpects(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TestCaseExpects) String() string {
@@ -399,6 +489,24 @@ func (b *BasicTestCaseTemplate) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BasicTestCaseTemplate) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BasicTestCaseTemplate
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BasicTestCaseTemplate(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BasicTestCaseTemplate) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -448,6 +556,24 @@ func (t *TestCaseTemplate) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TestCaseTemplate) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseTemplate
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseTemplate(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseTemplate) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -487,6 +613,24 @@ func (t *TestCaseImplementation) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TestCaseImplementation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseImplementation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseImplementation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TestCaseImplementation) String() string {
@@ -536,6 +680,24 @@ func (t *TestCaseWithActualResultImplementation) GetExtraProperties() map[string
 	return t.extraProperties
 }
 
+func (t *TestCaseWithActualResultImplementation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseWithActualResultImplementation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseWithActualResultImplementation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseWithActualResultImplementation) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -575,6 +737,24 @@ func (v *VoidFunctionDefinition) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return v.extraProperties
+}
+
+func (v *VoidFunctionDefinition) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionDefinition
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionDefinition(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (v *VoidFunctionDefinition) String() string {
@@ -626,6 +806,24 @@ func (p *Parameter) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Parameter) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Parameter
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = Parameter(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *Parameter) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -667,6 +865,24 @@ func (n *NonVoidFunctionDefinition) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NonVoidFunctionDefinition) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NonVoidFunctionDefinition
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NonVoidFunctionDefinition(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NonVoidFunctionDefinition) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -698,6 +914,24 @@ func (v *VoidFunctionSignature) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return v.extraProperties
+}
+
+func (v *VoidFunctionSignature) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionSignature
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionSignature(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (v *VoidFunctionSignature) String() string {
@@ -741,6 +975,24 @@ func (n *NonVoidFunctionSignature) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NonVoidFunctionSignature) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NonVoidFunctionSignature
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NonVoidFunctionSignature(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NonVoidFunctionSignature) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -782,6 +1034,24 @@ func (v *VoidFunctionSignatureThatTakesActualResult) GetExtraProperties() map[st
 	return v.extraProperties
 }
 
+func (v *VoidFunctionSignatureThatTakesActualResult) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionSignatureThatTakesActualResult
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionSignatureThatTakesActualResult(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (v *VoidFunctionSignatureThatTakesActualResult) String() string {
 	if len(v.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(v.rawJSON); err == nil {
@@ -820,6 +1090,24 @@ func (d *DeepEqualityCorrectnessCheck) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DeepEqualityCorrectnessCheck) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DeepEqualityCorrectnessCheck
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DeepEqualityCorrectnessCheck(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DeepEqualityCorrectnessCheck) String() string {
@@ -864,6 +1152,24 @@ func (v *VoidFunctionDefinitionThatTakesActualResult) GetExtraProperties() map[s
 	return v.extraProperties
 }
 
+func (v *VoidFunctionDefinitionThatTakesActualResult) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionDefinitionThatTakesActualResult
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionDefinitionThatTakesActualResult(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (v *VoidFunctionDefinitionThatTakesActualResult) String() string {
 	if len(v.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(v.rawJSON); err == nil {
@@ -895,6 +1201,24 @@ func (t *TestCaseImplementationDescription) GetExtraProperties() map[string]any 
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TestCaseImplementationDescription) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseImplementationDescription
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseImplementationDescription(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TestCaseImplementationDescription) String() string {
@@ -952,6 +1276,24 @@ func (t *TestCaseMetadata) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TestCaseMetadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseMetadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseMetadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseMetadata) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -983,6 +1325,24 @@ func (f *FunctionImplementationForMultipleLanguages) GetExtraProperties() map[st
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FunctionImplementationForMultipleLanguages) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FunctionImplementationForMultipleLanguages
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FunctionImplementationForMultipleLanguages(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FunctionImplementationForMultipleLanguages) String() string {
@@ -1024,6 +1384,24 @@ func (f *FunctionImplementation) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FunctionImplementation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FunctionImplementation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FunctionImplementation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FunctionImplementation) String() string {
@@ -1073,6 +1451,24 @@ func (g *GeneratedFiles) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GeneratedFiles) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GeneratedFiles
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GeneratedFiles(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GeneratedFiles) String() string {
@@ -1138,6 +1534,24 @@ func (b *BasicCustomFiles) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BasicCustomFiles) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BasicCustomFiles
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BasicCustomFiles(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BasicCustomFiles) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -1169,6 +1583,24 @@ func (f *Files) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *Files) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Files
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Files(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *Files) String() string {
@@ -1228,6 +1660,24 @@ func (f *FileInfoV2) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *FileInfoV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FileInfoV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FileInfoV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *FileInfoV2) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1267,6 +1717,24 @@ func (d *DefaultProvidedFile) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DefaultProvidedFile) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DefaultProvidedFile
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DefaultProvidedFile(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DefaultProvidedFile) String() string {
@@ -1309,6 +1777,24 @@ func (g *GetFunctionSignatureRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetFunctionSignatureRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetFunctionSignatureRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetFunctionSignatureRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetFunctionSignatureRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1340,6 +1826,24 @@ func (g *GetFunctionSignatureResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GetFunctionSignatureResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetFunctionSignatureResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetFunctionSignatureResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GetFunctionSignatureResponse) String() string {
@@ -1383,6 +1887,24 @@ func (g *GetBasicSolutionFileRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetBasicSolutionFileRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetBasicSolutionFileRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetBasicSolutionFileRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetBasicSolutionFileRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1414,6 +1936,24 @@ func (g *GetBasicSolutionFileResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GetBasicSolutionFileResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetBasicSolutionFileResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetBasicSolutionFileResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GetBasicSolutionFileResponse) String() string {
@@ -1457,6 +1997,24 @@ func (g *GetGeneratedTestCaseFileRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetGeneratedTestCaseFileRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetGeneratedTestCaseFileRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetGeneratedTestCaseFileRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetGeneratedTestCaseFileRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1488,6 +2046,24 @@ func (g *GetGeneratedTestCaseTemplateFileRequest) GetExtraProperties() map[strin
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GetGeneratedTestCaseTemplateFileRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetGeneratedTestCaseTemplateFileRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetGeneratedTestCaseTemplateFileRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GetGeneratedTestCaseTemplateFileRequest) String() string {

--- a/seed/go-model/trace/v2/v3/problem.go
+++ b/seed/go-model/trace/v2/v3/problem.go
@@ -108,6 +108,24 @@ func (p *ProblemInfoV2) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *ProblemInfoV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ProblemInfoV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = ProblemInfoV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *ProblemInfoV2) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -163,6 +181,24 @@ func (l *LightweightProblemInfoV2) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return l.extraProperties
+}
+
+func (l *LightweightProblemInfoV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler LightweightProblemInfoV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = LightweightProblemInfoV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (l *LightweightProblemInfoV2) String() string {
@@ -246,6 +282,24 @@ func (c *CreateProblemRequestV2) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *CreateProblemRequestV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CreateProblemRequestV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CreateProblemRequestV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *CreateProblemRequestV2) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -303,6 +357,24 @@ func (t *TestCaseV2) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TestCaseV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseV2) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -334,6 +406,24 @@ func (t *TestCaseExpects) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TestCaseExpects) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseExpects
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseExpects(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TestCaseExpects) String() string {
@@ -399,6 +489,24 @@ func (b *BasicTestCaseTemplate) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BasicTestCaseTemplate) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BasicTestCaseTemplate
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BasicTestCaseTemplate(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BasicTestCaseTemplate) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -448,6 +556,24 @@ func (t *TestCaseTemplate) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TestCaseTemplate) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseTemplate
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseTemplate(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseTemplate) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -487,6 +613,24 @@ func (t *TestCaseImplementation) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TestCaseImplementation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseImplementation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseImplementation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TestCaseImplementation) String() string {
@@ -536,6 +680,24 @@ func (t *TestCaseWithActualResultImplementation) GetExtraProperties() map[string
 	return t.extraProperties
 }
 
+func (t *TestCaseWithActualResultImplementation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseWithActualResultImplementation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseWithActualResultImplementation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseWithActualResultImplementation) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -575,6 +737,24 @@ func (v *VoidFunctionDefinition) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return v.extraProperties
+}
+
+func (v *VoidFunctionDefinition) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionDefinition
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionDefinition(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (v *VoidFunctionDefinition) String() string {
@@ -626,6 +806,24 @@ func (p *Parameter) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *Parameter) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Parameter
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = Parameter(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *Parameter) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -667,6 +865,24 @@ func (n *NonVoidFunctionDefinition) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NonVoidFunctionDefinition) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NonVoidFunctionDefinition
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NonVoidFunctionDefinition(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NonVoidFunctionDefinition) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -698,6 +914,24 @@ func (v *VoidFunctionSignature) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return v.extraProperties
+}
+
+func (v *VoidFunctionSignature) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionSignature
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionSignature(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (v *VoidFunctionSignature) String() string {
@@ -741,6 +975,24 @@ func (n *NonVoidFunctionSignature) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NonVoidFunctionSignature) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NonVoidFunctionSignature
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NonVoidFunctionSignature(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NonVoidFunctionSignature) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -782,6 +1034,24 @@ func (v *VoidFunctionSignatureThatTakesActualResult) GetExtraProperties() map[st
 	return v.extraProperties
 }
 
+func (v *VoidFunctionSignatureThatTakesActualResult) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionSignatureThatTakesActualResult
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionSignatureThatTakesActualResult(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (v *VoidFunctionSignatureThatTakesActualResult) String() string {
 	if len(v.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(v.rawJSON); err == nil {
@@ -820,6 +1090,24 @@ func (d *DeepEqualityCorrectnessCheck) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DeepEqualityCorrectnessCheck) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DeepEqualityCorrectnessCheck
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DeepEqualityCorrectnessCheck(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DeepEqualityCorrectnessCheck) String() string {
@@ -864,6 +1152,24 @@ func (v *VoidFunctionDefinitionThatTakesActualResult) GetExtraProperties() map[s
 	return v.extraProperties
 }
 
+func (v *VoidFunctionDefinitionThatTakesActualResult) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VoidFunctionDefinitionThatTakesActualResult
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VoidFunctionDefinitionThatTakesActualResult(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (v *VoidFunctionDefinitionThatTakesActualResult) String() string {
 	if len(v.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(v.rawJSON); err == nil {
@@ -895,6 +1201,24 @@ func (t *TestCaseImplementationDescription) GetExtraProperties() map[string]any 
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TestCaseImplementationDescription) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseImplementationDescription
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseImplementationDescription(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TestCaseImplementationDescription) String() string {
@@ -952,6 +1276,24 @@ func (t *TestCaseMetadata) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TestCaseMetadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TestCaseMetadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TestCaseMetadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TestCaseMetadata) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -983,6 +1325,24 @@ func (f *FunctionImplementationForMultipleLanguages) GetExtraProperties() map[st
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FunctionImplementationForMultipleLanguages) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FunctionImplementationForMultipleLanguages
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FunctionImplementationForMultipleLanguages(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FunctionImplementationForMultipleLanguages) String() string {
@@ -1024,6 +1384,24 @@ func (f *FunctionImplementation) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FunctionImplementation) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FunctionImplementation
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FunctionImplementation(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FunctionImplementation) String() string {
@@ -1073,6 +1451,24 @@ func (g *GeneratedFiles) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GeneratedFiles) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GeneratedFiles
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GeneratedFiles(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GeneratedFiles) String() string {
@@ -1138,6 +1534,24 @@ func (b *BasicCustomFiles) GetExtraProperties() map[string]any {
 	return b.extraProperties
 }
 
+func (b *BasicCustomFiles) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler BasicCustomFiles
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BasicCustomFiles(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (b *BasicCustomFiles) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -1169,6 +1583,24 @@ func (f *Files) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *Files) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Files
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Files(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *Files) String() string {
@@ -1228,6 +1660,24 @@ func (f *FileInfoV2) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *FileInfoV2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FileInfoV2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FileInfoV2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *FileInfoV2) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1267,6 +1717,24 @@ func (d *DefaultProvidedFile) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DefaultProvidedFile) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DefaultProvidedFile
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DefaultProvidedFile(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DefaultProvidedFile) String() string {
@@ -1309,6 +1777,24 @@ func (g *GetFunctionSignatureRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetFunctionSignatureRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetFunctionSignatureRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetFunctionSignatureRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetFunctionSignatureRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1340,6 +1826,24 @@ func (g *GetFunctionSignatureResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GetFunctionSignatureResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetFunctionSignatureResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetFunctionSignatureResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GetFunctionSignatureResponse) String() string {
@@ -1383,6 +1887,24 @@ func (g *GetBasicSolutionFileRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetBasicSolutionFileRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetBasicSolutionFileRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetBasicSolutionFileRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetBasicSolutionFileRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1414,6 +1936,24 @@ func (g *GetBasicSolutionFileResponse) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GetBasicSolutionFileResponse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetBasicSolutionFileResponse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetBasicSolutionFileResponse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GetBasicSolutionFileResponse) String() string {
@@ -1457,6 +1997,24 @@ func (g *GetGeneratedTestCaseFileRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetGeneratedTestCaseFileRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetGeneratedTestCaseFileRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetGeneratedTestCaseFileRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetGeneratedTestCaseFileRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1488,6 +2046,24 @@ func (g *GetGeneratedTestCaseTemplateFileRequest) GetExtraProperties() map[strin
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GetGeneratedTestCaseTemplateFileRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetGeneratedTestCaseTemplateFileRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetGeneratedTestCaseTemplateFileRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GetGeneratedTestCaseTemplateFileRequest) String() string {

--- a/seed/go-model/undiscriminated-unions/union.go
+++ b/seed/go-model/undiscriminated-unions/union.go
@@ -29,6 +29,24 @@ func (r *Request) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *Request) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Request
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = Request(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -60,6 +78,24 @@ func (t *TypeWithOptionalUnion) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TypeWithOptionalUnion) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TypeWithOptionalUnion
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TypeWithOptionalUnion(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TypeWithOptionalUnion) String() string {
@@ -146,6 +182,24 @@ func (n *NamedMetadata) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return n.extraProperties
+}
+
+func (n *NamedMetadata) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NamedMetadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NamedMetadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (n *NamedMetadata) String() string {

--- a/seed/go-model/unions/bigunion.go
+++ b/seed/go-model/unions/bigunion.go
@@ -66,6 +66,24 @@ func (n *NormalSweet) GetExtraProperties() map[string]any {
 	return n.extraProperties
 }
 
+func (n *NormalSweet) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler NormalSweet
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*n = NormalSweet(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *n)
+	if err != nil {
+		return err
+	}
+	n.extraProperties = extraProperties
+	n.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (n *NormalSweet) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -97,6 +115,24 @@ func (t *ThankfulFactor) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *ThankfulFactor) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ThankfulFactor
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = ThankfulFactor(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *ThankfulFactor) String() string {
@@ -132,6 +168,24 @@ func (j *JumboEnd) GetExtraProperties() map[string]any {
 	return j.extraProperties
 }
 
+func (j *JumboEnd) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler JumboEnd
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*j = JumboEnd(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *j)
+	if err != nil {
+		return err
+	}
+	j.extraProperties = extraProperties
+	j.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (j *JumboEnd) String() string {
 	if len(j.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(j.rawJSON); err == nil {
@@ -163,6 +217,24 @@ func (h *HastyPain) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return h.extraProperties
+}
+
+func (h *HastyPain) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler HastyPain
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HastyPain(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+	h.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (h *HastyPain) String() string {
@@ -198,6 +270,24 @@ func (m *MistySnow) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *MistySnow) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler MistySnow
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = MistySnow(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *MistySnow) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -229,6 +319,24 @@ func (d *DistinctFailure) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DistinctFailure) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DistinctFailure
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DistinctFailure(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DistinctFailure) String() string {
@@ -264,6 +372,24 @@ func (p *PracticalPrinciple) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *PracticalPrinciple) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler PracticalPrinciple
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = PracticalPrinciple(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *PracticalPrinciple) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -295,6 +421,24 @@ func (l *LimpingStep) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return l.extraProperties
+}
+
+func (l *LimpingStep) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler LimpingStep
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = LimpingStep(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+	l.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (l *LimpingStep) String() string {
@@ -330,6 +474,24 @@ func (v *VibrantExcitement) GetExtraProperties() map[string]any {
 	return v.extraProperties
 }
 
+func (v *VibrantExcitement) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler VibrantExcitement
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*v = VibrantExcitement(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *v)
+	if err != nil {
+		return err
+	}
+	v.extraProperties = extraProperties
+	v.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (v *VibrantExcitement) String() string {
 	if len(v.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(v.rawJSON); err == nil {
@@ -361,6 +523,24 @@ func (a *ActiveDiamond) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return a.extraProperties
+}
+
+func (a *ActiveDiamond) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ActiveDiamond
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = ActiveDiamond(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (a *ActiveDiamond) String() string {
@@ -396,6 +576,24 @@ func (p *PopularLimit) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *PopularLimit) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler PopularLimit
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = PopularLimit(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *PopularLimit) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -427,6 +625,24 @@ func (f *FalseMirror) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FalseMirror) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FalseMirror
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FalseMirror(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FalseMirror) String() string {
@@ -462,6 +678,24 @@ func (p *PrimaryBlock) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *PrimaryBlock) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler PrimaryBlock
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = PrimaryBlock(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *PrimaryBlock) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -493,6 +727,24 @@ func (r *RotatingRatio) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *RotatingRatio) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler RotatingRatio
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = RotatingRatio(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *RotatingRatio) String() string {
@@ -528,6 +780,24 @@ func (c *ColorfulCover) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *ColorfulCover) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ColorfulCover
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = ColorfulCover(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *ColorfulCover) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -559,6 +829,24 @@ func (d *DisloyalValue) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return d.extraProperties
+}
+
+func (d *DisloyalValue) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DisloyalValue
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DisloyalValue(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (d *DisloyalValue) String() string {
@@ -594,6 +882,24 @@ func (g *GruesomeCoach) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GruesomeCoach) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GruesomeCoach
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GruesomeCoach(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GruesomeCoach) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -625,6 +931,24 @@ func (t *TotalWork) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return t.extraProperties
+}
+
+func (t *TotalWork) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TotalWork
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TotalWork(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (t *TotalWork) String() string {
@@ -660,6 +984,24 @@ func (h *HarmoniousPlay) GetExtraProperties() map[string]any {
 	return h.extraProperties
 }
 
+func (h *HarmoniousPlay) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler HarmoniousPlay
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HarmoniousPlay(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+	h.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (h *HarmoniousPlay) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -691,6 +1033,24 @@ func (u *UniqueStress) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return u.extraProperties
+}
+
+func (u *UniqueStress) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UniqueStress
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UniqueStress(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (u *UniqueStress) String() string {
@@ -726,6 +1086,24 @@ func (u *UnwillingSmoke) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *UnwillingSmoke) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler UnwillingSmoke
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = UnwillingSmoke(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *UnwillingSmoke) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -757,6 +1135,24 @@ func (f *FrozenSleep) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return f.extraProperties
+}
+
+func (f *FrozenSleep) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FrozenSleep
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FrozenSleep(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (f *FrozenSleep) String() string {
@@ -792,6 +1188,24 @@ func (d *DiligentDeal) GetExtraProperties() map[string]any {
 	return d.extraProperties
 }
 
+func (d *DiligentDeal) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler DiligentDeal
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DiligentDeal(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+	d.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (d *DiligentDeal) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -823,6 +1237,24 @@ func (a *AttractiveScript) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return a.extraProperties
+}
+
+func (a *AttractiveScript) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler AttractiveScript
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*a = AttractiveScript(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *a)
+	if err != nil {
+		return err
+	}
+	a.extraProperties = extraProperties
+	a.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (a *AttractiveScript) String() string {
@@ -858,6 +1290,24 @@ func (h *HoarseMouse) GetExtraProperties() map[string]any {
 	return h.extraProperties
 }
 
+func (h *HoarseMouse) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler HoarseMouse
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HoarseMouse(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+	h.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (h *HoarseMouse) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -889,6 +1339,24 @@ func (c *CircularCard) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return c.extraProperties
+}
+
+func (c *CircularCard) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler CircularCard
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = CircularCard(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (c *CircularCard) String() string {
@@ -924,6 +1392,24 @@ func (p *PotableBad) GetExtraProperties() map[string]any {
 	return p.extraProperties
 }
 
+func (p *PotableBad) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler PotableBad
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*p = PotableBad(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *p)
+	if err != nil {
+		return err
+	}
+	p.extraProperties = extraProperties
+	p.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (p *PotableBad) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -957,6 +1443,24 @@ func (t *TriangularRepair) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *TriangularRepair) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler TriangularRepair
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = TriangularRepair(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *TriangularRepair) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -988,6 +1492,24 @@ func (g *GaseousRoad) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return g.extraProperties
+}
+
+func (g *GaseousRoad) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GaseousRoad
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GaseousRoad(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (g *GaseousRoad) String() string {

--- a/seed/go-model/unions/types.go
+++ b/seed/go-model/unions/types.go
@@ -121,6 +121,24 @@ func (f *Foo) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *Foo) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Foo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = Foo(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *Foo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -162,6 +180,24 @@ func (f *FooExtended) GetExtraProperties() map[string]any {
 	return f.extraProperties
 }
 
+func (f *FooExtended) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler FooExtended
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = FooExtended(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *f)
+	if err != nil {
+		return err
+	}
+	f.extraProperties = extraProperties
+	f.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (f *FooExtended) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -193,6 +229,24 @@ func (b *Bar) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return b.extraProperties
+}
+
+func (b *Bar) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Bar
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = Bar(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+	b.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (b *Bar) String() string {

--- a/seed/go-model/unions/union.go
+++ b/seed/go-model/unions/union.go
@@ -29,6 +29,24 @@ func (g *GetShapeRequest) GetExtraProperties() map[string]any {
 	return g.extraProperties
 }
 
+func (g *GetShapeRequest) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler GetShapeRequest
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GetShapeRequest(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (g *GetShapeRequest) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -69,6 +87,24 @@ func (c *Circle) GetExtraProperties() map[string]any {
 	return c.extraProperties
 }
 
+func (c *Circle) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Circle
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = Circle(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *c)
+	if err != nil {
+		return err
+	}
+	c.extraProperties = extraProperties
+	c.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (c *Circle) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -100,6 +136,24 @@ func (s *Square) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *Square) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Square
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = Square(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *Square) String() string {

--- a/seed/go-model/unknown/unknown.go
+++ b/seed/go-model/unknown/unknown.go
@@ -31,6 +31,24 @@ func (m *MyObject) GetExtraProperties() map[string]any {
 	return m.extraProperties
 }
 
+func (m *MyObject) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler MyObject
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = MyObject(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+	m.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (m *MyObject) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {

--- a/seed/go-model/validation/types.go
+++ b/seed/go-model/validation/types.go
@@ -89,6 +89,24 @@ func (t *Type) GetExtraProperties() map[string]any {
 	return t.extraProperties
 }
 
+func (t *Type) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler Type
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = Type(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *t)
+	if err != nil {
+		return err
+	}
+	t.extraProperties = extraProperties
+	t.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (t *Type) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {

--- a/seed/go-model/version-no-default/user.go
+++ b/seed/go-model/version-no-default/user.go
@@ -39,6 +39,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/version/user.go
+++ b/seed/go-model/version/user.go
@@ -39,6 +39,24 @@ func (u *User) GetExtraProperties() map[string]any {
 	return u.extraProperties
 }
 
+func (u *User) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler User
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*u = User(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *u)
+	if err != nil {
+		return err
+	}
+	u.extraProperties = extraProperties
+	u.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {

--- a/seed/go-model/websocket/realtime.go
+++ b/seed/go-model/websocket/realtime.go
@@ -37,6 +37,24 @@ func (s *SendEvent) GetExtraProperties() map[string]any {
 	return s.extraProperties
 }
 
+func (s *SendEvent) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SendEvent
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SendEvent(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (s *SendEvent) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -76,6 +94,24 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *SendSnakeCase) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SendSnakeCase
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SendSnakeCase(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *SendSnakeCase) String() string {
@@ -119,6 +155,24 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ReceiveEvent
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = ReceiveEvent(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *ReceiveEvent) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -160,6 +214,24 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ReceiveSnakeCase
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = ReceiveSnakeCase(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -199,6 +271,24 @@ func (s *SendEvent2) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return s.extraProperties
+}
+
+func (s *SendEvent2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler SendEvent2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = SendEvent2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *s)
+	if err != nil {
+		return err
+	}
+	s.extraProperties = extraProperties
+	s.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (s *SendEvent2) String() string {
@@ -250,6 +340,24 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]any {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ReceiveEvent2
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = ReceiveEvent2(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
+}
+
 func (r *ReceiveEvent2) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -281,6 +389,24 @@ func (r *ReceiveEvent3) GetExtraProperties() map[string]any {
 		return nil
 	}
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) UnmarshalJSON(
+	data []byte,
+) error {
+	type unmarshaler ReceiveEvent3
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*r = ReceiveEvent3(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *r)
+	if err != nil {
+		return err
+	}
+	r.extraProperties = extraProperties
+	r.rawJSON = json.RawMessage(data)
+	return nil
 }
 
 func (r *ReceiveEvent3) String() string {


### PR DESCRIPTION
This adds the custom `UnmarshalJSON` method implementation for all objects that need it. This includes objects that define any of the following:

1. Date
2. DateTime
3. Literals
4. Additional properties

With this, object generation matches the original Go implementation. The same logic needs to be carried over to the generated request wrapper types, so a lot of the helper functions defined in the `ObjectGenerator` will likely need to be moved into a shared abstraction.