### PR TITLE
fix(csharp): Ensure that query parameters are properly URI escaped

### DIFF
--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -208,7 +208,7 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value => $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}")
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +217,7 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current += $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.4
+  changelogEntry:
+    - type: fix
+      summary: ensure that query parameters are Uri encodeded in RawClient.cs
+  createdAt: '2025-07-31'
+  irVersion: 58
 - version: 2.1.3
   changelogEntry:
     - type: fix

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/auth-environment-variables/src/SeedAuthEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/auth-environment-variables/src/SeedAuthEnvironmentVariables/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/csharp-property-access/src/SeedCsharpAccess/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-property-access/src/SeedCsharpAccess/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/custom-auth/src/SeedCustomAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/custom-auth/src/SeedCustomAuth/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/extra-properties/no-additional-properties/src/SeedExtraProperties/Core/RawClient.cs
+++ b/seed/csharp-sdk/extra-properties/no-additional-properties/src/SeedExtraProperties/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/extra-properties/no-custom-config/src/SeedExtraProperties/Core/RawClient.cs
+++ b/seed/csharp-sdk/extra-properties/no-custom-config/src/SeedExtraProperties/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/literal/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/src/SeedLiteral/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/nullable/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/src/SeedNullable/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
@@ -212,7 +212,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -221,7 +223,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/request-parameters/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/src/SeedRequestParameters/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/streaming/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/src/SeedStreaming/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -210,7 +210,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -219,7 +221,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;

--- a/seed/csharp-sdk/websocket/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/src/SeedWebsocket/Core/RawClient.cs
@@ -208,7 +208,9 @@ internal partial class RawClient(ClientOptions clientOptions)
                 {
                     var items = collection
                         .Cast<object>()
-                        .Select(value => $"{queryItem.Key}={value}")
+                        .Select(value =>
+                            $"{Uri.EscapeDataString(queryItem.Key)}={Uri.EscapeDataString(value.ToString())}"
+                        )
                         .ToList();
                     if (items.Any())
                     {
@@ -217,7 +219,8 @@ internal partial class RawClient(ClientOptions clientOptions)
                 }
                 else
                 {
-                    current += $"{queryItem.Key}={queryItem.Value}&";
+                    current +=
+                        $"{Uri.EscapeUriString(queryItem.Key)}={Uri.EscapeUriString(queryItem.Value)}&";
                 }
 
                 return current;


### PR DESCRIPTION
## Description
Changes `RawClient.template.ts` to ensure that all query parameters (keys and values) are encoded with `Uri.EscapeDataString`

This will allow query parameter values to contain characters like `+ % [ ] @ ( )` ... etc to be used.

## Changes Made
- `RawClient.template.ts`  - `BuildUrl` has been updated to escape the keys and values

## Testing
<!-- Describe how you tested these changes -->
- [x] ran `seed test --generator csharp-sdk` - regenerates the fixtures and `RawClient.cs` is updated in each output

