### PR TITLE
feat(swift): extended properties in structs

### DIFF
--- a/generators/swift/model/src/object/ObjectGenerator.ts
+++ b/generators/swift/model/src/object/ObjectGenerator.ts
@@ -10,7 +10,7 @@ export class ObjectGenerator {
     private readonly name: string;
     private readonly directory: RelativeFilePath;
     private readonly properties: (ObjectProperty | InlinedRequestBodyProperty)[];
-    private readonly extendedProperties?: ObjectProperty[];
+    private readonly extendedProperties: ObjectProperty[];
 
     public constructor(
         name: string,
@@ -21,7 +21,7 @@ export class ObjectGenerator {
         this.name = name;
         this.directory = directory;
         this.properties = properties;
-        this.extendedProperties = extendedProperties;
+        this.extendedProperties = extendedProperties ?? [];
     }
 
     private get filename(): string {
@@ -41,7 +41,7 @@ export class ObjectGenerator {
         return new StructGenerator({
             name: this.name,
             constantPropertyDefinitions: [],
-            dataPropertyDefinitions: this.properties.map((p) => ({
+            dataPropertyDefinitions: [...this.extendedProperties, ...this.properties].map((p) => ({
                 unsafeName: p.name.name.camelCase.unsafeName,
                 rawName: p.name.wireValue,
                 type: getSwiftTypeForTypeReference(p.valueType)

--- a/generators/swift/model/src/union/DiscriminatedUnionGenerator.ts
+++ b/generators/swift/model/src/union/DiscriminatedUnionGenerator.ts
@@ -288,7 +288,7 @@ export class DiscriminatedUnionGenerator {
         return typeDeclaration.shape._visit({
             alias: () => [],
             enum: () => [],
-            object: (otd) => otd.properties,
+            object: (otd) => [...(otd.extendedProperties ?? []), ...otd.properties],
             union: () => [],
             undiscriminatedUnion: () => [],
             _other: () => []

--- a/generators/swift/sdk/src/generators/client/util/__test__/format-endpoint-path-for-swift.test.ts
+++ b/generators/swift/sdk/src/generators/client/util/__test__/format-endpoint-path-for-swift.test.ts
@@ -4,8 +4,6 @@ import { resolve } from "node:path";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createSampleIr } from "@fern-api/test-utils";
 
-import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
-
 import { formatEndpointPathForSwift } from "../format-endpoint-path-for-swift";
 
 const pathToTestDefinitions = resolve(__dirname, "../../../../../../../../test-definitions/fern/apis");
@@ -13,7 +11,7 @@ const testDefinitionNames = readdirSync(pathToTestDefinitions, { withFileTypes: 
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
 
-async function getIRForTestDefinition(testDefinitionName: string): Promise<IntermediateRepresentation> {
+async function getIRForTestDefinition(testDefinitionName: string) {
     const absolutePathToWorkspace = AbsoluteFilePath.of(resolve(pathToTestDefinitions, testDefinitionName));
     return await createSampleIr(absolutePathToWorkspace);
 }

--- a/seed/swift-sdk/alias-extends/Sources/Requests/InlinedChildRequest.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Requests/InlinedChildRequest.swift
@@ -1,17 +1,21 @@
 public struct InlinedChildRequest: Codable, Hashable, Sendable {
+    public let parent: String
     public let child: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        parent: String,
         child: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.parent = parent
         self.child = child
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.parent = try container.decode(String.self, forKey: .parent)
         self.child = try container.decode(String.self, forKey: .child)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +23,12 @@ public struct InlinedChildRequest: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.parent, forKey: .parent)
         try container.encode(self.child, forKey: .child)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case parent
         case child
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Schemas/Child.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Schemas/Child.swift
@@ -1,17 +1,21 @@
 public struct Child: Codable, Hashable, Sendable {
+    public let parent: String
     public let child: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        parent: String,
         child: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.parent = parent
         self.child = child
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.parent = try container.decode(String.self, forKey: .parent)
         self.child = try container.decode(String.self, forKey: .child)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +23,12 @@ public struct Child: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.parent, forKey: .parent)
         try container.encode(self.child, forKey: .child)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case parent
         case child
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/A.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/A.swift
@@ -1,17 +1,28 @@
 public struct A: Codable, Hashable, Sendable {
+    public let s: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        s: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.s = s
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
-        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.s = try container.decode(String.self, forKey: .s)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.s, forKey: .s)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case s
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/Acai.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/Acai.swift
@@ -1,17 +1,28 @@
 public struct Acai: Codable, Hashable, Sendable {
+    public let animal: Animal
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        animal: Animal,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.animal = animal
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
-        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.animal = try container.decode(Animal.self, forKey: .animal)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.animal, forKey: .animal)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case animal
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Schemas/A.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/A.swift
@@ -1,17 +1,28 @@
 public struct A: Codable, Hashable, Sendable {
+    public let s: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        s: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.s = s
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
-        self.additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.s = try container.decode(String.self, forKey: .s)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 
     public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.s, forKey: .s)
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case s
     }
 }

--- a/seed/swift-sdk/examples/Sources/Schemas/ExtendedMovie.swift
+++ b/seed/swift-sdk/examples/Sources/Schemas/ExtendedMovie.swift
@@ -1,17 +1,57 @@
 public struct ExtendedMovie: Codable, Hashable, Sendable {
+    public let id: MovieId
+    public let prequel: MovieId?
+    public let title: String
+    public let from: String
+    public let rating: Double
+    public let type: JSONValue
+    public let tag: Tag
+    public let book: String?
+    public let metadata: [String: JSONValue]
+    public let revenue: Int64
     public let cast: [String]
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        id: MovieId,
+        prequel: MovieId? = nil,
+        title: String,
+        from: String,
+        rating: Double,
+        type: JSONValue,
+        tag: Tag,
+        book: String? = nil,
+        metadata: [String: JSONValue],
+        revenue: Int64,
         cast: [String],
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.id = id
+        self.prequel = prequel
+        self.title = title
+        self.from = from
+        self.rating = rating
+        self.type = type
+        self.tag = tag
+        self.book = book
+        self.metadata = metadata
+        self.revenue = revenue
         self.cast = cast
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(MovieId.self, forKey: .id)
+        self.prequel = try container.decodeIfPresent(MovieId.self, forKey: .prequel)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.from = try container.decode(String.self, forKey: .from)
+        self.rating = try container.decode(Double.self, forKey: .rating)
+        self.type = try container.decode(JSONValue.self, forKey: .type)
+        self.tag = try container.decode(Tag.self, forKey: .tag)
+        self.book = try container.decodeIfPresent(String.self, forKey: .book)
+        self.metadata = try container.decode([String: JSONValue].self, forKey: .metadata)
+        self.revenue = try container.decode(Int64.self, forKey: .revenue)
         self.cast = try container.decode([String].self, forKey: .cast)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +59,30 @@ public struct ExtendedMovie: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encodeIfPresent(self.prequel, forKey: .prequel)
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.from, forKey: .from)
+        try container.encode(self.rating, forKey: .rating)
+        try container.encode(self.type, forKey: .type)
+        try container.encode(self.tag, forKey: .tag)
+        try container.encodeIfPresent(self.book, forKey: .book)
+        try container.encode(self.metadata, forKey: .metadata)
+        try container.encode(self.revenue, forKey: .revenue)
         try container.encode(self.cast, forKey: .cast)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case prequel
+        case title
+        case from
+        case rating
+        case type
+        case tag
+        case book
+        case metadata
+        case revenue
         case cast
     }
 }

--- a/seed/swift-sdk/extends/Sources/Requests/Inlined.swift
+++ b/seed/swift-sdk/extends/Sources/Requests/Inlined.swift
@@ -1,17 +1,25 @@
 public struct Inlined: Codable, Hashable, Sendable {
+    public let name: String
+    public let docs: String
     public let unique: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        name: String,
+        docs: String,
         unique: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.name = name
+        self.docs = docs
         self.unique = unique
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.docs = try container.decode(String.self, forKey: .docs)
         self.unique = try container.decode(String.self, forKey: .unique)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct Inlined: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.docs, forKey: .docs)
         try container.encode(self.unique, forKey: .unique)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case name
+        case docs
         case unique
     }
 }

--- a/seed/swift-sdk/extends/Sources/Schemas/ExampleType.swift
+++ b/seed/swift-sdk/extends/Sources/Schemas/ExampleType.swift
@@ -1,17 +1,21 @@
 public struct ExampleType: Codable, Hashable, Sendable {
+    public let docs: String
     public let name: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        docs: String,
         name: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.docs = docs
         self.name = name
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.docs = try container.decode(String.self, forKey: .docs)
         self.name = try container.decode(String.self, forKey: .name)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +23,12 @@ public struct ExampleType: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.docs, forKey: .docs)
         try container.encode(self.name, forKey: .name)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case docs
         case name
     }
 }

--- a/seed/swift-sdk/extends/Sources/Schemas/Json.swift
+++ b/seed/swift-sdk/extends/Sources/Schemas/Json.swift
@@ -1,17 +1,21 @@
 public struct Json: Codable, Hashable, Sendable {
+    public let docs: String
     public let raw: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        docs: String,
         raw: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.docs = docs
         self.raw = raw
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.docs = try container.decode(String.self, forKey: .docs)
         self.raw = try container.decode(String.self, forKey: .raw)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +23,12 @@ public struct Json: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.docs, forKey: .docs)
         try container.encode(self.raw, forKey: .raw)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case docs
         case raw
     }
 }

--- a/seed/swift-sdk/extends/Sources/Schemas/NestedType.swift
+++ b/seed/swift-sdk/extends/Sources/Schemas/NestedType.swift
@@ -1,17 +1,25 @@
 public struct NestedType: Codable, Hashable, Sendable {
+    public let raw: String
+    public let docs: String
     public let name: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        raw: String,
+        docs: String,
         name: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.raw = raw
+        self.docs = docs
         self.name = name
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.raw = try container.decode(String.self, forKey: .raw)
+        self.docs = try container.decode(String.self, forKey: .docs)
         self.name = try container.decode(String.self, forKey: .name)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct NestedType: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.raw, forKey: .raw)
+        try container.encode(self.docs, forKey: .docs)
         try container.encode(self.name, forKey: .name)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case raw
+        case docs
         case name
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Schemas/ListUsersExtendedOptionalListResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Schemas/ListUsersExtendedOptionalListResponse.swift
@@ -1,17 +1,25 @@
 public struct ListUsersExtendedOptionalListResponse: Codable, Hashable, Sendable {
+    public let data: UserOptionalListContainer
+    public let next: UUID?
     public let totalCount: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        data: UserOptionalListContainer,
+        next: UUID? = nil,
         totalCount: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.data = data
+        self.next = next
         self.totalCount = totalCount
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode(UserOptionalListContainer.self, forKey: .data)
+        self.next = try container.decodeIfPresent(UUID.self, forKey: .next)
         self.totalCount = try container.decode(Int.self, forKey: .totalCount)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct ListUsersExtendedOptionalListResponse: Codable, Hashable, Sendable
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.data, forKey: .data)
+        try container.encodeIfPresent(self.next, forKey: .next)
         try container.encode(self.totalCount, forKey: .totalCount)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case data
+        case next
         case totalCount = "total_count"
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Schemas/ListUsersExtendedResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Schemas/ListUsersExtendedResponse.swift
@@ -1,17 +1,25 @@
 public struct ListUsersExtendedResponse: Codable, Hashable, Sendable {
+    public let data: UserListContainer
+    public let next: UUID?
     public let totalCount: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        data: UserListContainer,
+        next: UUID? = nil,
         totalCount: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.data = data
+        self.next = next
         self.totalCount = totalCount
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode(UserListContainer.self, forKey: .data)
+        self.next = try container.decodeIfPresent(UUID.self, forKey: .next)
         self.totalCount = try container.decode(Int.self, forKey: .totalCount)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct ListUsersExtendedResponse: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.data, forKey: .data)
+        try container.encodeIfPresent(self.next, forKey: .next)
         try container.encode(self.totalCount, forKey: .totalCount)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case data
+        case next
         case totalCount = "total_count"
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Schemas/ListUsersExtendedOptionalListResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Schemas/ListUsersExtendedOptionalListResponse.swift
@@ -1,17 +1,25 @@
 public struct ListUsersExtendedOptionalListResponse: Codable, Hashable, Sendable {
+    public let data: UserOptionalListContainer
+    public let next: UUID?
     public let totalCount: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        data: UserOptionalListContainer,
+        next: UUID? = nil,
         totalCount: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.data = data
+        self.next = next
         self.totalCount = totalCount
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode(UserOptionalListContainer.self, forKey: .data)
+        self.next = try container.decodeIfPresent(UUID.self, forKey: .next)
         self.totalCount = try container.decode(Int.self, forKey: .totalCount)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct ListUsersExtendedOptionalListResponse: Codable, Hashable, Sendable
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.data, forKey: .data)
+        try container.encodeIfPresent(self.next, forKey: .next)
         try container.encode(self.totalCount, forKey: .totalCount)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case data
+        case next
         case totalCount = "total_count"
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Schemas/ListUsersExtendedResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Schemas/ListUsersExtendedResponse.swift
@@ -1,17 +1,25 @@
 public struct ListUsersExtendedResponse: Codable, Hashable, Sendable {
+    public let data: UserListContainer
+    public let next: UUID?
     public let totalCount: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        data: UserListContainer,
+        next: UUID? = nil,
         totalCount: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.data = data
+        self.next = next
         self.totalCount = totalCount
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode(UserListContainer.self, forKey: .data)
+        self.next = try container.decodeIfPresent(UUID.self, forKey: .next)
         self.totalCount = try container.decode(Int.self, forKey: .totalCount)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct ListUsersExtendedResponse: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.data, forKey: .data)
+        try container.encodeIfPresent(self.next, forKey: .next)
         try container.encode(self.totalCount, forKey: .totalCount)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case data
+        case next
         case totalCount = "total_count"
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Schemas/ListUsersExtendedOptionalListResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Schemas/ListUsersExtendedOptionalListResponse.swift
@@ -1,17 +1,25 @@
 public struct ListUsersExtendedOptionalListResponse: Codable, Hashable, Sendable {
+    public let data: UserOptionalListContainer
+    public let next: UUID?
     public let totalCount: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        data: UserOptionalListContainer,
+        next: UUID? = nil,
         totalCount: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.data = data
+        self.next = next
         self.totalCount = totalCount
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode(UserOptionalListContainer.self, forKey: .data)
+        self.next = try container.decodeIfPresent(UUID.self, forKey: .next)
         self.totalCount = try container.decode(Int.self, forKey: .totalCount)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct ListUsersExtendedOptionalListResponse: Codable, Hashable, Sendable
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.data, forKey: .data)
+        try container.encodeIfPresent(self.next, forKey: .next)
         try container.encode(self.totalCount, forKey: .totalCount)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case data
+        case next
         case totalCount = "total_count"
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Schemas/ListUsersExtendedResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Schemas/ListUsersExtendedResponse.swift
@@ -1,17 +1,25 @@
 public struct ListUsersExtendedResponse: Codable, Hashable, Sendable {
+    public let data: UserListContainer
+    public let next: UUID?
     public let totalCount: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        data: UserListContainer,
+        next: UUID? = nil,
         totalCount: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.data = data
+        self.next = next
         self.totalCount = totalCount
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode(UserListContainer.self, forKey: .data)
+        self.next = try container.decodeIfPresent(UUID.self, forKey: .next)
         self.totalCount = try container.decode(Int.self, forKey: .totalCount)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct ListUsersExtendedResponse: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.data, forKey: .data)
+        try container.encodeIfPresent(self.next, forKey: .next)
         try container.encode(self.totalCount, forKey: .totalCount)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case data
+        case next
         case totalCount = "total_count"
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Schemas/Response.swift
+++ b/seed/swift-sdk/response-property/Sources/Schemas/Response.swift
@@ -1,17 +1,25 @@
 public struct Response: Codable, Hashable, Sendable {
+    public let metadata: [String: String]
+    public let docs: String
     public let data: Movie
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        metadata: [String: String],
+        docs: String,
         data: Movie,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.metadata = metadata
+        self.docs = docs
         self.data = data
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.metadata = try container.decode([String: String].self, forKey: .metadata)
+        self.docs = try container.decode(String.self, forKey: .docs)
         self.data = try container.decode(Movie.self, forKey: .data)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +27,14 @@ public struct Response: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.metadata, forKey: .metadata)
+        try container.encode(self.docs, forKey: .docs)
         try container.encode(self.data, forKey: .data)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case metadata
+        case docs
         case data
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Schemas/Account.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Schemas/Account.swift
@@ -1,4 +1,7 @@
 public struct Account: Codable, Hashable, Sendable {
+    public let id: String
+    public let relatedResources: [ResourceList]
+    public let memo: Memo
     public let resourceType: JSONValue
     public let name: String
     public let patient: Patient?
@@ -6,12 +9,18 @@ public struct Account: Codable, Hashable, Sendable {
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        id: String,
+        relatedResources: [ResourceList],
+        memo: Memo,
         resourceType: JSONValue,
         name: String,
         patient: Patient? = nil,
         practitioner: Practitioner? = nil,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.id = id
+        self.relatedResources = relatedResources
+        self.memo = memo
         self.resourceType = resourceType
         self.name = name
         self.patient = patient
@@ -21,6 +30,9 @@ public struct Account: Codable, Hashable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.relatedResources = try container.decode([ResourceList].self, forKey: .relatedResources)
+        self.memo = try container.decode(Memo.self, forKey: .memo)
         self.resourceType = try container.decode(JSONValue.self, forKey: .resourceType)
         self.name = try container.decode(String.self, forKey: .name)
         self.patient = try container.decodeIfPresent(Patient.self, forKey: .patient)
@@ -31,6 +43,9 @@ public struct Account: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.relatedResources, forKey: .relatedResources)
+        try container.encode(self.memo, forKey: .memo)
         try container.encode(self.resourceType, forKey: .resourceType)
         try container.encode(self.name, forKey: .name)
         try container.encodeIfPresent(self.patient, forKey: .patient)
@@ -38,6 +53,9 @@ public struct Account: Codable, Hashable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case relatedResources = "related_resources"
+        case memo
         case resourceType = "resource_type"
         case name
         case patient

--- a/seed/swift-sdk/simple-fhir/Sources/Schemas/Patient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Schemas/Patient.swift
@@ -1,15 +1,24 @@
 public struct Patient: Codable, Hashable, Sendable {
+    public let id: String
+    public let relatedResources: [ResourceList]
+    public let memo: Memo
     public let resourceType: JSONValue
     public let name: String
     public let scripts: [Script]
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        id: String,
+        relatedResources: [ResourceList],
+        memo: Memo,
         resourceType: JSONValue,
         name: String,
         scripts: [Script],
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.id = id
+        self.relatedResources = relatedResources
+        self.memo = memo
         self.resourceType = resourceType
         self.name = name
         self.scripts = scripts
@@ -18,6 +27,9 @@ public struct Patient: Codable, Hashable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.relatedResources = try container.decode([ResourceList].self, forKey: .relatedResources)
+        self.memo = try container.decode(Memo.self, forKey: .memo)
         self.resourceType = try container.decode(JSONValue.self, forKey: .resourceType)
         self.name = try container.decode(String.self, forKey: .name)
         self.scripts = try container.decode([Script].self, forKey: .scripts)
@@ -27,12 +39,18 @@ public struct Patient: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.relatedResources, forKey: .relatedResources)
+        try container.encode(self.memo, forKey: .memo)
         try container.encode(self.resourceType, forKey: .resourceType)
         try container.encode(self.name, forKey: .name)
         try container.encode(self.scripts, forKey: .scripts)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case relatedResources = "related_resources"
+        case memo
         case resourceType = "resource_type"
         case name
         case scripts

--- a/seed/swift-sdk/simple-fhir/Sources/Schemas/Practitioner.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Schemas/Practitioner.swift
@@ -1,13 +1,22 @@
 public struct Practitioner: Codable, Hashable, Sendable {
+    public let id: String
+    public let relatedResources: [ResourceList]
+    public let memo: Memo
     public let resourceType: JSONValue
     public let name: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        id: String,
+        relatedResources: [ResourceList],
+        memo: Memo,
         resourceType: JSONValue,
         name: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.id = id
+        self.relatedResources = relatedResources
+        self.memo = memo
         self.resourceType = resourceType
         self.name = name
         self.additionalProperties = additionalProperties
@@ -15,6 +24,9 @@ public struct Practitioner: Codable, Hashable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.relatedResources = try container.decode([ResourceList].self, forKey: .relatedResources)
+        self.memo = try container.decode(Memo.self, forKey: .memo)
         self.resourceType = try container.decode(JSONValue.self, forKey: .resourceType)
         self.name = try container.decode(String.self, forKey: .name)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
@@ -23,11 +35,17 @@ public struct Practitioner: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.relatedResources, forKey: .relatedResources)
+        try container.encode(self.memo, forKey: .memo)
         try container.encode(self.resourceType, forKey: .resourceType)
         try container.encode(self.name, forKey: .name)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case relatedResources = "related_resources"
+        case memo
         case resourceType = "resource_type"
         case name
     }

--- a/seed/swift-sdk/simple-fhir/Sources/Schemas/Script.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Schemas/Script.swift
@@ -1,13 +1,22 @@
 public struct Script: Codable, Hashable, Sendable {
+    public let id: String
+    public let relatedResources: [ResourceList]
+    public let memo: Memo
     public let resourceType: JSONValue
     public let name: String
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        id: String,
+        relatedResources: [ResourceList],
+        memo: Memo,
         resourceType: JSONValue,
         name: String,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.id = id
+        self.relatedResources = relatedResources
+        self.memo = memo
         self.resourceType = resourceType
         self.name = name
         self.additionalProperties = additionalProperties
@@ -15,6 +24,9 @@ public struct Script: Codable, Hashable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.relatedResources = try container.decode([ResourceList].self, forKey: .relatedResources)
+        self.memo = try container.decode(Memo.self, forKey: .memo)
         self.resourceType = try container.decode(JSONValue.self, forKey: .resourceType)
         self.name = try container.decode(String.self, forKey: .name)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
@@ -23,11 +35,17 @@ public struct Script: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.relatedResources, forKey: .relatedResources)
+        try container.encode(self.memo, forKey: .memo)
         try container.encode(self.resourceType, forKey: .resourceType)
         try container.encode(self.name, forKey: .name)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case relatedResources = "related_resources"
+        case memo
         case resourceType = "resource_type"
         case name
     }

--- a/seed/swift-sdk/trace/Sources/Schemas/Playlist.swift
+++ b/seed/swift-sdk/trace/Sources/Schemas/Playlist.swift
@@ -1,13 +1,19 @@
 public struct Playlist: Codable, Hashable, Sendable {
+    public let name: String
+    public let problems: [ProblemId]
     public let playlistId: PlaylistId
     public let ownerId: UserId
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        name: String,
+        problems: [ProblemId],
         playlistId: PlaylistId,
         ownerId: UserId,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.name = name
+        self.problems = problems
         self.playlistId = playlistId
         self.ownerId = ownerId
         self.additionalProperties = additionalProperties
@@ -15,6 +21,8 @@ public struct Playlist: Codable, Hashable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.problems = try container.decode([ProblemId].self, forKey: .problems)
         self.playlistId = try container.decode(PlaylistId.self, forKey: .playlistId)
         self.ownerId = try container.decode(UserId.self, forKey: .ownerId)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
@@ -23,11 +31,15 @@ public struct Playlist: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.problems, forKey: .problems)
         try container.encode(self.playlistId, forKey: .playlistId)
         try container.encode(self.ownerId, forKey: .ownerId)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case name
+        case problems
         case playlistId = "playlist_id"
         case ownerId = "owner-id"
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/FooExtended.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/FooExtended.swift
@@ -1,17 +1,21 @@
 public struct FooExtended: Codable, Hashable, Sendable {
+    public let name: String
     public let age: Int
     public let additionalProperties: [String: JSONValue]
 
     public init(
+        name: String,
         age: Int,
         additionalProperties: [String: JSONValue] = .init()
     ) {
+        self.name = name
         self.age = age
         self.additionalProperties = additionalProperties
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
         self.age = try container.decode(Int.self, forKey: .age)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -19,10 +23,12 @@ public struct FooExtended: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.name, forKey: .name)
         try container.encode(self.age, forKey: .age)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case name
         case age
     }
 }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithSubTypes.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithSubTypes.swift
@@ -63,19 +63,23 @@ public enum UnionWithSubTypes: Codable, Hashable, Sendable {
 
     public struct FooExtended: Codable, Hashable, Sendable {
         public let type: String = "fooExtended"
+        public let name: String
         public let age: Int
         public let additionalProperties: [String: JSONValue]
 
         public init(
+            name: String,
             age: Int,
             additionalProperties: [String: JSONValue] = .init()
         ) {
+            self.name = name
             self.age = age
             self.additionalProperties = additionalProperties
         }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.name = try container.decode(String.self, forKey: .name)
             self.age = try container.decode(Int.self, forKey: .age)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
@@ -84,11 +88,13 @@ public enum UnionWithSubTypes: Codable, Hashable, Sendable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try encoder.encodeAdditionalProperties(self.additionalProperties)
             try container.encode(self.type, forKey: .type)
+            try container.encode(self.name, forKey: .name)
             try container.encode(self.age, forKey: .age)
         }
 
         enum CodingKeys: String, CodingKey, CaseIterable {
             case type
+            case name
             case age
         }
     }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Wiith this PR, we'll add the extended object properties to the generated structs. Applies to all relevant types like inline request bodies, discriminated union variants, schema types etc.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `ObjectGenerator` and `DiscriminatedUnionGenerator` to include extended properties.
- Removed `getIRForTestDefinition` return type which was causing a TS compile error
- Updated seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

