### PR TITLE
fix(cli): support self hosted snippet generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -12,7 +12,7 @@
         ```
       type: feat
   irVersion: 58
-  createdAt: "2025-07-29"
+  createdAt: "2025-07-30"
   version: 0.65.37
 
 - changelogEntry:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,22 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add support for snippet.json output as part of self hosted SDK generation. The following config in 
+        `generators.yml` will generate a `snippet.json` file in the relevant director: 
+        ```
+        groups: 
+          ts-sdk: 
+            - name: fernapi/fern-typescript-sdk
+              snippets: 
+                path: ../snippets.json
+        ```
+      type: feat
+  irVersion: 58
+  createdAt: "2025-07-29"
+  version: 0.65.37
+
+- changelogEntry:
+    - summary: |
         Add support for multiple content types on requestBody
       type: feat
   irVersion: 58

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -3,13 +3,12 @@ import os from "os";
 import path from "path";
 import tmp from "tmp-promise";
 
-import { FernToken } from "@fern-api/auth";
-import { getAccessToken } from "@fern-api/auth";
+import { FernToken, getAccessToken } from "@fern-api/auth";
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { createVenusService } from "@fern-api/core";
 import { ContainerRunner, replaceEnvVariables } from "@fern-api/core-utils";
-import { RelativeFilePath, join } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, RelativeFilePath, join } from "@fern-api/fs-utils";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { FernIr } from "@fern-api/ir-sdk";
 import { TaskContext } from "@fern-api/task-context";
@@ -112,13 +111,22 @@ export async function runLocalGenerationForWorkspace({
                         RelativeFilePath.of(generatorInvocation.language ?? generatorInvocation.name)
                     );
 
+                const absolutePathToLocalSnippetJSON = generatorInvocation.raw?.snippets?.path != null
+                    ? AbsoluteFilePath.of(
+                        join(
+                            workspace.absoluteFilePath,
+                            RelativeFilePath.of(generatorInvocation.raw.snippets.path)
+                        )
+                    )
+                    : undefined;
+
                 await writeFilesToDiskAndRunGenerator({
                     organization: projectConfig.organization,
                     absolutePathToFernConfig: projectConfig._absolutePath,
                     workspace: fernWorkspace,
                     generatorInvocation,
                     absolutePathToLocalOutput,
-                    absolutePathToLocalSnippetJSON: undefined,
+                    absolutePathToLocalSnippetJSON,
                     absolutePathToLocalSnippetTemplateJSON: undefined,
                     audiences: generatorGroup.audiences,
                     workspaceTempDir,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -111,14 +111,15 @@ export async function runLocalGenerationForWorkspace({
                         RelativeFilePath.of(generatorInvocation.language ?? generatorInvocation.name)
                     );
 
-                const absolutePathToLocalSnippetJSON = generatorInvocation.raw?.snippets?.path != null
-                    ? AbsoluteFilePath.of(
-                        join(
-                            workspace.absoluteFilePath,
-                            RelativeFilePath.of(generatorInvocation.raw.snippets.path)
-                        )
-                    )
-                    : undefined;
+                const absolutePathToLocalSnippetJSON =
+                    generatorInvocation.raw?.snippets?.path != null
+                        ? AbsoluteFilePath.of(
+                              join(
+                                  workspace.absoluteFilePath,
+                                  RelativeFilePath.of(generatorInvocation.raw.snippets.path)
+                              )
+                          )
+                        : undefined;
 
                 await writeFilesToDiskAndRunGenerator({
                     organization: projectConfig.organization,


### PR DESCRIPTION
Add support for snippet.json output as part of self hosted SDK generation. The following config in 
`generators.yml` will generate a `snippet.json` file in the relevant director: 
```
groups: 
  ts-sdk: 
    - name: fernapi/fern-typescript-sdk
      snippets: 
        path: ../snippets.json
```