### PR TITLE
fix(cli): mount snippet file to Docker for local generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix snippet generation for local file system output mode. Snippets configured with `snippets.path` 
+        in generators.yml were not being generated when using `--local` flag due to missing Docker volume 
+        mounting for the downloadFiles output mode.
+      type: fix
+  irVersion: 58
+  createdAt: "2025-07-31"
+  version: 0.65.39
+
+- changelogEntry:
+    - summary: |
         IR parser: Extended the logic for flattening properties in oneOf schemas to anyOf schemas as well
       type: feat
   irVersion: 58

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
@@ -129,12 +129,21 @@ export function getGeneratorConfig({
             };
         },
         downloadFiles: () => {
-            return {
+            const outputConfig: FernGeneratorExec.GeneratorOutputConfig = {
                 mode: FernGeneratorExec.OutputMode.downloadFiles(),
                 path: DOCKER_CODEGEN_OUTPUT_DIRECTORY,
-                snippetFilepath: DOCKER_PATH_TO_SNIPPET,
                 publishingMetadata: generatorInvocation.publishMetadata
             };
+            if (absolutePathToSnippet !== undefined) {
+                console.log(`[DEBUG] Adding snippet bind: ${absolutePathToSnippet}:${DOCKER_PATH_TO_SNIPPET}`);
+                binds.push(`${absolutePathToSnippet}:${DOCKER_PATH_TO_SNIPPET}`);
+                outputConfig.snippetFilepath = DOCKER_PATH_TO_SNIPPET;
+            }
+            if (absolutePathToSnippetTemplates !== undefined) {
+                binds.push(`${absolutePathToSnippetTemplates}:${DOCKER_PATH_TO_SNIPPET_TEMPLATES}`);
+                outputConfig.snippetTemplateFilepath = DOCKER_PATH_TO_SNIPPET_TEMPLATES;
+            }
+            return outputConfig;
         },
         github: (value) => {
             const outputConfig: FernGeneratorExec.GeneratorOutputConfig = {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
@@ -135,7 +135,6 @@ export function getGeneratorConfig({
                 publishingMetadata: generatorInvocation.publishMetadata
             };
             if (absolutePathToSnippet !== undefined) {
-                console.log(`[DEBUG] Adding snippet bind: ${absolutePathToSnippet}:${DOCKER_PATH_TO_SNIPPET}`);
                 binds.push(`${absolutePathToSnippet}:${DOCKER_PATH_TO_SNIPPET}`);
                 outputConfig.snippetFilepath = DOCKER_PATH_TO_SNIPPET;
             }


### PR DESCRIPTION
## Description
Snippets was empty when generating with `--local` flag. 

## Changes Made
- Use filepath generated from this PR https://github.com/fern-api/fern/pull/8472 and mount it to docker. 

## Testing
<!-- Describe how you tested these changes -->
 - Locally tested cli with a generators.yml given from Intuit. Snippets.json were succesfully genreated! Artifcats provided on slack. 

