### PR TITLE
fix(csharp): Use fullly qualified namespace for System.IO.Stream

### DIFF
--- a/generators/csharp/sdk/src/endpoint/utils/getEndpointReturnType.ts
+++ b/generators/csharp/sdk/src/endpoint/utils/getEndpointReturnType.ts
@@ -24,7 +24,8 @@ export function getEndpointReturnType({
             csharp.Type.reference(
                 csharp.classReference({
                     name: "Stream",
-                    namespace: "System.IO"
+                    namespace: "System.IO",
+                    fullyQualified: true
                 })
             ),
         json: (reference) => {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.3
+  changelogEntry:
+    - type: fix
+      summary: uses fully qualified class name `System.IO.Stream` for downloads
+  createdAt: '2025-07-29'
+  irVersion: 58
 - version: 2.1.2
   changelogEntry:
     - type: feat
@@ -36,7 +42,7 @@
         }
         ```
       
-  createdAt: '2025-07-23'
+  createdAt: '2025-07-29'
   irVersion: 58
 - version: 2.1.1
   changelogEntry:

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
@@ -49,7 +49,7 @@ public partial class ServiceClient
         }
     }
 
-    public async Task<Stream> DownloadFileAsync(
+    public async Task<System.IO.Stream> DownloadFileAsync(
         RequestOptions? options = null,
         CancellationToken cancellationToken = default
     )

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
@@ -14,7 +14,7 @@ public partial class ServiceClient
         _client = client;
     }
 
-    public async Task<Stream> GetAsync(
+    public async Task<System.IO.Stream> GetAsync(
         RequestOptions? options = null,
         CancellationToken cancellationToken = default
     )


### PR DESCRIPTION
Use fully qualified namespace for `System.IO.Stream` in file download (avoids a conflict with `Stream` in a customer sdk)

## Description
Quick fix to use a fully qualified namespace for `System.IO.Stream` 
