### PR TITLE
fix(cli): literal type headers should use literal value for example

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/dates.json
@@ -14,10 +14,7 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "date_header": "date_header",
-                    "date_time_header": "date_time_header",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -99,9 +96,7 @@
         type: Response
         status-code: 200
       examples:
-        - headers:
-            date_header: date_header
-            date_time_header: date_time_header
+        - headers: {}
           request: {}
           response:
             body:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/intercom.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/intercom.json
@@ -13673,9 +13673,7 @@ You can view the currently authorised admin along with the embedded app object (
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -13729,9 +13727,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "query-parameters": {
                     "created_at_after": "1677253093",
@@ -13810,9 +13806,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -13859,9 +13853,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin found",
                   "path-parameters": {
                     "id": 1,
@@ -13920,9 +13912,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -13957,9 +13947,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -13994,9 +13982,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Unauthorized",
                   "path-parameters": {
                     "id": 1,
@@ -14169,8 +14155,7 @@ service:
         status-code: 200
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -14234,8 +14219,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -14260,8 +14244,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -14286,8 +14269,7 @@ service:
         - name: Unauthorized
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -14341,8 +14323,7 @@ service:
           query-parameters:
             created_at_after: '1677253093'
             created_at_before: '1677861493'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: activity_log.list
@@ -14388,8 +14369,7 @@ service:
         - root.ListAdminsRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin.list
@@ -14428,8 +14408,7 @@ service:
         - name: Admin found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -14707,9 +14686,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "article created",
                   "request": {
                     "author_id": 991267407,
@@ -15172,9 +15149,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "author_id": 1295,
@@ -15654,9 +15629,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -15702,9 +15675,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -15768,9 +15739,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article found",
                   "path-parameters": {
                     "id": 1,
@@ -16245,9 +16214,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Search successful",
                   "query-parameters": {
                     "phrase": "Getting started",
@@ -16340,9 +16307,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -16794,9 +16759,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -17531,8 +17494,7 @@ service:
         - root.ListArticlesRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -17587,8 +17549,7 @@ service:
         - root.CreateArticleRequestUnauthorizedError
       examples:
         - name: article created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -18005,8 +17966,7 @@ service:
                 neutral_reaction_percentage: 0
                 sad_reaction_percentage: 0
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -18438,8 +18398,7 @@ service:
         - name: Article found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: article
@@ -18869,8 +18828,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -19277,8 +19235,7 @@ service:
         - name: Article Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -19707,8 +19664,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '51'
@@ -19754,8 +19710,7 @@ service:
           query-parameters:
             phrase: Getting started
             state: published
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -20002,9 +19957,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -20119,9 +20072,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -20172,9 +20123,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -20260,9 +20209,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -20344,9 +20291,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "id",
@@ -20402,9 +20347,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "path-parameters": {
                     "id": "id",
@@ -20460,9 +20403,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company Not Found",
                   "path-parameters": {
                     "id": "id",
@@ -20572,9 +20513,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "company_id": "company_remote_id",
@@ -20657,9 +20596,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -20701,9 +20638,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "58a430d35458202d41b1e65b",
@@ -20797,9 +20732,7 @@ When using the Companies endpoint and the pages object to iterate through the re
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "order": "desc",
@@ -20909,9 +20842,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "company_id": "12345",
@@ -21039,9 +20970,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -21316,8 +21245,7 @@ service:
             company_id: '12345'
             tag_id: '678910'
             segment_id: '98765'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21394,8 +21322,7 @@ service:
         - root.CreateOrUpdateCompanyRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: my company
             company_id: company_remote_id
@@ -21457,8 +21384,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -21521,8 +21447,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -21580,8 +21505,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: 667d60848a68186f43bafd45
@@ -21610,8 +21534,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21703,8 +21626,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21767,8 +21689,7 @@ service:
         - name: Successful
           query-parameters:
             order: desc
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21853,8 +21774,7 @@ service:
         - root.ScrollOverAllCompaniesRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21923,8 +21843,7 @@ service:
         - name: Successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d608d8a68186f43bafd70
           response:
@@ -21964,8 +21883,7 @@ service:
         - name: Bad Request
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 58a430d35458202d41b1e65b
           response:
@@ -22005,8 +21923,7 @@ service:
         - name: Company Not Found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -22070,8 +21987,7 @@ service:
           path-parameters:
             contact_id: 58a430d35458202d41b1e65b
             id: 58a430d35458202d41b1e65b
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -22231,9 +22147,7 @@ types:
               "docs": "You can archive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -22275,9 +22189,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "email": "joebloggs@intercom.io",
@@ -22369,9 +22281,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "id",
@@ -22418,9 +22328,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -22525,9 +22433,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "from": "667d60ac8a68186f43bafdbb",
@@ -22738,9 +22644,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -22866,9 +22770,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -22962,9 +22864,7 @@ The table below shows the operators you can use to define how you want to search
               "docs": "You can unarchive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -23006,9 +22906,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -23165,9 +23063,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -23243,9 +23139,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -23303,9 +23197,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -23389,9 +23281,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -23679,8 +23569,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23737,8 +23626,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23785,8 +23673,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23844,8 +23731,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23878,8 +23764,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -23990,8 +23875,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
             name: joe bloggs
@@ -24063,8 +23947,7 @@ service:
         - name: successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -24104,8 +23987,7 @@ service:
         - root.MergeContactRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from: 667d60ac8a68186f43bafdbb
             into: 667d60ac8a68186f43bafdbc
@@ -24390,8 +24272,7 @@ service:
         - root.SearchContactsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -24492,8 +24373,7 @@ service:
         - root.ListContactsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -24581,8 +24461,7 @@ service:
         - root.CreateContactRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
           response:
@@ -24648,8 +24527,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -24676,8 +24554,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -24883,9 +24760,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attach a contact to a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -25061,9 +24936,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -25290,9 +25163,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation using assignment rules",
                   "path-parameters": {
                     "id": "123",
@@ -25433,9 +25304,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -25560,9 +25429,7 @@ It is not possible to use this endpoint with Workflows.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad request",
                   "path-parameters": {
                     "id": 1,
@@ -25744,9 +25611,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation created",
                   "request": {
                     "body": "Hello there",
@@ -25768,9 +25633,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact Not Found",
                   "request": {
                     "body": "Hello there",
@@ -25838,9 +25701,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Detach a contact from a group conversation",
                   "path-parameters": {
                     "contact_id": "123",
@@ -26014,9 +25875,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -26190,9 +26049,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -26366,9 +26223,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Last customer",
                   "path-parameters": {
                     "contact_id": "123",
@@ -26596,9 +26451,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -26694,9 +26547,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Close a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -26813,9 +26664,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Snooze a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -26932,9 +26781,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Open a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -27050,9 +26897,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -27174,9 +27019,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -27331,9 +27174,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Redact a conversation part",
                   "request": {
                     "conversation_id": "19894788788",
@@ -27452,9 +27293,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "request": {
                     "conversation_id": "really_123_doesnt_exist",
@@ -27600,9 +27439,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27725,9 +27562,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27856,9 +27691,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User last conversation reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27981,9 +27814,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -28149,9 +27980,7 @@ For AI agent conversation metadata, please note that you need to have the agent 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -28379,9 +28208,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -28527,9 +28354,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -28677,9 +28502,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": 1,
@@ -29175,8 +28998,7 @@ service:
         - root.ListConversationsRequestForbiddenError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation.list
@@ -29259,8 +29081,7 @@ service:
         - root.CreateConversationRequestNotFoundError
       examples:
         - name: conversation created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -29276,8 +29097,7 @@ service:
               message_type: inapp
               conversation_id: '363'
         - name: Contact Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -29344,8 +29164,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -29461,8 +29280,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -29572,8 +29390,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -30015,8 +29832,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -30122,8 +29938,7 @@ service:
         - name: User reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -30213,8 +30028,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -30316,8 +30130,7 @@ service:
         - name: User last conversation reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -30407,8 +30220,7 @@ service:
         - name: Not found
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -30527,8 +30339,7 @@ service:
         - name: Close a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -30613,8 +30424,7 @@ service:
         - name: Snooze a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017691'
             snoozed_until: 1673609604
@@ -30699,8 +30509,7 @@ service:
         - name: Open a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
             message_type: open
@@ -30784,8 +30593,7 @@ service:
         - name: Assign a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -30874,8 +30682,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -30989,8 +30796,7 @@ service:
         - name: Assign a conversation using assignment rules
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -31116,8 +30922,7 @@ service:
         - name: Attach a contact to a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -31249,8 +31054,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -31428,8 +31232,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31560,8 +31363,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31692,8 +31494,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31824,8 +31625,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31985,8 +31785,7 @@ service:
         - root.RedactConversationRequestNotFoundError
       examples:
         - name: Redact a conversation part
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: '19894788788'
@@ -32073,8 +31872,7 @@ service:
                   - id: '7583'
               ai_agent_participated: false
         - name: Not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: really_123_doesnt_exist
@@ -32194,8 +31992,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '79'
           response:
@@ -32290,8 +32087,7 @@ service:
         - name: Bad request
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '80'
           response:
@@ -32652,9 +32448,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "data_type": "string",
@@ -32687,9 +32481,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Same name already exists",
                   "request": {
                     "data_type": "integer",
@@ -32722,9 +32514,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid name",
                   "request": {
                     "data_type": "string",
@@ -32757,9 +32547,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute already exists",
                   "request": {
                     "data_type": "string",
@@ -32792,9 +32580,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid Data Type",
                   "request": {
                     "data_type": "string",
@@ -32827,9 +32613,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options for list",
                   "request": {
                     "data_type": "string",
@@ -32922,9 +32706,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -33352,9 +33134,7 @@ You can update a data attribute.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": 1,
@@ -33393,9 +33173,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options in list",
                   "path-parameters": {
                     "id": 1,
@@ -33434,9 +33212,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -33475,9 +33251,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Has Dependant Object",
                   "path-parameters": {
                     "id": 1,
@@ -33856,8 +33630,7 @@ service:
         - root.LisDataAttributesRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -34238,8 +34011,7 @@ service:
         - root.CreateDataAttributeRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Mithril Shirt
             model: company
@@ -34266,8 +34038,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Same name already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: contact
@@ -34294,8 +34065,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid name
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: '!nv@l!d n@me'
             model: company
@@ -34322,8 +34092,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Attribute already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: company
@@ -34350,8 +34119,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid Data Type
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The Second Ring
             model: company
@@ -34378,8 +34146,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Too few options for list
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: My Data Attribute
             model: contact
@@ -34464,8 +34231,7 @@ service:
         - name: Successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -34496,8 +34262,7 @@ service:
         - name: Too few options in list
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Too few options
@@ -34528,8 +34293,7 @@ service:
         - name: Attribute Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -34560,8 +34324,7 @@ service:
         - name: Has Dependant Object
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: true
             description: Trying to archieve
@@ -34675,9 +34438,7 @@ Duplicated events are responded to using the normal `202 Accepted` code - an err
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "request": {},
                 },
               ],
@@ -35203,8 +34964,7 @@ service:
       errors:
         - root.DataEventSummariesRequestUnauthorizedError
       examples:
-        - headers:
-            Intercom-Version: Intercom-Version
+        - headers: {}
           request: {}
   source:
     openapi: ../openapi.yml
@@ -35227,9 +34987,7 @@ docs: Everything about your Data Events
               "docs": "You can cancel your job",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -35283,9 +35041,7 @@ The only parameters you need to provide are the range of dates that you want exp
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "created_at_after": 1719474967,
@@ -35345,9 +35101,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "job_identifier": "job_identifier",
                   },
@@ -35377,9 +35131,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -35529,8 +35281,7 @@ Your exported message data will be streamed continuously back down to you in a g
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             created_at_after: 1719474967
             created_at_before: 1719492967
@@ -35574,8 +35325,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -35602,8 +35352,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -35640,8 +35389,7 @@ Your exported message data will be streamed continuously back down to you in a g
       examples:
         - path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
   source:
     openapi: ../openapi.yml
   display-name: Data Export
@@ -35702,9 +35450,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "collection created",
                   "request": {
                     "name": "Thanks for everything",
@@ -35914,9 +35660,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "description": "Missing required parameter",
@@ -36179,9 +35923,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -36225,9 +35967,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -36295,9 +36035,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Help Centers found",
                   "response": {
                     "body": {
@@ -36339,9 +36077,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -36579,9 +36315,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -36627,9 +36361,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -36842,9 +36574,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -37252,8 +36982,7 @@ service:
         - root.ListAllCollectionsRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -37334,8 +37063,7 @@ service:
         - root.CreateCollectionRequestUnauthorizedError
       examples:
         - name: collection created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Thanks for everything
           response:
@@ -37502,8 +37230,7 @@ service:
                   description: ' Collection description'
               help_center_id: 81
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: collection 51
             description: Missing required parameter
@@ -37695,8 +37422,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '170'
@@ -37907,8 +37633,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -38077,8 +37802,7 @@ service:
         - name: Collection Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -38269,8 +37993,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '182'
@@ -38301,8 +38024,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '93'
@@ -38330,8 +38052,7 @@ service:
         - root.ListHelpCentersRequestUnauthorizedError
       examples:
         - name: Help Centers found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -38488,9 +38209,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "user message created",
                   "request": {
                     "body": "heyy",
@@ -38513,9 +38232,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "lead message created",
                   "request": {
                     "body": "heyy",
@@ -38538,9 +38255,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "admin message created",
                   "request": {
                     "body": "heyy",
@@ -38567,9 +38282,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for message",
                   "request": {
                     "from": {
@@ -38596,9 +38309,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No subject supplied for email message",
                   "request": {
                     "body": "hey there",
@@ -38625,9 +38336,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for email message",
                   "request": {
                     "from": {
@@ -38779,8 +38488,7 @@ service:
         - root.CreateMessageRequestUnprocessableEntityError
       examples:
         - name: user message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -38797,8 +38505,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: lead message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: lead
@@ -38815,8 +38522,7 @@ service:
               message_type: inapp
               conversation_id: '477'
         - name: admin message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38836,8 +38542,7 @@ service:
               message_type: inapp
               conversation_id: '64619700005570'
         - name: No body supplied for message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38857,8 +38562,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No subject supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38878,8 +38582,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No body supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38968,9 +38671,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "body": "<p>New costumes in store for this spooky season</p>",
@@ -39052,9 +38753,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -39095,9 +38794,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -39174,9 +38871,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -39269,9 +38964,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -39329,9 +39022,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -39393,9 +39084,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -39438,9 +39127,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -39482,9 +39169,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "News Item Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -39703,8 +39388,7 @@ service:
         - root.ListNewsItemsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -39782,8 +39466,7 @@ service:
         - root.CreateNewsItemRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Halloween is here!
             body: <p>New costumes in store for this spooky season</p>
@@ -39844,8 +39527,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '34'
@@ -39893,8 +39575,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -39924,8 +39605,7 @@ service:
         - name: News Item Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -39975,8 +39655,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '40'
@@ -40006,8 +39685,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -40059,8 +39737,7 @@ service:
         - root.ListNewsfeedsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -40108,8 +39785,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '72'
@@ -40255,9 +39931,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -40303,9 +39977,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -40351,9 +40023,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "id": 1,
@@ -40449,9 +40119,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -40560,9 +40228,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Note found",
                   "path-parameters": {
                     "id": 1,
@@ -40708,8 +40374,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -40804,8 +40469,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60978a68186f43bafd9e
@@ -40839,8 +40503,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60988a68186f43bafd9f
@@ -40874,8 +40537,7 @@ service:
         - name: Contact not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: '123'
@@ -40929,8 +40591,7 @@ service:
         - name: Note found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: note
@@ -41020,9 +40681,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -41085,9 +40744,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "123",
@@ -41207,8 +40864,7 @@ service:
         - root.ListSegmentsRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment.list
@@ -41252,8 +40908,7 @@ service:
         - name: Successful response
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment
@@ -41335,9 +40990,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41371,9 +41024,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41407,9 +41058,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Resource not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41490,9 +41139,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41554,9 +41201,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -41729,8 +41374,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -41753,8 +41397,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -41777,8 +41420,7 @@ service:
         - name: Resource not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: invalid_id
             consent_type: opt_in
@@ -41830,8 +41472,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '37846'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: subscription
@@ -41866,8 +41507,7 @@ service:
         - root.ListSubscriptionTypesRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -41976,9 +41616,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "custom_attributes": {
@@ -41995,9 +41633,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - exception sending sms",
                   "request": {
                     "custom_attributes": {
@@ -42014,9 +41650,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - invalid number",
                   "request": {
                     "custom_attributes": {
@@ -42033,9 +41667,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "unprocessable entity",
                   "request": {
                     "custom_attributes": {
@@ -42112,8 +41744,7 @@ service:
         - root.CreatePhoneSwitchRequestUnprocessableEntityError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -42124,8 +41755,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - exception sending sms
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -42136,8 +41766,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - invalid number
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -42148,8 +41777,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: unprocessable entity
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+40241100100'
             custom_attributes:
@@ -42187,9 +41815,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -42211,9 +41837,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -42235,9 +41859,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -42302,9 +41924,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42327,9 +41947,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42399,9 +42017,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -42424,9 +42040,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -42510,9 +42124,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Action successful",
                   "request": {
                     "name": "test",
@@ -42531,9 +42143,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid parameters",
                   "request": {
                     "name": "Independent",
@@ -42552,9 +42162,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company not found",
                   "request": {
                     "companies": [
@@ -42578,9 +42186,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User  not found",
                   "request": {
                     "name": "test",
@@ -42631,9 +42237,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "123",
                   },
@@ -42662,9 +42266,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -42716,9 +42318,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42741,9 +42341,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42766,9 +42364,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42838,9 +42434,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "7522907",
@@ -42863,9 +42457,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -42888,9 +42480,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -42962,9 +42552,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag found",
                   "path-parameters": {
                     "id": "123",
@@ -43012,9 +42600,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -43144,8 +42730,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -43160,8 +42745,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -43176,8 +42760,7 @@ service:
         - name: Tag not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -43218,8 +42801,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -43265,8 +42847,7 @@ service:
         - name: successful
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -43282,8 +42863,7 @@ service:
         - name: Conversation not found
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -43333,8 +42913,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43350,8 +42929,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43367,8 +42945,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43398,8 +42975,7 @@ service:
         - root.ListTagsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -43444,8 +43020,7 @@ service:
         - root.CreateTagRequestNotFoundError
       examples:
         - name: Action successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
           response:
@@ -43458,8 +43033,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Invalid parameters
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Independent
           response:
@@ -43472,8 +43046,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Company not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             companies:
@@ -43488,8 +43061,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: User  not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             users:
@@ -43528,8 +43100,7 @@ service:
         - name: Tag found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -43560,8 +43131,7 @@ service:
       examples:
         - path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
     attachTagToTicket:
       path: /tickets/{ticket_id}/tags
       method: POST
@@ -43598,8 +43168,7 @@ service:
         - name: successful
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -43615,8 +43184,7 @@ service:
         - name: Ticket not found
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -43666,8 +43234,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43683,8 +43250,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43700,8 +43266,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43771,9 +43336,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -43814,9 +43377,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -43917,8 +43478,7 @@ service:
         - root.ListTeamsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team.list
@@ -43953,8 +43513,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team
@@ -44014,9 +43573,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute created",
                   "path-parameters": {
                     "ticket_type_id": "ticket_type_id",
@@ -44134,9 +43691,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute updated",
                   "path-parameters": {
                     "id": "id",
@@ -44370,8 +43925,7 @@ service:
         - name: Ticket Type Attribute created
           path-parameters:
             ticket_type_id: ticket_type_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Attribute Title
             description: Attribute Description
@@ -44485,8 +44039,7 @@ service:
           path-parameters:
             ticket_type_id: ticket_type_id
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             description: New Attribute Description
           response:
@@ -44542,9 +44095,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type created",
                   "request": {
                     "category": "Customer",
@@ -44619,9 +44170,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type found",
                   "path-parameters": {
                     "id": "id",
@@ -44693,9 +44242,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -44745,9 +44292,7 @@ You can update a ticket type.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type updated",
                   "path-parameters": {
                     "id": "id",
@@ -44848,8 +44393,7 @@ service:
         - root.ListTicketTypesRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -44895,8 +44439,7 @@ service:
         - root.CreateTicketTypeRequestUnauthorizedError
       examples:
         - name: Ticket type created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Customer Issue
             description: Customer Report Template
@@ -44957,8 +44500,7 @@ service:
         - name: Ticket type found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket_type
@@ -45028,8 +44570,7 @@ service:
         - name: Ticket type updated
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Bug Report 2
           response:
@@ -45090,9 +44631,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "request": {
                     "contacts": [
@@ -45249,9 +44788,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket found",
                   "path-parameters": {
                     "id": "id",
@@ -45377,9 +44914,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123",
@@ -45431,9 +44966,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123",
@@ -45485,9 +45018,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin quick_reply reply",
                   "path-parameters": {
                     "id": "123",
@@ -45537,9 +45068,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -45677,9 +45206,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -45831,9 +45358,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "id",
@@ -46074,9 +45599,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": "id",
@@ -46315,9 +45838,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assignee not found",
                   "path-parameters": {
                     "id": "id",
@@ -47310,8 +46831,7 @@ service:
         - name: User reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -47354,8 +46874,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -47402,8 +46921,7 @@ service:
         - name: Admin quick_reply reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: quick_reply
             type: admin
@@ -47438,8 +46956,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -47520,8 +47037,7 @@ service:
         - root.CreateTicketRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '1234'
             contacts:
@@ -47621,8 +47137,7 @@ service:
         - name: Ticket found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket
@@ -47739,8 +47254,7 @@ service:
         - name: Successful response
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -47927,8 +47441,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -48113,8 +47626,7 @@ service:
         - name: Assignee not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -48473,8 +47985,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -48596,9 +48107,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "type": "user",
@@ -48711,9 +48220,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "query-parameters": {
                     "user_id": "user_id",
@@ -48838,9 +48345,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "id": "667d61cc8a68186f43bafe95",
@@ -48933,9 +48438,7 @@ docs: Everything about your tickets
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "visitor Not Found",
                   "request": {
                     "name": "Christian Fail",
@@ -49082,8 +48585,7 @@ service:
         - name: successful
           query-parameters:
             user_id: user_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: visitor
@@ -49178,8 +48680,7 @@ service:
         - root.UpdateVisitorRequestNotFoundError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d61cc8a68186f43bafe95
             name: Gareth Bale
@@ -49252,8 +48753,7 @@ service:
               custom_attributes:
                 key: value
         - name: visitor Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             user_id: fail
             name: Christian Fail
@@ -49364,8 +48864,7 @@ service:
         - root.ConvertVisitorRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: user
             user:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/merge.json
@@ -9814,9 +9814,7 @@ service:
               "docs": "Returns the account token for the end user with the provided public token.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "public_token": "public_token",
                   },
@@ -9886,8 +9884,7 @@ service:
       examples:
         - path-parameters:
             public_token: public_token
-          headers:
-            X-Account-Token: X-Account-Token
+          headers: {}
           response:
             body:
               account_token: T9klMDQrcHdm9jrtHuOS2Nf06BIHwMNjpPXPMB
@@ -17162,9 +17159,7 @@ service:
               "docs": "Create a remote key.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "Remote Deployment Key 1",
                   },
@@ -17241,8 +17236,7 @@ service:
         type: root.RemoteKey
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           request:
             name: Remote Deployment Key 1
           response:
@@ -17610,9 +17604,7 @@ service:
               "docs": "Gets issues.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -17706,9 +17698,7 @@ service:
               "docs": "Get a specific issue.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -17841,8 +17831,7 @@ service:
         type: root.PaginatedIssueList
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -17875,8 +17864,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            X-Account-Token: X-Account-Token
+          headers: {}
           response:
             body:
               id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -17909,9 +17897,7 @@ service:
               "docs": "Creates a link token to be used when linking a new end user.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "request": {
                     "categories": [
                       "hris",
@@ -18106,8 +18092,7 @@ service:
         type: root.LinkToken
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           request:
             end_user_email_address: end_user_email_address
             end_user_organization_name: end_user_organization_name
@@ -18138,9 +18123,7 @@ service:
               "docs": "List linked accounts for your organization.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -18403,8 +18386,7 @@ service:
         type: root.PaginatedAccountDetailsAndActionsList
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -19819,9 +19801,7 @@ service:
               "docs": "Exchange remote keys.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "Remote Deployment Key 1",
                   },
@@ -19898,8 +19878,7 @@ service:
         type: root.RemoteKey
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           request:
             name: Remote Deployment Key 1
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/only-include-referenced-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/only-include-referenced-schemas.json
@@ -13158,9 +13158,7 @@ You can view the currently authorised admin along with the embedded app object (
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -13214,9 +13212,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "query-parameters": {
                     "created_at_after": "1677253093",
@@ -13295,9 +13291,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -13344,9 +13338,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin found",
                   "path-parameters": {
                     "id": 1,
@@ -13405,9 +13397,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -13442,9 +13432,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -13479,9 +13467,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Unauthorized",
                   "path-parameters": {
                     "id": 1,
@@ -13654,8 +13640,7 @@ service:
         status-code: 200
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -13719,8 +13704,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -13745,8 +13729,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -13771,8 +13754,7 @@ service:
         - name: Unauthorized
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -13826,8 +13808,7 @@ service:
           query-parameters:
             created_at_after: '1677253093'
             created_at_before: '1677861493'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: activity_log.list
@@ -13873,8 +13854,7 @@ service:
         - root.ListAdminsRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin.list
@@ -13913,8 +13893,7 @@ service:
         - name: Admin found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -14192,9 +14171,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "article created",
                   "request": {
                     "author_id": 991267407,
@@ -14657,9 +14634,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "author_id": 1295,
@@ -15139,9 +15114,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -15187,9 +15160,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -15253,9 +15224,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article found",
                   "path-parameters": {
                     "id": 1,
@@ -15730,9 +15699,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Search successful",
                   "query-parameters": {
                     "phrase": "Getting started",
@@ -15825,9 +15792,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -16279,9 +16244,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -17016,8 +16979,7 @@ service:
         - root.ListArticlesRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -17072,8 +17034,7 @@ service:
         - root.CreateArticleRequestUnauthorizedError
       examples:
         - name: article created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -17490,8 +17451,7 @@ service:
                 neutral_reaction_percentage: 0
                 sad_reaction_percentage: 0
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -17923,8 +17883,7 @@ service:
         - name: Article found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: article
@@ -18354,8 +18313,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -18762,8 +18720,7 @@ service:
         - name: Article Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -19192,8 +19149,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '51'
@@ -19239,8 +19195,7 @@ service:
           query-parameters:
             phrase: Getting started
             state: published
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19487,9 +19442,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -19604,9 +19557,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -19657,9 +19608,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -19745,9 +19694,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -19829,9 +19776,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "id",
@@ -19887,9 +19832,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "path-parameters": {
                     "id": "id",
@@ -19945,9 +19888,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company Not Found",
                   "path-parameters": {
                     "id": "id",
@@ -20057,9 +19998,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "company_id": "company_remote_id",
@@ -20142,9 +20081,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -20186,9 +20123,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "58a430d35458202d41b1e65b",
@@ -20282,9 +20217,7 @@ When using the Companies endpoint and the pages object to iterate through the re
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "order": "desc",
@@ -20394,9 +20327,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "company_id": "12345",
@@ -20524,9 +20455,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -20801,8 +20730,7 @@ service:
             company_id: '12345'
             tag_id: '678910'
             segment_id: '98765'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -20879,8 +20807,7 @@ service:
         - root.CreateOrUpdateCompanyRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: my company
             company_id: company_remote_id
@@ -20942,8 +20869,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -21006,8 +20932,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -21065,8 +20990,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: 667d60848a68186f43bafd45
@@ -21095,8 +21019,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21188,8 +21111,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21252,8 +21174,7 @@ service:
         - name: Successful
           query-parameters:
             order: desc
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21338,8 +21259,7 @@ service:
         - root.ScrollOverAllCompaniesRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21408,8 +21328,7 @@ service:
         - name: Successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d608d8a68186f43bafd70
           response:
@@ -21449,8 +21368,7 @@ service:
         - name: Bad Request
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 58a430d35458202d41b1e65b
           response:
@@ -21490,8 +21408,7 @@ service:
         - name: Company Not Found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -21555,8 +21472,7 @@ service:
           path-parameters:
             contact_id: 58a430d35458202d41b1e65b
             id: 58a430d35458202d41b1e65b
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -21716,9 +21632,7 @@ types:
               "docs": "You can archive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -21760,9 +21674,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "email": "joebloggs@intercom.io",
@@ -21854,9 +21766,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "id",
@@ -21903,9 +21813,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -22010,9 +21918,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "from": "667d60ac8a68186f43bafdbb",
@@ -22223,9 +22129,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -22351,9 +22255,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -22447,9 +22349,7 @@ The table below shows the operators you can use to define how you want to search
               "docs": "You can unarchive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -22491,9 +22391,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -22650,9 +22548,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -22728,9 +22624,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -22788,9 +22682,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -22874,9 +22766,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -23164,8 +23054,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23222,8 +23111,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23270,8 +23158,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23329,8 +23216,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -23363,8 +23249,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -23475,8 +23360,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
             name: joe bloggs
@@ -23548,8 +23432,7 @@ service:
         - name: successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -23589,8 +23472,7 @@ service:
         - root.MergeContactRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from: 667d60ac8a68186f43bafdbb
             into: 667d60ac8a68186f43bafdbc
@@ -23875,8 +23757,7 @@ service:
         - root.SearchContactsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -23977,8 +23858,7 @@ service:
         - root.ListContactsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -24066,8 +23946,7 @@ service:
         - root.CreateContactRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
           response:
@@ -24133,8 +24012,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -24161,8 +24039,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -24368,9 +24245,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attach a contact to a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24546,9 +24421,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -24775,9 +24648,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation using assignment rules",
                   "path-parameters": {
                     "id": "123",
@@ -24918,9 +24789,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -25045,9 +24914,7 @@ It is not possible to use this endpoint with Workflows.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad request",
                   "path-parameters": {
                     "id": 1,
@@ -25229,9 +25096,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation created",
                   "request": {
                     "body": "Hello there",
@@ -25253,9 +25118,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact Not Found",
                   "request": {
                     "body": "Hello there",
@@ -25323,9 +25186,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Detach a contact from a group conversation",
                   "path-parameters": {
                     "contact_id": "123",
@@ -25499,9 +25360,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -25675,9 +25534,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -25851,9 +25708,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Last customer",
                   "path-parameters": {
                     "contact_id": "123",
@@ -26081,9 +25936,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -26179,9 +26032,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Close a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -26298,9 +26149,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Snooze a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -26417,9 +26266,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Open a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -26535,9 +26382,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -26659,9 +26504,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -26816,9 +26659,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Redact a conversation part",
                   "request": {
                     "conversation_id": "19894788788",
@@ -26937,9 +26778,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "request": {
                     "conversation_id": "really_123_doesnt_exist",
@@ -27085,9 +26924,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27210,9 +27047,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27341,9 +27176,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User last conversation reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27466,9 +27299,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -27634,9 +27465,7 @@ For AI agent conversation metadata, please note that you need to have the agent 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -27864,9 +27693,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -28012,9 +27839,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -28162,9 +27987,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": 1,
@@ -28660,8 +28483,7 @@ service:
         - root.ListConversationsRequestForbiddenError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation.list
@@ -28744,8 +28566,7 @@ service:
         - root.CreateConversationRequestNotFoundError
       examples:
         - name: conversation created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -28761,8 +28582,7 @@ service:
               message_type: inapp
               conversation_id: '363'
         - name: Contact Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -28829,8 +28649,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -28946,8 +28765,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -29057,8 +28875,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -29500,8 +29317,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -29607,8 +29423,7 @@ service:
         - name: User reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -29698,8 +29513,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -29801,8 +29615,7 @@ service:
         - name: User last conversation reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -29892,8 +29705,7 @@ service:
         - name: Not found
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -30012,8 +29824,7 @@ service:
         - name: Close a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -30098,8 +29909,7 @@ service:
         - name: Snooze a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017691'
             snoozed_until: 1673609604
@@ -30184,8 +29994,7 @@ service:
         - name: Open a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
             message_type: open
@@ -30269,8 +30078,7 @@ service:
         - name: Assign a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -30359,8 +30167,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -30474,8 +30281,7 @@ service:
         - name: Assign a conversation using assignment rules
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -30601,8 +30407,7 @@ service:
         - name: Attach a contact to a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -30734,8 +30539,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -30913,8 +30717,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31045,8 +30848,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31177,8 +30979,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31309,8 +31110,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -31470,8 +31270,7 @@ service:
         - root.RedactConversationRequestNotFoundError
       examples:
         - name: Redact a conversation part
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: '19894788788'
@@ -31558,8 +31357,7 @@ service:
                   - id: '7583'
               ai_agent_participated: false
         - name: Not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: really_123_doesnt_exist
@@ -31679,8 +31477,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '79'
           response:
@@ -31775,8 +31572,7 @@ service:
         - name: Bad request
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '80'
           response:
@@ -32137,9 +31933,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "data_type": "string",
@@ -32172,9 +31966,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Same name already exists",
                   "request": {
                     "data_type": "integer",
@@ -32207,9 +31999,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid name",
                   "request": {
                     "data_type": "string",
@@ -32242,9 +32032,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute already exists",
                   "request": {
                     "data_type": "string",
@@ -32277,9 +32065,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid Data Type",
                   "request": {
                     "data_type": "string",
@@ -32312,9 +32098,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options for list",
                   "request": {
                     "data_type": "string",
@@ -32407,9 +32191,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -32837,9 +32619,7 @@ You can update a data attribute.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": 1,
@@ -32878,9 +32658,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options in list",
                   "path-parameters": {
                     "id": 1,
@@ -32919,9 +32697,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -32960,9 +32736,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Has Dependant Object",
                   "path-parameters": {
                     "id": 1,
@@ -33341,8 +33115,7 @@ service:
         - root.LisDataAttributesRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -33723,8 +33496,7 @@ service:
         - root.CreateDataAttributeRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Mithril Shirt
             model: company
@@ -33751,8 +33523,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Same name already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: contact
@@ -33779,8 +33550,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid name
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: '!nv@l!d n@me'
             model: company
@@ -33807,8 +33577,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Attribute already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: company
@@ -33835,8 +33604,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid Data Type
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The Second Ring
             model: company
@@ -33863,8 +33631,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Too few options for list
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: My Data Attribute
             model: contact
@@ -33949,8 +33716,7 @@ service:
         - name: Successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -33981,8 +33747,7 @@ service:
         - name: Too few options in list
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Too few options
@@ -34013,8 +33778,7 @@ service:
         - name: Attribute Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -34045,8 +33809,7 @@ service:
         - name: Has Dependant Object
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: true
             description: Trying to archieve
@@ -34160,9 +33923,7 @@ Duplicated events are responded to using the normal `202 Accepted` code - an err
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "request": {},
                 },
               ],
@@ -34612,8 +34373,7 @@ service:
       errors:
         - root.DataEventSummariesRequestUnauthorizedError
       examples:
-        - headers:
-            Intercom-Version: Intercom-Version
+        - headers: {}
           request: {}
   source:
     openapi: ../openapi.yml
@@ -34636,9 +34396,7 @@ docs: Everything about your Data Events
               "docs": "You can cancel your job",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -34692,9 +34450,7 @@ The only parameters you need to provide are the range of dates that you want exp
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "created_at_after": 1719474967,
@@ -34754,9 +34510,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "job_identifier": "job_identifier",
                   },
@@ -34786,9 +34540,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -34938,8 +34690,7 @@ Your exported message data will be streamed continuously back down to you in a g
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             created_at_after: 1719474967
             created_at_before: 1719492967
@@ -34983,8 +34734,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -35011,8 +34761,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -35049,8 +34798,7 @@ Your exported message data will be streamed continuously back down to you in a g
       examples:
         - path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
   source:
     openapi: ../openapi.yml
   display-name: Data Export
@@ -35111,9 +34859,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "collection created",
                   "request": {
                     "name": "Thanks for everything",
@@ -35323,9 +35069,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "description": "Missing required parameter",
@@ -35588,9 +35332,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -35634,9 +35376,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -35704,9 +35444,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Help Centers found",
                   "response": {
                     "body": {
@@ -35748,9 +35486,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -35988,9 +35724,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -36036,9 +35770,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -36251,9 +35983,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -36661,8 +36391,7 @@ service:
         - root.ListAllCollectionsRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -36743,8 +36472,7 @@ service:
         - root.CreateCollectionRequestUnauthorizedError
       examples:
         - name: collection created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Thanks for everything
           response:
@@ -36911,8 +36639,7 @@ service:
                   description: ' Collection description'
               help_center_id: 81
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: collection 51
             description: Missing required parameter
@@ -37104,8 +36831,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '170'
@@ -37316,8 +37042,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -37486,8 +37211,7 @@ service:
         - name: Collection Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -37678,8 +37402,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '182'
@@ -37710,8 +37433,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '93'
@@ -37739,8 +37461,7 @@ service:
         - root.ListHelpCentersRequestUnauthorizedError
       examples:
         - name: Help Centers found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -37897,9 +37618,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "user message created",
                   "request": {
                     "body": "heyy",
@@ -37922,9 +37641,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "lead message created",
                   "request": {
                     "body": "heyy",
@@ -37947,9 +37664,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "admin message created",
                   "request": {
                     "body": "heyy",
@@ -37976,9 +37691,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for message",
                   "request": {
                     "from": {
@@ -38005,9 +37718,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No subject supplied for email message",
                   "request": {
                     "body": "hey there",
@@ -38034,9 +37745,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for email message",
                   "request": {
                     "from": {
@@ -38188,8 +37897,7 @@ service:
         - root.CreateMessageRequestUnprocessableEntityError
       examples:
         - name: user message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -38206,8 +37914,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: lead message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: lead
@@ -38224,8 +37931,7 @@ service:
               message_type: inapp
               conversation_id: '477'
         - name: admin message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38245,8 +37951,7 @@ service:
               message_type: inapp
               conversation_id: '64619700005570'
         - name: No body supplied for message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38266,8 +37971,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No subject supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38287,8 +37991,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No body supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -38377,9 +38080,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "body": "<p>New costumes in store for this spooky season</p>",
@@ -38461,9 +38162,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -38504,9 +38203,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -38583,9 +38280,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -38678,9 +38373,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -38738,9 +38431,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -38802,9 +38493,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -38847,9 +38536,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -38891,9 +38578,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "News Item Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -39112,8 +38797,7 @@ service:
         - root.ListNewsItemsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -39191,8 +38875,7 @@ service:
         - root.CreateNewsItemRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Halloween is here!
             body: <p>New costumes in store for this spooky season</p>
@@ -39253,8 +38936,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '34'
@@ -39302,8 +38984,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -39333,8 +39014,7 @@ service:
         - name: News Item Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -39384,8 +39064,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '40'
@@ -39415,8 +39094,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -39468,8 +39146,7 @@ service:
         - root.ListNewsfeedsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -39517,8 +39194,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '72'
@@ -39664,9 +39340,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -39712,9 +39386,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -39760,9 +39432,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "id": 1,
@@ -39858,9 +39528,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -39969,9 +39637,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Note found",
                   "path-parameters": {
                     "id": 1,
@@ -40117,8 +39783,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -40213,8 +39878,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60978a68186f43bafd9e
@@ -40248,8 +39912,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60988a68186f43bafd9f
@@ -40283,8 +39946,7 @@ service:
         - name: Contact not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: '123'
@@ -40338,8 +40000,7 @@ service:
         - name: Note found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: note
@@ -40429,9 +40090,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -40494,9 +40153,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "123",
@@ -40616,8 +40273,7 @@ service:
         - root.ListSegmentsRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment.list
@@ -40661,8 +40317,7 @@ service:
         - name: Successful response
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment
@@ -40744,9 +40399,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40780,9 +40433,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40816,9 +40467,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Resource not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40899,9 +40548,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40963,9 +40610,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -41138,8 +40783,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -41162,8 +40806,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -41186,8 +40829,7 @@ service:
         - name: Resource not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: invalid_id
             consent_type: opt_in
@@ -41239,8 +40881,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '37846'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: subscription
@@ -41275,8 +40916,7 @@ service:
         - root.ListSubscriptionTypesRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -41385,9 +41025,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "custom_attributes": {
@@ -41404,9 +41042,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - exception sending sms",
                   "request": {
                     "custom_attributes": {
@@ -41423,9 +41059,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - invalid number",
                   "request": {
                     "custom_attributes": {
@@ -41442,9 +41076,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "unprocessable entity",
                   "request": {
                     "custom_attributes": {
@@ -41521,8 +41153,7 @@ service:
         - root.CreatePhoneSwitchRequestUnprocessableEntityError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -41533,8 +41164,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - exception sending sms
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -41545,8 +41175,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - invalid number
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -41557,8 +41186,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: unprocessable entity
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+40241100100'
             custom_attributes:
@@ -41596,9 +41224,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41620,9 +41246,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41644,9 +41268,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -41711,9 +41333,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -41736,9 +41356,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -41808,9 +41426,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -41833,9 +41449,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -41919,9 +41533,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Action successful",
                   "request": {
                     "name": "test",
@@ -41940,9 +41552,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid parameters",
                   "request": {
                     "name": "Independent",
@@ -41961,9 +41571,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company not found",
                   "request": {
                     "companies": [
@@ -41987,9 +41595,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User  not found",
                   "request": {
                     "name": "test",
@@ -42040,9 +41646,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "123",
                   },
@@ -42071,9 +41675,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -42125,9 +41727,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42150,9 +41750,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42175,9 +41773,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -42247,9 +41843,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "7522907",
@@ -42272,9 +41866,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -42297,9 +41889,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -42371,9 +41961,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag found",
                   "path-parameters": {
                     "id": "123",
@@ -42421,9 +42009,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -42553,8 +42139,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -42569,8 +42154,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -42585,8 +42169,7 @@ service:
         - name: Tag not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -42627,8 +42210,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -42674,8 +42256,7 @@ service:
         - name: successful
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -42691,8 +42272,7 @@ service:
         - name: Conversation not found
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -42742,8 +42322,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -42759,8 +42338,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -42776,8 +42354,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -42807,8 +42384,7 @@ service:
         - root.ListTagsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -42853,8 +42429,7 @@ service:
         - root.CreateTagRequestNotFoundError
       examples:
         - name: Action successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
           response:
@@ -42867,8 +42442,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Invalid parameters
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Independent
           response:
@@ -42881,8 +42455,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Company not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             companies:
@@ -42897,8 +42470,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: User  not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             users:
@@ -42937,8 +42509,7 @@ service:
         - name: Tag found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -42969,8 +42540,7 @@ service:
       examples:
         - path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
     attachTagToTicket:
       path: /tickets/{ticket_id}/tags
       method: POST
@@ -43007,8 +42577,7 @@ service:
         - name: successful
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -43024,8 +42593,7 @@ service:
         - name: Ticket not found
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -43075,8 +42643,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43092,8 +42659,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43109,8 +42675,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -43180,9 +42745,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -43223,9 +42786,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -43326,8 +42887,7 @@ service:
         - root.ListTeamsRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team.list
@@ -43362,8 +42922,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team
@@ -43423,9 +42982,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute created",
                   "path-parameters": {
                     "ticket_type_id": "ticket_type_id",
@@ -43543,9 +43100,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute updated",
                   "path-parameters": {
                     "id": "id",
@@ -43779,8 +43334,7 @@ service:
         - name: Ticket Type Attribute created
           path-parameters:
             ticket_type_id: ticket_type_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Attribute Title
             description: Attribute Description
@@ -43894,8 +43448,7 @@ service:
           path-parameters:
             ticket_type_id: ticket_type_id
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             description: New Attribute Description
           response:
@@ -43951,9 +43504,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type created",
                   "request": {
                     "category": "Customer",
@@ -44028,9 +43579,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type found",
                   "path-parameters": {
                     "id": "id",
@@ -44102,9 +43651,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -44154,9 +43701,7 @@ You can update a ticket type.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type updated",
                   "path-parameters": {
                     "id": "id",
@@ -44257,8 +43802,7 @@ service:
         - root.ListTicketTypesRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -44304,8 +43848,7 @@ service:
         - root.CreateTicketTypeRequestUnauthorizedError
       examples:
         - name: Ticket type created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Customer Issue
             description: Customer Report Template
@@ -44366,8 +43909,7 @@ service:
         - name: Ticket type found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket_type
@@ -44437,8 +43979,7 @@ service:
         - name: Ticket type updated
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Bug Report 2
           response:
@@ -44499,9 +44040,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "request": {
                     "contacts": [
@@ -44658,9 +44197,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket found",
                   "path-parameters": {
                     "id": "id",
@@ -44786,9 +44323,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123",
@@ -44840,9 +44375,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123",
@@ -44894,9 +44427,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin quick_reply reply",
                   "path-parameters": {
                     "id": "123",
@@ -44946,9 +44477,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -45086,9 +44615,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -45240,9 +44767,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "id",
@@ -45483,9 +45008,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": "id",
@@ -45724,9 +45247,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assignee not found",
                   "path-parameters": {
                     "id": "id",
@@ -46719,8 +46240,7 @@ service:
         - name: User reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -46763,8 +46283,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -46811,8 +46330,7 @@ service:
         - name: Admin quick_reply reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: quick_reply
             type: admin
@@ -46847,8 +46365,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -46929,8 +46446,7 @@ service:
         - root.CreateTicketRequestUnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '1234'
             contacts:
@@ -47030,8 +46546,7 @@ service:
         - name: Ticket found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket
@@ -47148,8 +46663,7 @@ service:
         - name: Successful response
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -47336,8 +46850,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -47522,8 +47035,7 @@ service:
         - name: Assignee not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -47882,8 +47394,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -48005,9 +47516,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "type": "user",
@@ -48120,9 +47629,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "query-parameters": {
                     "user_id": "user_id",
@@ -48247,9 +47754,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "id": "667d61cc8a68186f43bafe95",
@@ -48342,9 +47847,7 @@ docs: Everything about your tickets
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "visitor Not Found",
                   "request": {
                     "name": "Christian Fail",
@@ -48491,8 +47994,7 @@ service:
         - name: successful
           query-parameters:
             user_id: user_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: visitor
@@ -48587,8 +48089,7 @@ service:
         - root.UpdateVisitorRequestNotFoundError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d61cc8a68186f43bafe95
             name: Gareth Bale
@@ -48661,8 +48162,7 @@ service:
               custom_attributes:
                 key: value
         - name: visitor Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             user_id: fail
             name: Christian Fail
@@ -48773,8 +48273,7 @@ service:
         - root.ConvertVisitorRequestUnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: user
             user:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/openapi-filter.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/openapi-filter.json
@@ -279,9 +279,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "company_id": "company_remote_id",
@@ -538,8 +536,7 @@ service:
         - root.CreateOrUpdateCompanyRequestUnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: my company
             company_id: company_remote_id

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/seam.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/seam.json
@@ -10315,11 +10315,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -10439,11 +10435,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_ids": [
                       "device_ids",
@@ -10552,11 +10544,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -10629,11 +10617,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -10714,11 +10698,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -10807,11 +10787,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -10894,11 +10870,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -10979,11 +10951,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -11432,10 +11400,7 @@ service:
         - root.AccessCodesCreateRequestBadRequestError
         - root.AccessCodesCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -11520,10 +11485,7 @@ service:
         - root.AccessCodesCreateMultipleRequestBadRequestError
         - root.AccessCodesCreateMultipleRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_ids:
               - device_ids
@@ -11585,10 +11547,7 @@ service:
         - root.AccessCodesDeleteRequestBadRequestError
         - root.AccessCodesDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -11625,10 +11584,7 @@ service:
         - root.AccessCodesGenerateCodeRequestBadRequestError
         - root.AccessCodesGenerateCodeRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -11688,10 +11644,7 @@ service:
         - root.AccessCodesGetRequestBadRequestError
         - root.AccessCodesGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -11747,10 +11700,7 @@ service:
         - root.AccessCodesListRequestBadRequestError
         - root.AccessCodesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -11804,10 +11754,7 @@ service:
         - root.AccessCodesPullBackupAccessCodeRequestBadRequestError
         - root.AccessCodesPullBackupAccessCodeRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -11892,10 +11839,7 @@ service:
         - root.AccessCodesUpdateRequestBadRequestError
         - root.AccessCodesUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -11931,11 +11875,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "code": "code",
                     "device_id": "device_id",
@@ -12073,10 +12013,7 @@ service:
         - root.SimulateCreateUnmanagedAccessCodeRequestBadRequestError
         - root.SimulateCreateUnmanagedAccessCodeRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             name: name
@@ -12123,11 +12060,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -12187,11 +12120,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -12255,11 +12184,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -12339,11 +12264,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -12418,11 +12339,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                     "is_managed": true,
@@ -12596,10 +12513,7 @@ service:
         - root.UnmanagedConvertToManagedRequestBadRequestError
         - root.UnmanagedConvertToManagedRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -12632,10 +12546,7 @@ service:
         - root.UnmanagedDeleteRequestBadRequestError
         - root.UnmanagedDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -12677,10 +12588,7 @@ service:
         - root.UnmanagedGetRequestBadRequestError
         - root.UnmanagedGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -12726,10 +12634,7 @@ service:
         - root.UnmanagedListRequestBadRequestError
         - root.UnmanagedListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -12778,10 +12683,7 @@ service:
         - root.UnmanagedUpdateRequestBadRequestError
         - root.UnmanagedUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
             is_managed: true
@@ -12812,11 +12714,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -12879,11 +12777,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                   },
@@ -12949,11 +12843,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -13028,11 +12918,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                   },
@@ -13111,11 +12997,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -13292,10 +13174,7 @@ service:
         - root.AccessGroupsAddUserRequestBadRequestError
         - root.AccessGroupsAddUserRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
             acs_user_id: acs_user_id
@@ -13327,10 +13206,7 @@ service:
         - root.AccessGroupsGetRequestBadRequestError
         - root.AccessGroupsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
           response:
@@ -13376,10 +13252,7 @@ service:
         - root.AccessGroupsListRequestBadRequestError
         - root.AccessGroupsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -13420,10 +13293,7 @@ service:
         - root.AccessGroupsListUsersRequestBadRequestError
         - root.AccessGroupsListUsersRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
           response:
@@ -13478,10 +13348,7 @@ service:
         - root.AccessGroupsRemoveUserRequestBadRequestError
         - root.AccessGroupsRemoveUserRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
             acs_user_id: acs_user_id
@@ -13512,11 +13379,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -13628,10 +13491,7 @@ service:
         - root.CredentialPoolsListRequestBadRequestError
         - root.CredentialPoolsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -13669,11 +13529,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "credential_manager_acs_system_id": "credential_manager_acs_system_id",
                     "user_identity_id": "user_identity_id",
@@ -13823,10 +13679,7 @@ service:
         - root.CredentialProvisioningAutomationsLaunchRequestBadRequestError
         - root.CredentialProvisioningAutomationsLaunchRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             credential_manager_acs_system_id: credential_manager_acs_system_id
@@ -13863,11 +13716,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                     "acs_user_id": "acs_user_id",
@@ -13973,11 +13822,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_method": "code",
                     "acs_user_id": "acs_user_id",
@@ -14102,11 +13947,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -14159,11 +14000,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -14260,11 +14097,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -14344,11 +14177,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -14426,11 +14255,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                     "acs_user_id": "acs_user_id",
@@ -14536,11 +14361,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -14916,10 +14737,7 @@ service:
         - root.CredentialsAssignRequestBadRequestError
         - root.CredentialsAssignRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_credential_id: acs_credential_id
@@ -14999,10 +14817,7 @@ service:
         - root.CredentialsCreateRequestBadRequestError
         - root.CredentialsCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             access_method: code
@@ -15065,10 +14880,7 @@ service:
         - root.CredentialsDeleteRequestBadRequestError
         - root.CredentialsDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -15099,10 +14911,7 @@ service:
         - root.CredentialsGetRequestBadRequestError
         - root.CredentialsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -15162,10 +14971,7 @@ service:
         - root.CredentialsListRequestBadRequestError
         - root.CredentialsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -15221,10 +15027,7 @@ service:
         - root.CredentialsListAccessibleEntrancesRequestBadRequestError
         - root.CredentialsListAccessibleEntrancesRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -15274,10 +15077,7 @@ service:
         - root.CredentialsUnassignRequestBadRequestError
         - root.CredentialsUnassignRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_credential_id: acs_credential_id
@@ -15342,10 +15142,7 @@ service:
         - root.CredentialsUpdateRequestBadRequestError
         - root.CredentialsUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -15407,11 +15204,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_entrance_id": "acs_entrance_id",
                   },
@@ -15493,11 +15286,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_entrance_id": "acs_entrance_id",
                     "acs_user_id": "acs_user_id",
@@ -15560,11 +15349,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -15649,11 +15434,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_entrance_id": "acs_entrance_id",
                   },
@@ -15840,10 +15621,7 @@ service:
         - root.EntrancesGetRequestBadRequestError
         - root.EntrancesGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_entrance_id: acs_entrance_id
           response:
@@ -15896,10 +15674,7 @@ service:
         - root.EntrancesGrantAccessRequestBadRequestError
         - root.EntrancesGrantAccessRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_entrance_id: acs_entrance_id
             acs_user_id: acs_user_id
@@ -15935,10 +15710,7 @@ service:
         - root.EntrancesListRequestBadRequestError
         - root.EntrancesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -15985,10 +15757,7 @@ service:
         - root.EntrancesListCredentialsWithAccessRequestBadRequestError
         - root.EntrancesListCredentialsWithAccessRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_entrance_id: acs_entrance_id
           response:
@@ -16044,11 +15813,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -16131,11 +15896,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16218,11 +15979,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -16388,10 +16145,7 @@ service:
         - root.SystemsGetRequestBadRequestError
         - root.SystemsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -16445,10 +16199,7 @@ service:
         - root.SystemsListRequestBadRequestError
         - root.SystemsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -16503,10 +16254,7 @@ service:
         - >-
           root.SystemsListCompatibleCredentialManagerAcsSystemsRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -16559,11 +16307,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -16626,11 +16370,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -16743,11 +16483,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -16800,11 +16536,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -16881,11 +16613,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16973,11 +16701,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -17055,11 +16779,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -17122,11 +16842,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -17179,11 +16895,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -17236,11 +16948,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -17293,11 +17001,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -17627,10 +17331,7 @@ service:
         - root.UsersAddToAccessGroupRequestBadRequestError
         - root.UsersAddToAccessGroupRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_access_group_id: acs_access_group_id
@@ -17684,10 +17385,7 @@ service:
         - root.UsersCreateRequestBadRequestError
         - root.UsersCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -17738,10 +17436,7 @@ service:
         - root.UsersDeleteRequestBadRequestError
         - root.UsersDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -17772,10 +17467,7 @@ service:
         - root.UsersGetRequestBadRequestError
         - root.UsersGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -17833,10 +17525,7 @@ service:
         - root.UsersListRequestBadRequestError
         - root.UsersListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -17887,10 +17576,7 @@ service:
         - root.UsersListAccessibleEntrancesRequestBadRequestError
         - root.UsersListAccessibleEntrancesRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -17940,10 +17626,7 @@ service:
         - root.UsersRemoveFromAccessGroupRequestBadRequestError
         - root.UsersRemoveFromAccessGroupRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_access_group_id: acs_access_group_id
@@ -17974,10 +17657,7 @@ service:
         - root.UsersRevokeAccessToAllEntrancesRequestBadRequestError
         - root.UsersRevokeAccessToAllEntrancesRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -18007,10 +17687,7 @@ service:
         - root.UsersSuspendRequestBadRequestError
         - root.UsersSuspendRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -18040,10 +17717,7 @@ service:
         - root.UsersUnsuspendRequestBadRequestError
         - root.UsersUnsuspendRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -18094,10 +17768,7 @@ service:
         - root.UsersUpdateRequestBadRequestError
         - root.UsersUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -18127,11 +17798,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "action_attempt_id": "action_attempt_id",
                   },
@@ -18192,11 +17859,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "action_attempt_ids": [
                       "action_attempt_ids",
@@ -18317,10 +17980,7 @@ service:
         - root.ActionAttemptsGetRequestBadRequestError
         - root.ActionAttemptsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             action_attempt_id: action_attempt_id
           response:
@@ -18354,10 +18014,7 @@ service:
         - root.ActionAttemptsListRequestBadRequestError
         - root.ActionAttemptsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             action_attempt_ids:
               - action_attempt_ids
@@ -18394,11 +18051,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18471,11 +18124,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "client_session_id": "client_session_id",
                   },
@@ -18528,11 +18177,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18594,11 +18239,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18671,11 +18312,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18739,11 +18376,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18810,11 +18443,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "client_session_id": "client_session_id",
                   },
@@ -19016,10 +18645,7 @@ service:
         - root.ClientSessionsCreateRequestBadRequestError
         - root.ClientSessionsCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19061,10 +18687,7 @@ service:
         - root.ClientSessionsDeleteRequestBadRequestError
         - root.ClientSessionsDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             client_session_id: client_session_id
           response:
@@ -19093,10 +18716,7 @@ service:
         - root.ClientSessionsGetRequestBadRequestError
         - root.ClientSessionsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19143,10 +18763,7 @@ service:
         - root.ClientSessionsGetOrCreateRequestBadRequestError
         - root.ClientSessionsGetOrCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19189,10 +18806,7 @@ service:
         - root.ClientSessionsGrantAccessRequestBadRequestError
         - root.ClientSessionsGrantAccessRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19236,10 +18850,7 @@ service:
         - root.ClientSessionsListRequestBadRequestError
         - root.ClientSessionsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19281,10 +18892,7 @@ service:
         - root.ClientSessionsRevokeRequestBadRequestError
         - root.ClientSessionsRevokeRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             client_session_id: client_session_id
           response:
@@ -19314,11 +18922,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -19402,11 +19006,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connect_webview_id": "connect_webview_id",
                   },
@@ -19459,11 +19059,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connect_webview_id": "connect_webview_id",
                   },
@@ -19544,11 +19140,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -19926,10 +19518,7 @@ service:
         - root.ConnectWebviewsCreateRequestBadRequestError
         - root.ConnectWebviewsCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19981,10 +19570,7 @@ service:
         - root.ConnectWebviewsDeleteRequestBadRequestError
         - root.ConnectWebviewsDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connect_webview_id: connect_webview_id
           response:
@@ -20015,10 +19601,7 @@ service:
         - root.ConnectWebviewsGetRequestBadRequestError
         - root.ConnectWebviewsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connect_webview_id: connect_webview_id
           response:
@@ -20079,10 +19662,7 @@ service:
         - root.ConnectWebviewsListRequestBadRequestError
         - root.ConnectWebviewsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -20134,11 +19714,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connected_account_id": "connected_account_id",
                   },
@@ -20195,11 +19771,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connected_account_id": "connected_account_id",
                   },
@@ -20260,11 +19832,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -20329,11 +19897,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connected_account_id": "connected_account_id",
                   },
@@ -20638,10 +20202,7 @@ service:
         - root.ConnectedAccountsDeleteRequestBadRequestError
         - root.ConnectedAccountsDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connected_account_id: connected_account_id
           response:
@@ -20666,10 +20227,7 @@ service:
         - root.ConnectedAccountsGetRequestBadRequestError
         - root.ConnectedAccountsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connected_account_id: connected_account_id
           response:
@@ -20721,10 +20279,7 @@ service:
         - root.ConnectedAccountsListRequestBadRequestError
         - root.ConnectedAccountsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -20770,10 +20325,7 @@ service:
         - root.ConnectedAccountsUpdateRequestBadRequestError
         - root.ConnectedAccountsUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connected_account_id: connected_account_id
           response:
@@ -20821,11 +20373,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -20878,11 +20426,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -21188,11 +20732,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -21316,11 +20856,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -21374,11 +20910,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -21934,10 +21466,7 @@ service:
         - root.DevicesDeleteRequestBadRequestError
         - root.DevicesDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -21969,10 +21498,7 @@ service:
         - root.DevicesGetRequestBadRequestError
         - root.DevicesGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -22215,10 +21741,7 @@ service:
         - root.DevicesListRequestBadRequestError
         - root.DevicesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -22279,10 +21802,7 @@ service:
         - root.DevicesListDeviceProvidersRequestBadRequestError
         - root.DevicesListDeviceProvidersRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -22325,10 +21845,7 @@ service:
         - root.DevicesUpdateRequestBadRequestError
         - root.DevicesUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -22358,11 +21875,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -22415,11 +21928,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -22472,11 +21981,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -22603,10 +22108,7 @@ service:
         - root.SimulateConnectRequestBadRequestError
         - root.SimulateConnectRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -22636,10 +22138,7 @@ service:
         - root.SimulateDisconnectRequestBadRequestError
         - root.SimulateDisconnectRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -22669,10 +22168,7 @@ service:
         - root.SimulateRemoveRequestBadRequestError
         - root.SimulateRemoveRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -22702,11 +22198,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -22810,11 +22302,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -22930,11 +22418,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "is_managed": true,
@@ -23383,10 +22867,7 @@ service:
         - root.UnmanagedGetRequestBadRequestError
         - root.UnmanagedGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -23473,10 +22954,7 @@ service:
         - root.UnmanagedListRequestBadRequestError
         - root.UnmanagedListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -23534,10 +23012,7 @@ service:
         - root.UnmanagedUpdateRequestBadRequestError
         - root.UnmanagedUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             is_managed: true
@@ -23568,11 +23043,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -23649,11 +23120,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -24563,10 +24030,7 @@ service:
         - root.EventsGetRequestBadRequestError
         - root.EventsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -24627,10 +24091,7 @@ service:
         - root.EventsListRequestBadRequestError
         - root.EventsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -24672,11 +24133,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -25235,11 +24692,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -25411,11 +24864,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -25480,11 +24929,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -25966,10 +25411,7 @@ service:
         - root.LocksGetRequestBadRequestError
         - root.LocksGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -26407,10 +25849,7 @@ service:
         - root.LocksListRequestBadRequestError
         - root.LocksListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -26511,10 +25950,7 @@ service:
         - root.LocksLockDoorRequestBadRequestError
         - root.LocksLockDoorRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -26554,10 +25990,7 @@ service:
         - root.LocksUnlockDoorRequestBadRequestError
         - root.LocksUnlockDoorRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -26593,11 +26026,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "network_id": "network_id",
                   },
@@ -26657,11 +26086,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -26775,10 +26200,7 @@ service:
         - root.NetworksGetRequestBadRequestError
         - root.NetworksGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             network_id: network_id
           response:
@@ -26810,10 +26232,7 @@ service:
         - root.NetworksListRequestBadRequestError
         - root.NetworksListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -26847,11 +26266,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "ends_daily_at": "ends_daily_at",
@@ -26932,11 +26347,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "noise_threshold_id": "noise_threshold_id",
@@ -27010,11 +26421,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "noise_threshold_id": "noise_threshold_id",
                   },
@@ -27077,11 +26484,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -27147,11 +26550,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "noise_threshold_id": "noise_threshold_id",
@@ -27355,10 +26754,7 @@ service:
         - root.NoiseThresholdsCreateRequestBadRequestError
         - root.NoiseThresholdsCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             starts_daily_at: starts_daily_at
@@ -27411,10 +26807,7 @@ service:
         - root.NoiseThresholdsDeleteRequestBadRequestError
         - root.NoiseThresholdsDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             noise_threshold_id: noise_threshold_id
             device_id: device_id
@@ -27452,10 +26845,7 @@ service:
         - root.NoiseThresholdsGetRequestBadRequestError
         - root.NoiseThresholdsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             noise_threshold_id: noise_threshold_id
           response:
@@ -27495,10 +26885,7 @@ service:
         - root.NoiseThresholdsListRequestBadRequestError
         - root.NoiseThresholdsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -27548,10 +26935,7 @@ service:
         - root.NoiseThresholdsUpdateRequestBadRequestError
         - root.NoiseThresholdsUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             noise_threshold_id: noise_threshold_id
             device_id: device_id
@@ -27588,11 +26972,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -27689,10 +27069,7 @@ service:
         - root.SimulateTriggerNoiseThresholdRequestBadRequestError
         - root.SimulateTriggerNoiseThresholdRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -27722,11 +27099,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -27771,11 +27144,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -27922,10 +27291,7 @@ service:
         - root.PhonesDeactivateRequestBadRequestError
         - root.PhonesDeactivateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -27956,10 +27322,7 @@ service:
         - root.PhonesListRequestBadRequestError
         - root.PhonesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -28014,11 +27377,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -28292,10 +27651,7 @@ service:
         - root.SimulateCreateSandboxPhoneRequestBadRequestError
         - root.SimulateCreateSandboxPhoneRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -28359,11 +27715,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -28430,11 +27782,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -28740,11 +28088,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -28811,11 +28155,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -28884,11 +28224,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -29012,11 +28348,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -29081,11 +28413,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -29152,11 +28480,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "default_climate_setting": {},
                     "device_id": "device_id",
@@ -29779,10 +29103,7 @@ service:
         - root.ThermostatsCoolRequestBadRequestError
         - root.ThermostatsCoolRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -29820,10 +29141,7 @@ service:
         - root.ThermostatsGetRequestBadRequestError
         - root.ThermostatsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -30053,10 +29371,7 @@ service:
         - root.ThermostatsHeatRequestBadRequestError
         - root.ThermostatsHeatRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -30100,10 +29415,7 @@ service:
         - root.ThermostatsHeatCoolRequestBadRequestError
         - root.ThermostatsHeatCoolRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -30160,10 +29472,7 @@ service:
         - root.ThermostatsListRequestBadRequestError
         - root.ThermostatsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -30230,10 +29539,7 @@ service:
         - root.ThermostatsOffRequestBadRequestError
         - root.ThermostatsOffRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -30275,10 +29581,7 @@ service:
         - root.ThermostatsSetFanModeRequestBadRequestError
         - root.ThermostatsSetFanModeRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -30315,10 +29618,7 @@ service:
         - root.ThermostatsUpdateRequestBadRequestError
         - root.ThermostatsUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             default_climate_setting: {}
@@ -30349,11 +29649,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "schedule_ends_at": "schedule_ends_at",
@@ -30433,11 +29729,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "climate_setting_schedule_id": "climate_setting_schedule_id",
                   },
@@ -30490,11 +29782,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -30575,11 +29863,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -30656,11 +29940,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "climate_setting_schedule_id": "climate_setting_schedule_id",
                   },
@@ -30909,10 +30189,7 @@ service:
         - root.ClimateSettingSchedulesCreateRequestBadRequestError
         - root.ClimateSettingSchedulesCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             schedule_starts_at: schedule_starts_at
@@ -30962,10 +30239,7 @@ service:
         - root.ClimateSettingSchedulesDeleteRequestBadRequestError
         - root.ClimateSettingSchedulesDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             climate_setting_schedule_id: climate_setting_schedule_id
           response:
@@ -31000,10 +30274,7 @@ service:
         - root.ClimateSettingSchedulesGetRequestBadRequestError
         - root.ClimateSettingSchedulesGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -31052,10 +30323,7 @@ service:
         - root.ClimateSettingSchedulesListRequestBadRequestError
         - root.ClimateSettingSchedulesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -31115,10 +30383,7 @@ service:
         - root.ClimateSettingSchedulesUpdateRequestBadRequestError
         - root.ClimateSettingSchedulesUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             climate_setting_schedule_id: climate_setting_schedule_id
           response:
@@ -31166,11 +30431,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                     "user_identity_id": "user_identity_id",
@@ -31233,11 +30494,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -31318,11 +30575,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -31375,11 +30628,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -31427,11 +30676,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "user_identity_id": "user_identity_id",
@@ -31494,11 +30739,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -31562,11 +30803,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -31716,11 +30953,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -31805,11 +31038,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -31888,11 +31117,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                     "user_identity_id": "user_identity_id",
@@ -31955,11 +31180,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "user_identity_id": "user_identity_id",
@@ -32022,11 +31243,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -32411,10 +31628,7 @@ service:
         - root.UserIdentitiesAddAcsUserRequestBadRequestError
         - root.UserIdentitiesAddAcsUserRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             acs_user_id: acs_user_id
@@ -32455,10 +31669,7 @@ service:
         - root.UserIdentitiesCreateRequestBadRequestError
         - root.UserIdentitiesCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -32496,10 +31707,7 @@ service:
         - root.UserIdentitiesDeleteRequestBadRequestError
         - root.UserIdentitiesDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -32524,10 +31732,7 @@ service:
         - root.UserIdentitiesGetRequestBadRequestError
         - root.UserIdentitiesGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -32570,10 +31775,7 @@ service:
         - root.UserIdentitiesGrantAccessToDeviceRequestBadRequestError
         - root.UserIdentitiesGrantAccessToDeviceRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             device_id: device_id
@@ -32605,10 +31807,7 @@ service:
         - root.UserIdentitiesListRequestBadRequestError
         - root.UserIdentitiesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -32647,10 +31846,7 @@ service:
         - root.UserIdentitiesListAccessibleDevicesRequestBadRequestError
         - root.UserIdentitiesListAccessibleDevicesRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -32749,10 +31945,7 @@ service:
         - root.UserIdentitiesListAcsSystemsRequestBadRequestError
         - root.UserIdentitiesListAcsSystemsRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -32806,10 +31999,7 @@ service:
         - root.UserIdentitiesListAcsUsersRequestBadRequestError
         - root.UserIdentitiesListAcsUsersRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -32864,10 +32054,7 @@ service:
         - root.UserIdentitiesRemoveAcsUserRequestBadRequestError
         - root.UserIdentitiesRemoveAcsUserRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             acs_user_id: acs_user_id
@@ -32902,10 +32089,7 @@ service:
         - root.UserIdentitiesRevokeAccessToDeviceRequestBadRequestError
         - root.UserIdentitiesRevokeAccessToDeviceRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             device_id: device_id
@@ -32949,10 +32133,7 @@ service:
         - root.UserIdentitiesUpdateRequestBadRequestError
         - root.UserIdentitiesUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -32982,11 +32163,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "enrollment_automation_id": "enrollment_automation_id",
                   },
@@ -33039,11 +32216,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "enrollment_automation_id": "enrollment_automation_id",
                   },
@@ -33104,11 +32277,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "credential_manager_acs_system_id": "credential_manager_acs_system_id",
                     "user_identity_id": "user_identity_id",
@@ -33199,11 +32368,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -33442,10 +32607,7 @@ service:
         - root.EnrollmentAutomationsDeleteRequestBadRequestError
         - root.EnrollmentAutomationsDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             enrollment_automation_id: enrollment_automation_id
           response:
@@ -33476,10 +32638,7 @@ service:
         - root.EnrollmentAutomationsGetRequestBadRequestError
         - root.EnrollmentAutomationsGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             enrollment_automation_id: enrollment_automation_id
           response:
@@ -33529,10 +32688,7 @@ service:
         - root.EnrollmentAutomationsLaunchRequestBadRequestError
         - root.EnrollmentAutomationsLaunchRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             credential_manager_acs_system_id: credential_manager_acs_system_id
@@ -33571,10 +32727,7 @@ service:
         - root.EnrollmentAutomationsListRequestBadRequestError
         - root.EnrollmentAutomationsListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -33610,11 +32763,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "url": "url",
                   },
@@ -33677,11 +32826,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "webhook_id": "webhook_id",
                   },
@@ -33726,11 +32871,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "webhook_id": "webhook_id",
                   },
@@ -33784,11 +32925,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "ok": true,
@@ -33829,11 +32966,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "event_types": [
                       "event_types",
@@ -33994,10 +33127,7 @@ service:
         - root.WebhooksCreateRequestBadRequestError
         - root.WebhooksCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             url: url
           response:
@@ -34030,10 +33160,7 @@ service:
         - root.WebhooksDeleteRequestBadRequestError
         - root.WebhooksDeleteRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             webhook_id: webhook_id
           response:
@@ -34061,10 +33188,7 @@ service:
         - root.WebhooksGetRequestBadRequestError
         - root.WebhooksGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             webhook_id: webhook_id
           response:
@@ -34092,10 +33216,7 @@ service:
         - root.WebhooksListRequestBadRequestError
         - root.WebhooksListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               webhooks:
@@ -34127,10 +33248,7 @@ service:
         - root.WebhooksUpdateRequestBadRequestError
         - root.WebhooksUpdateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             webhook_id: webhook_id
             event_types:
@@ -34162,11 +33280,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                   },
@@ -34234,11 +33348,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "ok": true,
@@ -34276,11 +33386,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "ok": true,
@@ -34320,11 +33426,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "action_attempt": {
@@ -34488,10 +33590,7 @@ service:
         - root.WorkspacesCreateRequestBadRequestError
         - root.WorkspacesCreateRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             name: name
           response:
@@ -34519,10 +33618,7 @@ service:
         - root.WorkspacesGetRequestBadRequestError
         - root.WorkspacesGetRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               workspace:
@@ -34548,10 +33644,7 @@ service:
         - root.WorkspacesListRequestBadRequestError
         - root.WorkspacesListRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               workspaces:
@@ -34577,10 +33670,7 @@ service:
         - root.WorkspacesResetSandboxRequestBadRequestError
         - root.WorkspacesResetSandboxRequestUnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               action_attempt:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/speechify.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/speechify.json
@@ -956,9 +956,7 @@ types:
               "docs": "Create a new API key for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "api_key": "api_key",
@@ -988,9 +986,7 @@ types:
               "docs": "Deletes the given API key for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -1014,9 +1010,7 @@ types:
               "docs": "Fetches all the API keys for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "response": {
                     "body": [
                       {
@@ -1048,9 +1042,7 @@ types:
               "docs": "Update API key name for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -1113,8 +1105,7 @@ service:
         type: list<root.ApiKey>
         status-code: 200
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           response:
             body:
               - api_key: api_key
@@ -1137,8 +1128,7 @@ service:
         type: root.ApiKey
         status-code: 200
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           response:
             body:
               api_key: api_key
@@ -1161,8 +1151,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            Authorization: Authorization
+          headers: {}
     UpdateApiKey:
       path: /v1/token/{id}
       method: PATCH
@@ -1186,8 +1175,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            Authorization: Authorization
+          headers: {}
           request: string
           response:
             body:
@@ -1222,9 +1210,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "input": "input",
                     "voice_id": "voice_id",
@@ -1295,9 +1281,7 @@ simba-turbo ModelTurbo",
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "input": "input",
                     "voice_id": "voice_id",
@@ -1390,7 +1374,6 @@ simba-turbo ModelTurbo",
                 {
                   "headers": {
                     "Accept": "audio/mpeg",
-                    "Authorization": "Authorization",
                   },
                   "request": {
                     "input": "input",
@@ -1756,8 +1739,7 @@ service:
         - root.ExperimentalStreamCreateRequestForbiddenError
         - root.ExperimentalStreamCreateRequestInternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             input: input
             voice_id: voice_id
@@ -1837,8 +1819,7 @@ service:
         - root.GetSpeechRequestForbiddenError
         - root.GetSpeechRequestInternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             input: input
             voice_id: voice_id
@@ -1926,7 +1907,6 @@ service:
       examples:
         - headers:
             Accept: audio/mpeg
-            Authorization: Authorization
           request:
             input: input
             voice_id: voice_id
@@ -1955,9 +1935,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "grant_type": "client_credentials",
                   },
@@ -2109,8 +2087,7 @@ service:
       errors:
         - root.CreateAccessTokenRequestBadRequestError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             grant_type: client_credentials
           response:
@@ -2143,9 +2120,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "consent": "consent",
                     "name": "name",
@@ -2216,9 +2191,7 @@ This should include the fullName and email of the consenting individual.",
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -2246,9 +2219,7 @@ This should include the fullName and email of the consenting individual.",
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "response": {
                     "body": [
                       {
@@ -2308,8 +2279,7 @@ service:
         - root.GetVoicesRequestNotFoundError
         - root.GetVoicesRequestInternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           response:
             body:
               - avatar_image: avatar_image
@@ -2362,8 +2332,7 @@ service:
         - root.CreateVoiceRequestPaymentRequiredError
         - root.CreateVoiceRequestInternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             name: name
             consent: consent
@@ -2394,8 +2363,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            Authorization: Authorization
+          headers: {}
   source:
     openapi: ../openapi.json
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/superagent.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/superagent.json
@@ -472,9 +472,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                     "type": "type",
@@ -536,9 +534,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -573,9 +569,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -607,9 +601,7 @@ types:
               "docs": "List all agents",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -638,9 +630,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -684,9 +674,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -758,8 +746,7 @@ types:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -796,8 +783,7 @@ types:
       errors:
         - root.CreateAgentApiV1AgentsPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             name: name
             type: type
@@ -823,8 +809,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -848,8 +833,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -876,8 +860,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           request:
             key: value
           response:
@@ -913,8 +896,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           request:
             input:
               key: value
@@ -946,9 +928,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "description": "description",
                   },
@@ -992,9 +972,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "tokenId": "tokenId",
                   },
@@ -1029,9 +1007,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "tokenId": "tokenId",
                   },
@@ -1063,9 +1039,7 @@ imports:
               "docs": "List all API tokens",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -1108,8 +1082,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -1134,8 +1107,7 @@ imports:
       errors:
         - root.CreateApiTokenApiV1ApiTokensPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             description: description
           response:
@@ -1161,8 +1133,7 @@ imports:
       examples:
         - path-parameters:
             tokenId: tokenId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1186,8 +1157,7 @@ imports:
       examples:
         - path-parameters:
             tokenId: tokenId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1216,9 +1186,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "email": "email",
                     "password": "password",
@@ -1264,9 +1232,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "email": "email",
                     "password": "password",
@@ -1342,8 +1308,7 @@ service:
       errors:
         - root.SignInApiV1AuthSignInPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             email: email
             password: password
@@ -1375,8 +1340,7 @@ service:
       errors:
         - root.SignUpApiV1AuthSignUpPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             email: email
             password: password
@@ -1406,9 +1370,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                     "type": "type",
@@ -1471,9 +1433,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "documentId": "documentId",
                   },
@@ -1508,9 +1468,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "documentId": "documentId",
                   },
@@ -1542,9 +1500,7 @@ service:
               "docs": "List all documents",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -1587,8 +1543,7 @@ service:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -1625,8 +1580,7 @@ service:
       errors:
         - root.CreateDocumentApiV1DocumentsPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             type: type
             url: url
@@ -1654,8 +1608,7 @@ service:
       examples:
         - path-parameters:
             documentId: documentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1679,8 +1632,7 @@ service:
       examples:
         - path-parameters:
             documentId: documentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1709,9 +1661,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "input_variables": [],
                     "name": "name",
@@ -1761,9 +1711,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "promptId": "promptId",
                   },
@@ -1798,9 +1746,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "promptId": "promptId",
                   },
@@ -1832,9 +1778,7 @@ imports:
               "docs": "List all prompts",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -1863,9 +1807,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "promptId": "promptId",
                   },
@@ -1923,8 +1865,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -1952,8 +1893,7 @@ imports:
       errors:
         - root.CreateAPromptApiV1PromptsPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             name: name
             input_variables: []
@@ -1980,8 +1920,7 @@ imports:
       examples:
         - path-parameters:
             promptId: promptId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -2005,8 +1944,7 @@ imports:
       examples:
         - path-parameters:
             promptId: promptId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -2034,8 +1972,7 @@ imports:
       examples:
         - path-parameters:
             promptId: promptId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           request:
             key: value
           response:
@@ -2066,9 +2003,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                     "type": "type",
@@ -2117,9 +2052,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "toolId": "toolId",
                   },
@@ -2154,9 +2087,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "toolId": "toolId",
                   },
@@ -2188,9 +2119,7 @@ imports:
               "docs": "List all tools",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -2233,8 +2162,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -2262,8 +2190,7 @@ imports:
       errors:
         - root.CreateAToolApiV1ToolsPostRequestUnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             name: name
             type: type
@@ -2289,8 +2216,7 @@ imports:
       examples:
         - path-parameters:
             toolId: toolId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -2313,8 +2239,7 @@ imports:
       examples:
         - path-parameters:
             toolId: toolId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -2337,9 +2262,7 @@ imports:
               "docs": "List all agent traces",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -2382,8 +2305,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -2410,9 +2332,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "userId": "userId",
                   },
@@ -2444,9 +2364,7 @@ imports:
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -2488,8 +2406,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -2511,8 +2428,7 @@ imports:
       examples:
         - path-parameters:
             userId: userId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-streaming-with-stream-condition.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-streaming-with-stream-condition.json
@@ -15,10 +15,7 @@
               "docs": "Create a chat while specifying the default retrieval parameters used by the prompt.",
               "examples": [
                 {
-                  "headers": {
-                    "Request-Timeout": "Request-Timeout",
-                    "Request-Timeout-Millis": "Request-Timeout-Millis",
-                  },
+                  "headers": {},
                   "request": {
                     "query": "How can I use the Vectara platform?",
                     "stream_response": false,
@@ -69,10 +66,7 @@
               "docs": "Create a chat while specifying the default retrieval parameters used by the prompt.",
               "examples": [
                 {
-                  "headers": {
-                    "Request-Timeout": "Request-Timeout",
-                    "Request-Timeout-Millis": "Request-Timeout-Millis",
-                  },
+                  "headers": {},
                   "request": {
                     "query": "How can I use the Vectara platform?",
                     "stream_response": true,
@@ -189,9 +183,7 @@
         type: ChatStreamedResponse
         format: json
       examples:
-        - headers:
-            Request-Timeout: Request-Timeout
-            Request-Timeout-Millis: Request-Timeout-Millis
+        - headers: {}
           request:
             query: How can I use the Vectara platform?
             stream_response: true
@@ -224,9 +216,7 @@
         type: ChatFullResponse
         status-code: 200
       examples:
-        - headers:
-            Request-Timeout: Request-Timeout
-            Request-Timeout-Millis: Request-Timeout-Millis
+        - headers: {}
           request:
             query: How can I use the Vectara platform?
             stream_response: false

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-token-variable-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-token-variable-name.json
@@ -53,9 +53,7 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "X-API-Key": "X-API-Key",
-                  },
+                  "headers": {},
                   "request": {
                     "prompt": "prompt",
                   },
@@ -117,8 +115,7 @@
         type: string
         status-code: 200
       examples:
-        - headers:
-            X-API-Key: X-API-Key
+        - headers: {}
           request:
             prompt: prompt
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-version.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-version.json
@@ -53,9 +53,7 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "X-API-Key": "X-API-Key",
-                  },
+                  "headers": {},
                   "request": {
                     "prompt": "prompt",
                   },
@@ -117,8 +115,7 @@
         type: string
         status-code: 200
       examples:
-        - headers:
-            X-API-Key: X-API-Key
+        - headers: {}
           request:
             prompt: prompt
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/dates.json
@@ -14,10 +14,7 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "date_header": "date_header",
-                    "date_time_header": "date_time_header",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -99,9 +96,7 @@
         type: Response
         status-code: 200
       examples:
-        - headers:
-            date_header: date_header
-            date_time_header: date_time_header
+        - headers: {}
           request: {}
           response:
             body:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/intercom.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/intercom.json
@@ -11621,9 +11621,7 @@ You can view the currently authorised admin along with the embedded app object (
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -11677,9 +11675,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "query-parameters": {
                     "created_at_after": "1677253093",
@@ -11758,9 +11754,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -11807,9 +11801,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin found",
                   "path-parameters": {
                     "id": 1,
@@ -11868,9 +11860,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -11905,9 +11895,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -11942,9 +11930,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Unauthorized",
                   "path-parameters": {
                     "id": 1,
@@ -12117,8 +12103,7 @@ service:
         status-code: 200
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -12182,8 +12167,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -12208,8 +12192,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -12234,8 +12217,7 @@ service:
         - name: Unauthorized
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -12289,8 +12271,7 @@ service:
           query-parameters:
             created_at_after: '1677253093'
             created_at_before: '1677861493'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: activity_log.list
@@ -12336,8 +12317,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin.list
@@ -12376,8 +12356,7 @@ service:
         - name: Admin found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -12655,9 +12634,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "article created",
                   "request": {
                     "author_id": 991267407,
@@ -13120,9 +13097,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "author_id": 1295,
@@ -13602,9 +13577,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -13650,9 +13623,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -13716,9 +13687,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article found",
                   "path-parameters": {
                     "id": 1,
@@ -14193,9 +14162,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Search successful",
                   "query-parameters": {
                     "phrase": "Getting started",
@@ -14288,9 +14255,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -14742,9 +14707,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -15479,8 +15442,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -15535,8 +15497,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: article created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -15953,8 +15914,7 @@ service:
                 neutral_reaction_percentage: 0
                 sad_reaction_percentage: 0
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -16386,8 +16346,7 @@ service:
         - name: Article found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: article
@@ -16817,8 +16776,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -17225,8 +17183,7 @@ service:
         - name: Article Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -17655,8 +17612,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '51'
@@ -17702,8 +17658,7 @@ service:
           query-parameters:
             phrase: Getting started
             state: published
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -17950,9 +17905,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -18067,9 +18020,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -18120,9 +18071,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -18208,9 +18157,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -18292,9 +18239,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "id",
@@ -18350,9 +18295,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "path-parameters": {
                     "id": "id",
@@ -18408,9 +18351,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company Not Found",
                   "path-parameters": {
                     "id": "id",
@@ -18520,9 +18461,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "company_id": "company_remote_id",
@@ -18605,9 +18544,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -18649,9 +18586,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "58a430d35458202d41b1e65b",
@@ -18745,9 +18680,7 @@ When using the Companies endpoint and the pages object to iterate through the re
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "order": "desc",
@@ -18857,9 +18790,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "company_id": "12345",
@@ -18987,9 +18918,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -19264,8 +19193,7 @@ service:
             company_id: '12345'
             tag_id: '678910'
             segment_id: '98765'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19342,8 +19270,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: my company
             company_id: company_remote_id
@@ -19405,8 +19332,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -19469,8 +19395,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -19528,8 +19453,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: 667d60848a68186f43bafd45
@@ -19558,8 +19482,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19651,8 +19574,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19715,8 +19637,7 @@ service:
         - name: Successful
           query-parameters:
             order: desc
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19801,8 +19722,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19871,8 +19791,7 @@ service:
         - name: Successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d608d8a68186f43bafd70
           response:
@@ -19912,8 +19831,7 @@ service:
         - name: Bad Request
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 58a430d35458202d41b1e65b
           response:
@@ -19953,8 +19871,7 @@ service:
         - name: Company Not Found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -20018,8 +19935,7 @@ service:
           path-parameters:
             contact_id: 58a430d35458202d41b1e65b
             id: 58a430d35458202d41b1e65b
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -20179,9 +20095,7 @@ types:
               "docs": "You can archive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20223,9 +20137,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "email": "joebloggs@intercom.io",
@@ -20317,9 +20229,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "id",
@@ -20366,9 +20276,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -20473,9 +20381,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "from": "667d60ac8a68186f43bafdbb",
@@ -20686,9 +20592,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -20814,9 +20718,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20910,9 +20812,7 @@ The table below shows the operators you can use to define how you want to search
               "docs": "You can unarchive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20954,9 +20854,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -21113,9 +21011,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -21191,9 +21087,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -21251,9 +21145,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -21337,9 +21229,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -21627,8 +21517,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21685,8 +21574,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21733,8 +21621,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21792,8 +21679,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21826,8 +21712,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -21938,8 +21823,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
             name: joe bloggs
@@ -22011,8 +21895,7 @@ service:
         - name: successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -22052,8 +21935,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from: 667d60ac8a68186f43bafdbb
             into: 667d60ac8a68186f43bafdbc
@@ -22338,8 +22220,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -22440,8 +22321,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -22529,8 +22409,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
           response:
@@ -22596,8 +22475,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -22624,8 +22502,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -22831,9 +22708,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attach a contact to a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -23009,9 +22884,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -23238,9 +23111,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation using assignment rules",
                   "path-parameters": {
                     "id": "123",
@@ -23381,9 +23252,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -23508,9 +23377,7 @@ It is not possible to use this endpoint with Workflows.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad request",
                   "path-parameters": {
                     "id": 1,
@@ -23692,9 +23559,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation created",
                   "request": {
                     "body": "Hello there",
@@ -23716,9 +23581,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact Not Found",
                   "request": {
                     "body": "Hello there",
@@ -23786,9 +23649,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Detach a contact from a group conversation",
                   "path-parameters": {
                     "contact_id": "123",
@@ -23962,9 +23823,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -24138,9 +23997,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -24314,9 +24171,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Last customer",
                   "path-parameters": {
                     "contact_id": "123",
@@ -24544,9 +24399,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -24642,9 +24495,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Close a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24761,9 +24612,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Snooze a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24880,9 +24729,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Open a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24998,9 +24845,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -25122,9 +24967,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -25279,9 +25122,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Redact a conversation part",
                   "request": {
                     "conversation_id": "19894788788",
@@ -25400,9 +25241,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "request": {
                     "conversation_id": "really_123_doesnt_exist",
@@ -25548,9 +25387,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25673,9 +25510,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25804,9 +25639,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User last conversation reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25929,9 +25762,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -26097,9 +25928,7 @@ For AI agent conversation metadata, please note that you need to have the agent 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -26327,9 +26156,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -26475,9 +26302,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -26625,9 +26450,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": 1,
@@ -27123,8 +26946,7 @@ service:
         - root.ForbiddenError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation.list
@@ -27207,8 +27029,7 @@ service:
         - root.NotFoundError
       examples:
         - name: conversation created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -27224,8 +27045,7 @@ service:
               message_type: inapp
               conversation_id: '363'
         - name: Contact Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -27292,8 +27112,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -27409,8 +27228,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -27520,8 +27338,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -27963,8 +27780,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -28070,8 +27886,7 @@ service:
         - name: User reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -28161,8 +27976,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -28264,8 +28078,7 @@ service:
         - name: User last conversation reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -28355,8 +28168,7 @@ service:
         - name: Not found
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -28475,8 +28287,7 @@ service:
         - name: Close a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -28561,8 +28372,7 @@ service:
         - name: Snooze a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017691'
             snoozed_until: 1673609604
@@ -28647,8 +28457,7 @@ service:
         - name: Open a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
             message_type: open
@@ -28732,8 +28541,7 @@ service:
         - name: Assign a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -28822,8 +28630,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -28937,8 +28744,7 @@ service:
         - name: Assign a conversation using assignment rules
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -29064,8 +28870,7 @@ service:
         - name: Attach a contact to a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -29197,8 +29002,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -29376,8 +29180,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29508,8 +29311,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29640,8 +29442,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29772,8 +29573,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29933,8 +29733,7 @@ service:
         - root.NotFoundError
       examples:
         - name: Redact a conversation part
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: '19894788788'
@@ -30021,8 +29820,7 @@ service:
                   - id: '7583'
               ai_agent_participated: false
         - name: Not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: really_123_doesnt_exist
@@ -30142,8 +29940,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '79'
           response:
@@ -30238,8 +30035,7 @@ service:
         - name: Bad request
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '80'
           response:
@@ -30600,9 +30396,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "data_type": "string",
@@ -30635,9 +30429,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Same name already exists",
                   "request": {
                     "data_type": "integer",
@@ -30670,9 +30462,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid name",
                   "request": {
                     "data_type": "string",
@@ -30705,9 +30495,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute already exists",
                   "request": {
                     "data_type": "string",
@@ -30740,9 +30528,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid Data Type",
                   "request": {
                     "data_type": "string",
@@ -30775,9 +30561,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options for list",
                   "request": {
                     "data_type": "string",
@@ -30870,9 +30654,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -31300,9 +31082,7 @@ You can update a data attribute.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": 1,
@@ -31341,9 +31121,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options in list",
                   "path-parameters": {
                     "id": 1,
@@ -31382,9 +31160,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -31423,9 +31199,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Has Dependant Object",
                   "path-parameters": {
                     "id": 1,
@@ -31804,8 +31578,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -32186,8 +31959,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Mithril Shirt
             model: company
@@ -32214,8 +31986,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Same name already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: contact
@@ -32242,8 +32013,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid name
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: '!nv@l!d n@me'
             model: company
@@ -32270,8 +32040,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Attribute already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: company
@@ -32298,8 +32067,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid Data Type
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The Second Ring
             model: company
@@ -32326,8 +32094,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Too few options for list
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: My Data Attribute
             model: contact
@@ -32412,8 +32179,7 @@ service:
         - name: Successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -32444,8 +32210,7 @@ service:
         - name: Too few options in list
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Too few options
@@ -32476,8 +32241,7 @@ service:
         - name: Attribute Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -32508,8 +32272,7 @@ service:
         - name: Has Dependant Object
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: true
             description: Trying to archieve
@@ -32623,9 +32386,7 @@ Duplicated events are responded to using the normal `202 Accepted` code - an err
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "request": {},
                 },
               ],
@@ -33151,8 +32912,7 @@ service:
       errors:
         - root.UnauthorizedError
       examples:
-        - headers:
-            Intercom-Version: Intercom-Version
+        - headers: {}
           request: {}
   source:
     openapi: ../openapi.yml
@@ -33175,9 +32935,7 @@ docs: Everything about your Data Events
               "docs": "You can cancel your job",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -33231,9 +32989,7 @@ The only parameters you need to provide are the range of dates that you want exp
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "created_at_after": 1719474967,
@@ -33293,9 +33049,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "job_identifier": "job_identifier",
                   },
@@ -33325,9 +33079,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -33477,8 +33229,7 @@ Your exported message data will be streamed continuously back down to you in a g
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             created_at_after: 1719474967
             created_at_before: 1719492967
@@ -33522,8 +33273,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -33550,8 +33300,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -33588,8 +33337,7 @@ Your exported message data will be streamed continuously back down to you in a g
       examples:
         - path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
   source:
     openapi: ../openapi.yml
   display-name: Data Export
@@ -33650,9 +33398,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "collection created",
                   "request": {
                     "name": "Thanks for everything",
@@ -33862,9 +33608,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "description": "Missing required parameter",
@@ -34127,9 +33871,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -34173,9 +33915,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -34243,9 +33983,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Help Centers found",
                   "response": {
                     "body": {
@@ -34287,9 +34025,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -34527,9 +34263,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -34575,9 +34309,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -34790,9 +34522,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -35200,8 +34930,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -35282,8 +35011,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: collection created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Thanks for everything
           response:
@@ -35450,8 +35178,7 @@ service:
                   description: ' Collection description'
               help_center_id: 81
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: collection 51
             description: Missing required parameter
@@ -35643,8 +35370,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '170'
@@ -35855,8 +35581,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -36025,8 +35750,7 @@ service:
         - name: Collection Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -36217,8 +35941,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '182'
@@ -36249,8 +35972,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '93'
@@ -36278,8 +36000,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Help Centers found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -36436,9 +36157,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "user message created",
                   "request": {
                     "body": "heyy",
@@ -36461,9 +36180,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "lead message created",
                   "request": {
                     "body": "heyy",
@@ -36486,9 +36203,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "admin message created",
                   "request": {
                     "body": "heyy",
@@ -36515,9 +36230,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for message",
                   "request": {
                     "from": {
@@ -36544,9 +36257,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No subject supplied for email message",
                   "request": {
                     "body": "hey there",
@@ -36573,9 +36284,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for email message",
                   "request": {
                     "from": {
@@ -36727,8 +36436,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - name: user message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -36745,8 +36453,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: lead message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: lead
@@ -36763,8 +36470,7 @@ service:
               message_type: inapp
               conversation_id: '477'
         - name: admin message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36784,8 +36490,7 @@ service:
               message_type: inapp
               conversation_id: '64619700005570'
         - name: No body supplied for message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36805,8 +36510,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No subject supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36826,8 +36530,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No body supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36916,9 +36619,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "body": "<p>New costumes in store for this spooky season</p>",
@@ -37000,9 +36701,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -37043,9 +36742,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -37122,9 +36819,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -37217,9 +36912,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -37277,9 +36970,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -37341,9 +37032,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -37386,9 +37075,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -37430,9 +37117,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "News Item Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -37651,8 +37336,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -37730,8 +37414,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Halloween is here!
             body: <p>New costumes in store for this spooky season</p>
@@ -37792,8 +37475,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '34'
@@ -37841,8 +37523,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -37872,8 +37553,7 @@ service:
         - name: News Item Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -37923,8 +37603,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '40'
@@ -37954,8 +37633,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -38007,8 +37685,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -38056,8 +37733,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '72'
@@ -38203,9 +37879,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -38251,9 +37925,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -38299,9 +37971,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "id": 1,
@@ -38397,9 +38067,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -38508,9 +38176,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Note found",
                   "path-parameters": {
                     "id": 1,
@@ -38656,8 +38322,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -38752,8 +38417,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60978a68186f43bafd9e
@@ -38787,8 +38451,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60988a68186f43bafd9f
@@ -38822,8 +38485,7 @@ service:
         - name: Contact not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: '123'
@@ -38877,8 +38539,7 @@ service:
         - name: Note found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: note
@@ -38968,9 +38629,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -39033,9 +38692,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "123",
@@ -39155,8 +38812,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment.list
@@ -39200,8 +38856,7 @@ service:
         - name: Successful response
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment
@@ -39283,9 +38938,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39319,9 +38972,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39355,9 +39006,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Resource not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39438,9 +39087,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39502,9 +39149,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -39677,8 +39322,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -39701,8 +39345,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -39725,8 +39368,7 @@ service:
         - name: Resource not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: invalid_id
             consent_type: opt_in
@@ -39778,8 +39420,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '37846'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: subscription
@@ -39814,8 +39455,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -39924,9 +39564,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "custom_attributes": {
@@ -39943,9 +39581,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - exception sending sms",
                   "request": {
                     "custom_attributes": {
@@ -39962,9 +39598,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - invalid number",
                   "request": {
                     "custom_attributes": {
@@ -39981,9 +39615,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "unprocessable entity",
                   "request": {
                     "custom_attributes": {
@@ -40060,8 +39692,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -40072,8 +39703,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - exception sending sms
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -40084,8 +39714,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - invalid number
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -40096,8 +39725,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: unprocessable entity
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+40241100100'
             custom_attributes:
@@ -40135,9 +39763,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40159,9 +39785,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40183,9 +39807,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40250,9 +39872,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40275,9 +39895,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40347,9 +39965,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -40372,9 +39988,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -40458,9 +40072,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Action successful",
                   "request": {
                     "name": "test",
@@ -40479,9 +40091,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid parameters",
                   "request": {
                     "name": "Independent",
@@ -40500,9 +40110,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company not found",
                   "request": {
                     "companies": [
@@ -40526,9 +40134,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User  not found",
                   "request": {
                     "name": "test",
@@ -40579,9 +40185,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "123",
                   },
@@ -40610,9 +40214,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40664,9 +40266,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40689,9 +40289,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40714,9 +40312,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40786,9 +40382,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "7522907",
@@ -40811,9 +40405,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -40836,9 +40428,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -40910,9 +40500,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag found",
                   "path-parameters": {
                     "id": "123",
@@ -40960,9 +40548,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -41092,8 +40678,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -41108,8 +40693,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -41124,8 +40708,7 @@ service:
         - name: Tag not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -41166,8 +40749,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -41213,8 +40795,7 @@ service:
         - name: successful
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -41230,8 +40811,7 @@ service:
         - name: Conversation not found
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -41281,8 +40861,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41298,8 +40877,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41315,8 +40893,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41346,8 +40923,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -41392,8 +40968,7 @@ service:
         - root.NotFoundError
       examples:
         - name: Action successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
           response:
@@ -41406,8 +40981,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Invalid parameters
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Independent
           response:
@@ -41420,8 +40994,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Company not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             companies:
@@ -41436,8 +41009,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: User  not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             users:
@@ -41476,8 +41048,7 @@ service:
         - name: Tag found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -41508,8 +41079,7 @@ service:
       examples:
         - path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
     attachTagToTicket:
       path: /tickets/{ticket_id}/tags
       method: POST
@@ -41546,8 +41116,7 @@ service:
         - name: successful
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -41563,8 +41132,7 @@ service:
         - name: Ticket not found
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -41614,8 +41182,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41631,8 +41198,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41648,8 +41214,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41719,9 +41284,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -41762,9 +41325,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -41865,8 +41426,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team.list
@@ -41901,8 +41461,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team
@@ -41962,9 +41521,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute created",
                   "path-parameters": {
                     "ticket_type_id": "ticket_type_id",
@@ -42082,9 +41639,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute updated",
                   "path-parameters": {
                     "id": "id",
@@ -42318,8 +41873,7 @@ service:
         - name: Ticket Type Attribute created
           path-parameters:
             ticket_type_id: ticket_type_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Attribute Title
             description: Attribute Description
@@ -42433,8 +41987,7 @@ service:
           path-parameters:
             ticket_type_id: ticket_type_id
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             description: New Attribute Description
           response:
@@ -42490,9 +42043,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type created",
                   "request": {
                     "category": "Customer",
@@ -42567,9 +42118,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type found",
                   "path-parameters": {
                     "id": "id",
@@ -42641,9 +42190,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -42693,9 +42240,7 @@ You can update a ticket type.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type updated",
                   "path-parameters": {
                     "id": "id",
@@ -42796,8 +42341,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -42843,8 +42387,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Ticket type created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Customer Issue
             description: Customer Report Template
@@ -42905,8 +42448,7 @@ service:
         - name: Ticket type found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket_type
@@ -42976,8 +42518,7 @@ service:
         - name: Ticket type updated
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Bug Report 2
           response:
@@ -43038,9 +42579,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "request": {
                     "contacts": [
@@ -43197,9 +42736,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket found",
                   "path-parameters": {
                     "id": "id",
@@ -43325,9 +42862,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123",
@@ -43379,9 +42914,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123",
@@ -43433,9 +42966,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin quick_reply reply",
                   "path-parameters": {
                     "id": "123",
@@ -43485,9 +43016,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -43625,9 +43154,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -43779,9 +43306,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "id",
@@ -44022,9 +43547,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": "id",
@@ -44263,9 +43786,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assignee not found",
                   "path-parameters": {
                     "id": "id",
@@ -45258,8 +44779,7 @@ service:
         - name: User reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -45302,8 +44822,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -45350,8 +44869,7 @@ service:
         - name: Admin quick_reply reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: quick_reply
             type: admin
@@ -45386,8 +44904,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -45468,8 +44985,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '1234'
             contacts:
@@ -45569,8 +45085,7 @@ service:
         - name: Ticket found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket
@@ -45687,8 +45202,7 @@ service:
         - name: Successful response
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -45875,8 +45389,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -46061,8 +45574,7 @@ service:
         - name: Assignee not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -46421,8 +45933,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -46544,9 +46055,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "type": "user",
@@ -46659,9 +46168,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "query-parameters": {
                     "user_id": "user_id",
@@ -46786,9 +46293,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "id": "667d61cc8a68186f43bafe95",
@@ -46881,9 +46386,7 @@ docs: Everything about your tickets
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "visitor Not Found",
                   "request": {
                     "name": "Christian Fail",
@@ -47030,8 +46533,7 @@ service:
         - name: successful
           query-parameters:
             user_id: user_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: visitor
@@ -47126,8 +46628,7 @@ service:
         - root.NotFoundError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d61cc8a68186f43bafe95
             name: Gareth Bale
@@ -47200,8 +46701,7 @@ service:
               custom_attributes:
                 key: value
         - name: visitor Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             user_id: fail
             name: Christian Fail
@@ -47312,8 +46812,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: user
             user:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/merge.json
@@ -9814,9 +9814,7 @@ service:
               "docs": "Returns the account token for the end user with the provided public token.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "public_token": "public_token",
                   },
@@ -9886,8 +9884,7 @@ service:
       examples:
         - path-parameters:
             public_token: public_token
-          headers:
-            X-Account-Token: X-Account-Token
+          headers: {}
           response:
             body:
               account_token: T9klMDQrcHdm9jrtHuOS2Nf06BIHwMNjpPXPMB
@@ -17162,9 +17159,7 @@ service:
               "docs": "Create a remote key.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "Remote Deployment Key 1",
                   },
@@ -17241,8 +17236,7 @@ service:
         type: root.RemoteKey
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           request:
             name: Remote Deployment Key 1
           response:
@@ -17610,9 +17604,7 @@ service:
               "docs": "Gets issues.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -17706,9 +17698,7 @@ service:
               "docs": "Get a specific issue.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -17841,8 +17831,7 @@ service:
         type: root.PaginatedIssueList
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -17875,8 +17864,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            X-Account-Token: X-Account-Token
+          headers: {}
           response:
             body:
               id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -17909,9 +17897,7 @@ service:
               "docs": "Creates a link token to be used when linking a new end user.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "request": {
                     "categories": [
                       "hris",
@@ -18106,8 +18092,7 @@ service:
         type: root.LinkToken
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           request:
             end_user_email_address: end_user_email_address
             end_user_organization_name: end_user_organization_name
@@ -18138,9 +18123,7 @@ service:
               "docs": "List linked accounts for your organization.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "next": "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw",
@@ -18403,8 +18386,7 @@ service:
         type: root.PaginatedAccountDetailsAndActionsList
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           response:
             body:
               next: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
@@ -19819,9 +19801,7 @@ service:
               "docs": "Exchange remote keys.",
               "examples": [
                 {
-                  "headers": {
-                    "X-Account-Token": "X-Account-Token",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "Remote Deployment Key 1",
                   },
@@ -19898,8 +19878,7 @@ service:
         type: root.RemoteKey
         status-code: 200
       examples:
-        - headers:
-            X-Account-Token: X-Account-Token
+        - headers: {}
           request:
             name: Remote Deployment Key 1
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/only-include-referenced-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/only-include-referenced-schemas.json
@@ -11106,9 +11106,7 @@ You can view the currently authorised admin along with the embedded app object (
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -11162,9 +11160,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "query-parameters": {
                     "created_at_after": "1677253093",
@@ -11243,9 +11239,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -11292,9 +11286,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin found",
                   "path-parameters": {
                     "id": 1,
@@ -11353,9 +11345,7 @@ You can view the currently authorised admin along with the embedded app object (
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -11390,9 +11380,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -11427,9 +11415,7 @@ You can view the currently authorised admin along with the embedded app object (
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Unauthorized",
                   "path-parameters": {
                     "id": 1,
@@ -11602,8 +11588,7 @@ service:
         status-code: 200
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -11667,8 +11652,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -11693,8 +11677,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -11719,8 +11702,7 @@ service:
         - name: Unauthorized
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             away_mode_enabled: true
             away_mode_reassign: true
@@ -11774,8 +11756,7 @@ service:
           query-parameters:
             created_at_after: '1677253093'
             created_at_before: '1677861493'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: activity_log.list
@@ -11821,8 +11802,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin.list
@@ -11861,8 +11841,7 @@ service:
         - name: Admin found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: admin
@@ -12140,9 +12119,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "article created",
                   "request": {
                     "author_id": 991267407,
@@ -12605,9 +12582,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "author_id": 1295,
@@ -13087,9 +13062,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -13135,9 +13108,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -13201,9 +13172,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article found",
                   "path-parameters": {
                     "id": 1,
@@ -13678,9 +13647,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Search successful",
                   "query-parameters": {
                     "phrase": "Getting started",
@@ -13773,9 +13740,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -14227,9 +14192,7 @@ imports:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Article Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -14964,8 +14927,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -15020,8 +14982,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: article created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -15438,8 +15399,7 @@ service:
                 neutral_reaction_percentage: 0
                 sad_reaction_percentage: 0
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Thanks for everything
             description: Description of the Article
@@ -15871,8 +15831,7 @@ service:
         - name: Article found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: article
@@ -16302,8 +16261,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -16710,8 +16668,7 @@ service:
         - name: Article Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -17140,8 +17097,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '51'
@@ -17187,8 +17143,7 @@ service:
           query-parameters:
             phrase: Getting started
             state: published
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -17435,9 +17390,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -17552,9 +17505,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -17605,9 +17556,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -17693,9 +17642,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -17777,9 +17724,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "id",
@@ -17835,9 +17780,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "path-parameters": {
                     "id": "id",
@@ -17893,9 +17836,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company Not Found",
                   "path-parameters": {
                     "id": "id",
@@ -18005,9 +17946,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "company_id": "company_remote_id",
@@ -18090,9 +18029,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": "5f4d3c1c-7b1b-4d7d-a97e-6095715c6632",
@@ -18134,9 +18071,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "58a430d35458202d41b1e65b",
@@ -18230,9 +18165,7 @@ When using the Companies endpoint and the pages object to iterate through the re
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "order": "desc",
@@ -18342,9 +18275,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "query-parameters": {
                     "company_id": "12345",
@@ -18472,9 +18403,7 @@ You can fetch all companies and filter by `segment_id` or `tag_id` as a query pa
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -18749,8 +18678,7 @@ service:
             company_id: '12345'
             tag_id: '678910'
             segment_id: '98765'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -18827,8 +18755,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: my company
             company_id: company_remote_id
@@ -18890,8 +18817,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -18954,8 +18880,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -19013,8 +18938,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: 667d60848a68186f43bafd45
@@ -19043,8 +18967,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19136,8 +19059,7 @@ service:
         - name: Successful
           path-parameters:
             id: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19200,8 +19122,7 @@ service:
         - name: Successful
           query-parameters:
             order: desc
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19286,8 +19207,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -19356,8 +19276,7 @@ service:
         - name: Successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d608d8a68186f43bafd70
           response:
@@ -19397,8 +19316,7 @@ service:
         - name: Bad Request
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 58a430d35458202d41b1e65b
           response:
@@ -19438,8 +19356,7 @@ service:
         - name: Company Not Found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -19503,8 +19420,7 @@ service:
           path-parameters:
             contact_id: 58a430d35458202d41b1e65b
             id: 58a430d35458202d41b1e65b
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: company
@@ -19664,9 +19580,7 @@ types:
               "docs": "You can archive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -19708,9 +19622,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "email": "joebloggs@intercom.io",
@@ -19802,9 +19714,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "id",
@@ -19851,9 +19761,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -19958,9 +19866,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "from": "667d60ac8a68186f43bafdbb",
@@ -20171,9 +20077,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -20299,9 +20203,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20395,9 +20297,7 @@ The table below shows the operators you can use to define how you want to search
               "docs": "You can unarchive a single contact.",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20439,9 +20339,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20598,9 +20496,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "63a07ddf05a32042dffac965",
@@ -20676,9 +20572,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -20736,9 +20630,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -20822,9 +20714,7 @@ The data property will show a combined list of:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -21112,8 +21002,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21170,8 +21059,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21218,8 +21106,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21277,8 +21164,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -21311,8 +21197,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -21423,8 +21308,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
             name: joe bloggs
@@ -21496,8 +21380,7 @@ service:
         - name: successful
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -21537,8 +21420,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from: 667d60ac8a68186f43bafdbb
             into: 667d60ac8a68186f43bafdbc
@@ -21823,8 +21705,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -21925,8 +21806,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -22014,8 +21894,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             email: joebloggs@intercom.io
           response:
@@ -22081,8 +21960,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -22109,8 +21987,7 @@ service:
         - name: successful
           path-parameters:
             id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: contact
@@ -22316,9 +22193,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attach a contact to a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -22494,9 +22369,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -22723,9 +22596,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation using assignment rules",
                   "path-parameters": {
                     "id": "123",
@@ -22866,9 +22737,7 @@ It is not possible to use this endpoint with Workflows.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -22993,9 +22862,7 @@ It is not possible to use this endpoint with Workflows.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad request",
                   "path-parameters": {
                     "id": 1,
@@ -23177,9 +23044,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation created",
                   "request": {
                     "body": "Hello there",
@@ -23201,9 +23066,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact Not Found",
                   "request": {
                     "body": "Hello there",
@@ -23271,9 +23134,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Detach a contact from a group conversation",
                   "path-parameters": {
                     "contact_id": "123",
@@ -23447,9 +23308,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -23623,9 +23482,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "123",
@@ -23799,9 +23656,7 @@ If you add a contact via the email parameter and there is no user/lead found on 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Last customer",
                   "path-parameters": {
                     "contact_id": "123",
@@ -24029,9 +23884,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -24127,9 +23980,7 @@ You can optionally request the result page size and the cursor to start after to
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Close a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24246,9 +24097,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Snooze a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24365,9 +24214,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Open a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24483,9 +24330,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assign a conversation",
                   "path-parameters": {
                     "id": "123",
@@ -24607,9 +24452,7 @@ You can optionally request the result page size and the cursor to start after to
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -24764,9 +24607,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Redact a conversation part",
                   "request": {
                     "conversation_id": "19894788788",
@@ -24885,9 +24726,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "request": {
                     "conversation_id": "really_123_doesnt_exist",
@@ -25033,9 +24872,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25158,9 +24995,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25289,9 +25124,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User last conversation reply",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25414,9 +25247,7 @@ If you are redacting a conversation part, it must have a `body`. If you are reda
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123 or "last"",
@@ -25582,9 +25413,7 @@ For AI agent conversation metadata, please note that you need to have the agent 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -25812,9 +25641,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -25960,9 +25787,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "conversation found",
                   "path-parameters": {
                     "id": 1,
@@ -26110,9 +25935,7 @@ If you want to reply to a coveration or take an action such as assign, unassign,
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": 1,
@@ -26608,8 +26431,7 @@ service:
         - root.ForbiddenError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation.list
@@ -26692,8 +26514,7 @@ service:
         - root.NotFoundError
       examples:
         - name: conversation created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -26709,8 +26530,7 @@ service:
               message_type: inapp
               conversation_id: '363'
         - name: Contact Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -26777,8 +26597,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -26894,8 +26713,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -27005,8 +26823,7 @@ service:
             id: 1
           query-parameters:
             display_as: plaintext
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             read: true
             custom_attributes:
@@ -27448,8 +27265,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -27555,8 +27371,7 @@ service:
         - name: User reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -27646,8 +27461,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -27749,8 +27563,7 @@ service:
         - name: User last conversation reply
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -27840,8 +27653,7 @@ service:
         - name: Not found
           path-parameters:
             id: 123 or "last"
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -27960,8 +27772,7 @@ service:
         - name: Close a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -28046,8 +27857,7 @@ service:
         - name: Snooze a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017691'
             snoozed_until: 1673609604
@@ -28132,8 +27942,7 @@ service:
         - name: Open a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
             message_type: open
@@ -28217,8 +28026,7 @@ service:
         - name: Assign a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -28307,8 +28115,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: admin
             admin_id: '12345'
@@ -28422,8 +28229,7 @@ service:
         - name: Assign a conversation using assignment rules
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: conversation
@@ -28549,8 +28355,7 @@ service:
         - name: Attach a contact to a conversation
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -28682,8 +28487,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '12345'
             customer:
@@ -28861,8 +28665,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -28993,8 +28796,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29125,8 +28927,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29257,8 +29058,7 @@ service:
           path-parameters:
             conversation_id: '123'
             contact_id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '5017690'
           response:
@@ -29418,8 +29218,7 @@ service:
         - root.NotFoundError
       examples:
         - name: Redact a conversation part
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: '19894788788'
@@ -29506,8 +29305,7 @@ service:
                   - id: '7583'
               ai_agent_participated: false
         - name: Not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: conversation_part
             conversation_id: really_123_doesnt_exist
@@ -29627,8 +29425,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '79'
           response:
@@ -29723,8 +29520,7 @@ service:
         - name: Bad request
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '80'
           response:
@@ -30085,9 +29881,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "data_type": "string",
@@ -30120,9 +29914,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Same name already exists",
                   "request": {
                     "data_type": "integer",
@@ -30155,9 +29947,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid name",
                   "request": {
                     "data_type": "string",
@@ -30190,9 +29980,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute already exists",
                   "request": {
                     "data_type": "string",
@@ -30225,9 +30013,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid Data Type",
                   "request": {
                     "data_type": "string",
@@ -30260,9 +30046,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options for list",
                   "request": {
                     "data_type": "string",
@@ -30355,9 +30139,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -30785,9 +30567,7 @@ You can update a data attribute.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "id": 1,
@@ -30826,9 +30606,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Too few options in list",
                   "path-parameters": {
                     "id": 1,
@@ -30867,9 +30645,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Attribute Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -30908,9 +30684,7 @@ You can update a data attribute.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Has Dependant Object",
                   "path-parameters": {
                     "id": 1,
@@ -31289,8 +31063,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -31671,8 +31444,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Mithril Shirt
             model: company
@@ -31699,8 +31471,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Same name already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: contact
@@ -31727,8 +31498,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid name
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: '!nv@l!d n@me'
             model: company
@@ -31755,8 +31525,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Attribute already exists
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The One Ring
             model: company
@@ -31783,8 +31552,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Invalid Data Type
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: The Second Ring
             model: company
@@ -31811,8 +31579,7 @@ service:
               updated_at: 1719492955
               admin_id: '991267686'
         - name: Too few options for list
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: My Data Attribute
             model: contact
@@ -31897,8 +31664,7 @@ service:
         - name: Successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -31929,8 +31695,7 @@ service:
         - name: Too few options in list
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Too few options
@@ -31961,8 +31726,7 @@ service:
         - name: Attribute Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: false
             description: Just a plain old ring
@@ -31993,8 +31757,7 @@ service:
         - name: Has Dependant Object
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             archived: true
             description: Trying to archieve
@@ -32108,9 +31871,7 @@ Duplicated events are responded to using the normal `202 Accepted` code - an err
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "request": {},
                 },
               ],
@@ -32560,8 +32321,7 @@ service:
       errors:
         - root.UnauthorizedError
       examples:
-        - headers:
-            Intercom-Version: Intercom-Version
+        - headers: {}
           request: {}
   source:
     openapi: ../openapi.yml
@@ -32584,9 +32344,7 @@ docs: Everything about your Data Events
               "docs": "You can cancel your job",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -32640,9 +32398,7 @@ The only parameters you need to provide are the range of dates that you want exp
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "created_at_after": 1719474967,
@@ -32702,9 +32458,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "job_identifier": "job_identifier",
                   },
@@ -32734,9 +32488,7 @@ Your exported message data will be streamed continuously back down to you in a g
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "job_identifier": "job_identifier",
@@ -32886,8 +32638,7 @@ Your exported message data will be streamed continuously back down to you in a g
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             created_at_after: 1719474967
             created_at_before: 1719492967
@@ -32931,8 +32682,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -32959,8 +32709,7 @@ Your exported message data will be streamed continuously back down to you in a g
         - name: successful
           path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               job_identfier: orzzsbd7hk67xyu
@@ -32997,8 +32746,7 @@ Your exported message data will be streamed continuously back down to you in a g
       examples:
         - path-parameters:
             job_identifier: job_identifier
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
   source:
     openapi: ../openapi.yml
   display-name: Data Export
@@ -33059,9 +32807,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "collection created",
                   "request": {
                     "name": "Thanks for everything",
@@ -33271,9 +33017,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Bad Request",
                   "request": {
                     "description": "Missing required parameter",
@@ -33536,9 +33280,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -33582,9 +33324,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -33652,9 +33392,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Help Centers found",
                   "response": {
                     "body": {
@@ -33696,9 +33434,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -33936,9 +33672,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection found",
                   "path-parameters": {
                     "id": 1,
@@ -33984,9 +33718,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -34199,9 +33931,7 @@ Collections will be returned in descending order on the `updated_at` attribute. 
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Collection Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -34609,8 +34339,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -34691,8 +34420,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: collection created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Thanks for everything
           response:
@@ -34859,8 +34587,7 @@ service:
                   description: ' Collection description'
               help_center_id: 81
         - name: Bad Request
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: collection 51
             description: Missing required parameter
@@ -35052,8 +34779,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '170'
@@ -35264,8 +34990,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -35434,8 +35159,7 @@ service:
         - name: Collection Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Update collection name
           response:
@@ -35626,8 +35350,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '182'
@@ -35658,8 +35381,7 @@ service:
         - name: Collection found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '93'
@@ -35687,8 +35409,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Help Centers found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -35845,9 +35566,7 @@ This will return the Message model that has been created.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "user message created",
                   "request": {
                     "body": "heyy",
@@ -35870,9 +35589,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "lead message created",
                   "request": {
                     "body": "heyy",
@@ -35895,9 +35612,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "admin message created",
                   "request": {
                     "body": "heyy",
@@ -35924,9 +35639,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for message",
                   "request": {
                     "from": {
@@ -35953,9 +35666,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No subject supplied for email message",
                   "request": {
                     "body": "hey there",
@@ -35982,9 +35693,7 @@ This will return the Message model that has been created.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "No body supplied for email message",
                   "request": {
                     "from": {
@@ -36136,8 +35845,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - name: user message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: user
@@ -36154,8 +35862,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: lead message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: lead
@@ -36172,8 +35879,7 @@ service:
               message_type: inapp
               conversation_id: '477'
         - name: admin message created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36193,8 +35899,7 @@ service:
               message_type: inapp
               conversation_id: '64619700005570'
         - name: No body supplied for message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36214,8 +35919,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No subject supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36235,8 +35939,7 @@ service:
               message_type: inapp
               conversation_id: '476'
         - name: No body supplied for email message
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             from:
               type: admin
@@ -36325,9 +36028,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "body": "<p>New costumes in store for this spooky season</p>",
@@ -36409,9 +36110,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -36452,9 +36151,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -36531,9 +36228,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -36626,9 +36321,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -36686,9 +36379,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -36750,9 +36441,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -36795,9 +36484,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": 1,
@@ -36839,9 +36526,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "News Item Not Found",
                   "path-parameters": {
                     "id": 1,
@@ -37060,8 +36745,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -37139,8 +36823,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Halloween is here!
             body: <p>New costumes in store for this spooky season</p>
@@ -37201,8 +36884,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '34'
@@ -37250,8 +36932,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -37281,8 +36962,7 @@ service:
         - name: News Item Not Found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             title: Christmas is here!
             body: <p>New gifts in store for the jolly season</p>
@@ -37332,8 +37012,7 @@ service:
         - name: successful
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '40'
@@ -37363,8 +37042,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -37416,8 +37094,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -37465,8 +37142,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               id: '72'
@@ -37612,9 +37288,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -37660,9 +37334,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": 1,
@@ -37708,9 +37380,7 @@ types:
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "id": 1,
@@ -37806,9 +37476,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": 1,
@@ -37917,9 +37585,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Note found",
                   "path-parameters": {
                     "id": 1,
@@ -38065,8 +37731,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -38161,8 +37826,7 @@ service:
         - name: Successful response
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60978a68186f43bafd9e
@@ -38196,8 +37860,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: 667d60988a68186f43bafd9f
@@ -38231,8 +37894,7 @@ service:
         - name: Contact not found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             body: Hello
             contact_id: '123'
@@ -38286,8 +37948,7 @@ service:
         - name: Note found
           path-parameters:
             id: 1
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: note
@@ -38377,9 +38038,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "response": {
                     "body": {
@@ -38442,9 +38101,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "123",
@@ -38564,8 +38221,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment.list
@@ -38609,8 +38265,7 @@ service:
         - name: Successful response
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: segment
@@ -38692,9 +38347,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -38728,9 +38381,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -38764,9 +38415,7 @@ This will return a subscription type model for the subscription type that was ad
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Resource not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -38847,9 +38496,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -38911,9 +38558,7 @@ This will return a subscription type model for the subscription type that was ad
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "response": {
                     "body": {
@@ -39086,8 +38731,7 @@ service:
         - name: Successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -39110,8 +38754,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '37846'
             consent_type: opt_in
@@ -39134,8 +38777,7 @@ service:
         - name: Resource not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: invalid_id
             consent_type: opt_in
@@ -39187,8 +38829,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '37846'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: subscription
@@ -39223,8 +38864,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -39333,9 +38973,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "custom_attributes": {
@@ -39352,9 +38990,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - exception sending sms",
                   "request": {
                     "custom_attributes": {
@@ -39371,9 +39007,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "bad request - invalid number",
                   "request": {
                     "custom_attributes": {
@@ -39390,9 +39024,7 @@ If custom attributes are specified, they will be added to the user or lead's cus
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "unprocessable entity",
                   "request": {
                     "custom_attributes": {
@@ -39469,8 +39101,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -39481,8 +39112,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - exception sending sms
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -39493,8 +39123,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: bad request - invalid number
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+353832345678'
             custom_attributes:
@@ -39505,8 +39134,7 @@ service:
               type: phone_call_redirect
               phone: +1 1234567890
         - name: unprocessable entity
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             phone: '+40241100100'
             custom_attributes:
@@ -39544,9 +39172,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39568,9 +39194,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Contact not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39592,9 +39216,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -39659,9 +39281,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -39684,9 +39304,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -39756,9 +39374,7 @@ docs: Everything about Switch
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -39781,9 +39397,7 @@ docs: Everything about Switch
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "ticket_id": "64619700005694",
@@ -39867,9 +39481,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Action successful",
                   "request": {
                     "name": "test",
@@ -39888,9 +39500,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Invalid parameters",
                   "request": {
                     "name": "Independent",
@@ -39909,9 +39519,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Company not found",
                   "request": {
                     "companies": [
@@ -39935,9 +39543,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User  not found",
                   "request": {
                     "name": "test",
@@ -39988,9 +39594,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "123",
                   },
@@ -40019,9 +39623,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "contact_id": "63a07ddf05a32042dffac965",
@@ -40073,9 +39675,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40098,9 +39698,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Conversation not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40123,9 +39721,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "conversation_id": "64619700005694",
@@ -40195,9 +39791,7 @@ Each operation will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "7522907",
@@ -40220,9 +39814,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -40245,9 +39837,7 @@ Each operation will return a tag object.
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag not found",
                   "path-parameters": {
                     "id": "7522907",
@@ -40319,9 +39909,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Tag found",
                   "path-parameters": {
                     "id": "123",
@@ -40369,9 +39957,7 @@ This will return a tag object.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -40501,8 +40087,7 @@ service:
         - name: successful
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -40517,8 +40102,7 @@ service:
         - name: Contact not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
           response:
@@ -40533,8 +40117,7 @@ service:
         - name: Tag not found
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '123'
           response:
@@ -40575,8 +40158,7 @@ service:
           path-parameters:
             contact_id: 63a07ddf05a32042dffac965
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -40622,8 +40204,7 @@ service:
         - name: successful
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -40639,8 +40220,7 @@ service:
         - name: Conversation not found
           path-parameters:
             conversation_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -40690,8 +40270,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -40707,8 +40286,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -40724,8 +40302,7 @@ service:
           path-parameters:
             conversation_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -40755,8 +40332,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -40801,8 +40377,7 @@ service:
         - root.NotFoundError
       examples:
         - name: Action successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
           response:
@@ -40815,8 +40390,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Invalid parameters
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Independent
           response:
@@ -40829,8 +40403,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: Company not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             companies:
@@ -40845,8 +40418,7 @@ service:
                 type: contact
                 id: 1a2b3c
         - name: User  not found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: test
             users:
@@ -40885,8 +40457,7 @@ service:
         - name: Tag found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: tag
@@ -40917,8 +40488,7 @@ service:
       examples:
         - path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
     attachTagToTicket:
       path: /tickets/{ticket_id}/tags
       method: POST
@@ -40955,8 +40525,7 @@ service:
         - name: successful
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -40972,8 +40541,7 @@ service:
         - name: Ticket not found
           path-parameters:
             ticket_id: '64619700005694'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: '7522907'
             admin_id: '780'
@@ -41023,8 +40591,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41040,8 +40607,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41057,8 +40623,7 @@ service:
           path-parameters:
             ticket_id: '64619700005694'
             id: '7522907'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             admin_id: '123'
           response:
@@ -41128,9 +40693,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -41171,9 +40734,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "path-parameters": {
                     "id": "123",
@@ -41274,8 +40835,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team.list
@@ -41310,8 +40870,7 @@ service:
         - name: successful
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: team
@@ -41371,9 +40930,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute created",
                   "path-parameters": {
                     "ticket_type_id": "ticket_type_id",
@@ -41491,9 +41048,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket Type Attribute updated",
                   "path-parameters": {
                     "id": "id",
@@ -41727,8 +41282,7 @@ service:
         - name: Ticket Type Attribute created
           path-parameters:
             ticket_type_id: ticket_type_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Attribute Title
             description: Attribute Description
@@ -41842,8 +41396,7 @@ service:
           path-parameters:
             ticket_type_id: ticket_type_id
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             description: New Attribute Description
           response:
@@ -41899,9 +41452,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type created",
                   "request": {
                     "category": "Customer",
@@ -41976,9 +41527,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type found",
                   "path-parameters": {
                     "id": "id",
@@ -42050,9 +41599,7 @@ docs: Everything about your ticket type attributes
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "response": {
                     "body": {
@@ -42102,9 +41649,7 @@ You can update a ticket type.
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket type updated",
                   "path-parameters": {
                     "id": "id",
@@ -42205,8 +41750,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: list
@@ -42252,8 +41796,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Ticket type created
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Customer Issue
             description: Customer Report Template
@@ -42314,8 +41857,7 @@ service:
         - name: Ticket type found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket_type
@@ -42385,8 +41927,7 @@ service:
         - name: Ticket type updated
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: Bug Report 2
           response:
@@ -42447,9 +41988,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "request": {
                     "contacts": [
@@ -42606,9 +42145,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Ticket found",
                   "path-parameters": {
                     "id": "id",
@@ -42734,9 +42271,7 @@ docs: Everything about your ticket types
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "User reply",
                   "path-parameters": {
                     "id": "123",
@@ -42788,9 +42323,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin note reply",
                   "path-parameters": {
                     "id": "123",
@@ -42842,9 +42375,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin quick_reply reply",
                   "path-parameters": {
                     "id": "123",
@@ -42894,9 +42425,7 @@ docs: Everything about your ticket types
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Not found",
                   "path-parameters": {
                     "id": "123",
@@ -43034,9 +42563,7 @@ The table below shows the operators you can use to define how you want to search
 ",
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "pagination": {
@@ -43188,9 +42715,7 @@ The table below shows the operators you can use to define how you want to search
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful response",
                   "path-parameters": {
                     "id": "id",
@@ -43431,9 +42956,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Admin not found",
                   "path-parameters": {
                     "id": "id",
@@ -43672,9 +43195,7 @@ The table below shows the operators you can use to define how you want to search
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Assignee not found",
                   "path-parameters": {
                     "id": "id",
@@ -44667,8 +44188,7 @@ service:
         - name: User reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -44711,8 +44231,7 @@ service:
         - name: Admin note reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: note
             type: admin
@@ -44759,8 +44278,7 @@ service:
         - name: Admin quick_reply reply
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: quick_reply
             type: admin
@@ -44795,8 +44313,7 @@ service:
         - name: Not found
           path-parameters:
             id: '123'
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             message_type: comment
             type: user
@@ -44877,8 +44394,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful response
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_type_id: '1234'
             contacts:
@@ -44978,8 +44494,7 @@ service:
         - name: Ticket found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: ticket
@@ -45096,8 +44611,7 @@ service:
         - name: Successful response
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -45284,8 +44798,7 @@ service:
         - name: Admin not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -45470,8 +44983,7 @@ service:
         - name: Assignee not found
           path-parameters:
             id: id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             ticket_attributes:
               _default_title_: example
@@ -45830,8 +45342,7 @@ service:
         status-code: 200
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             query:
               operator: AND
@@ -45953,9 +45464,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "type": "user",
@@ -46068,9 +45577,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "query-parameters": {
                     "user_id": "user_id",
@@ -46195,9 +45702,7 @@ docs: Everything about your tickets
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "successful",
                   "request": {
                     "id": "667d61cc8a68186f43bafe95",
@@ -46290,9 +45795,7 @@ docs: Everything about your tickets
                   },
                 },
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "visitor Not Found",
                   "request": {
                     "name": "Christian Fail",
@@ -46439,8 +45942,7 @@ service:
         - name: successful
           query-parameters:
             user_id: user_id
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           response:
             body:
               type: visitor
@@ -46535,8 +46037,7 @@ service:
         - root.NotFoundError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             id: 667d61cc8a68186f43bafe95
             name: Gareth Bale
@@ -46609,8 +46110,7 @@ service:
               custom_attributes:
                 key: value
         - name: visitor Not Found
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             user_id: fail
             name: Christian Fail
@@ -46721,8 +46221,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             type: user
             user:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/openapi-filter.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/openapi-filter.json
@@ -279,9 +279,7 @@ Companies are looked up via `company_id` in a `POST` request, if not found via `
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Intercom-Version": "Intercom-Version",
-                  },
+                  "headers": {},
                   "name": "Successful",
                   "request": {
                     "company_id": "company_remote_id",
@@ -538,8 +536,7 @@ service:
         - root.UnauthorizedError
       examples:
         - name: Successful
-          headers:
-            Intercom-Version: Intercom-Version
+          headers: {}
           request:
             name: my company
             company_id: company_remote_id

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/seam.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/seam.json
@@ -8047,11 +8047,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -8171,11 +8167,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_ids": [
                       "device_ids",
@@ -8284,11 +8276,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -8361,11 +8349,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -8446,11 +8430,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -8539,11 +8519,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -8626,11 +8602,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -8711,11 +8683,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -9164,10 +9132,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -9252,10 +9217,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_ids:
               - device_ids
@@ -9317,10 +9279,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -9357,10 +9316,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -9420,10 +9376,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -9479,10 +9432,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -9536,10 +9486,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -9624,10 +9571,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -9663,11 +9607,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "code": "code",
                     "device_id": "device_id",
@@ -9805,10 +9745,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             name: name
@@ -9855,11 +9792,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -9919,11 +9852,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                   },
@@ -9987,11 +9916,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -10071,11 +9996,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -10150,11 +10071,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_code_id": "access_code_id",
                     "is_managed": true,
@@ -10328,10 +10245,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -10364,10 +10278,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
           response:
@@ -10409,10 +10320,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -10458,10 +10366,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -10510,10 +10415,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             access_code_id: access_code_id
             is_managed: true
@@ -10544,11 +10446,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -10611,11 +10509,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                   },
@@ -10681,11 +10575,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -10760,11 +10650,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                   },
@@ -10843,11 +10729,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -11024,10 +10906,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
             acs_user_id: acs_user_id
@@ -11059,10 +10938,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
           response:
@@ -11108,10 +10984,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -11152,10 +11025,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
           response:
@@ -11210,10 +11080,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_access_group_id: acs_access_group_id
             acs_user_id: acs_user_id
@@ -11244,11 +11111,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -11360,10 +11223,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -11401,11 +11261,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "credential_manager_acs_system_id": "credential_manager_acs_system_id",
                     "user_identity_id": "user_identity_id",
@@ -11555,10 +11411,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             credential_manager_acs_system_id: credential_manager_acs_system_id
@@ -11595,11 +11448,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                     "acs_user_id": "acs_user_id",
@@ -11705,11 +11554,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "access_method": "code",
                     "acs_user_id": "acs_user_id",
@@ -11834,11 +11679,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -11891,11 +11732,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -11992,11 +11829,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -12076,11 +11909,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -12158,11 +11987,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                     "acs_user_id": "acs_user_id",
@@ -12268,11 +12093,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_credential_id": "acs_credential_id",
                   },
@@ -12648,10 +12469,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_credential_id: acs_credential_id
@@ -12731,10 +12549,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             access_method: code
@@ -12797,10 +12612,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -12831,10 +12643,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -12894,10 +12703,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -12953,10 +12759,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -13006,10 +12809,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_credential_id: acs_credential_id
@@ -13074,10 +12874,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_credential_id: acs_credential_id
           response:
@@ -13139,11 +12936,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_entrance_id": "acs_entrance_id",
                   },
@@ -13225,11 +13018,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_entrance_id": "acs_entrance_id",
                     "acs_user_id": "acs_user_id",
@@ -13292,11 +13081,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -13381,11 +13166,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_entrance_id": "acs_entrance_id",
                   },
@@ -13572,10 +13353,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_entrance_id: acs_entrance_id
           response:
@@ -13628,10 +13406,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_entrance_id: acs_entrance_id
             acs_user_id: acs_user_id
@@ -13667,10 +13442,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -13717,10 +13489,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_entrance_id: acs_entrance_id
           response:
@@ -13776,11 +13545,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -13863,11 +13628,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -13950,11 +13711,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -14120,10 +13877,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -14177,10 +13931,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -14233,10 +13984,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -14289,11 +14037,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -14356,11 +14100,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_system_id": "acs_system_id",
                   },
@@ -14473,11 +14213,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -14530,11 +14266,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -14611,11 +14343,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -14703,11 +14431,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -14785,11 +14509,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_access_group_id": "acs_access_group_id",
                     "acs_user_id": "acs_user_id",
@@ -14852,11 +14572,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -14909,11 +14625,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -14966,11 +14678,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -15023,11 +14731,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                   },
@@ -15357,10 +15061,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_access_group_id: acs_access_group_id
@@ -15414,10 +15115,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_system_id: acs_system_id
           response:
@@ -15468,10 +15166,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15502,10 +15197,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15563,10 +15255,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -15617,10 +15306,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15670,10 +15356,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
             acs_access_group_id: acs_access_group_id
@@ -15704,10 +15387,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15737,10 +15417,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15770,10 +15447,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15824,10 +15498,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             acs_user_id: acs_user_id
           response:
@@ -15857,11 +15528,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "action_attempt_id": "action_attempt_id",
                   },
@@ -15922,11 +15589,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "action_attempt_ids": [
                       "action_attempt_ids",
@@ -16047,10 +15710,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             action_attempt_id: action_attempt_id
           response:
@@ -16084,10 +15744,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             action_attempt_ids:
               - action_attempt_ids
@@ -16124,11 +15781,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16201,11 +15854,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "client_session_id": "client_session_id",
                   },
@@ -16258,11 +15907,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16324,11 +15969,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16401,11 +16042,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16469,11 +16106,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -16540,11 +16173,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "client_session_id": "client_session_id",
                   },
@@ -16746,10 +16375,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -16791,10 +16417,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             client_session_id: client_session_id
           response:
@@ -16823,10 +16446,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -16873,10 +16493,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -16919,10 +16536,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -16966,10 +16580,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -17011,10 +16622,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             client_session_id: client_session_id
           response:
@@ -17044,11 +16652,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -17132,11 +16736,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connect_webview_id": "connect_webview_id",
                   },
@@ -17189,11 +16789,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connect_webview_id": "connect_webview_id",
                   },
@@ -17274,11 +16870,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -17656,10 +17248,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -17711,10 +17300,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connect_webview_id: connect_webview_id
           response:
@@ -17745,10 +17331,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connect_webview_id: connect_webview_id
           response:
@@ -17809,10 +17392,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -17864,11 +17444,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connected_account_id": "connected_account_id",
                   },
@@ -17925,11 +17501,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connected_account_id": "connected_account_id",
                   },
@@ -17990,11 +17562,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18059,11 +17627,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "connected_account_id": "connected_account_id",
                   },
@@ -18368,10 +17932,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connected_account_id: connected_account_id
           response:
@@ -18396,10 +17957,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connected_account_id: connected_account_id
           response:
@@ -18451,10 +18009,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -18500,10 +18055,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             connected_account_id: connected_account_id
           response:
@@ -18551,11 +18103,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -18608,11 +18156,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -18918,11 +18462,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -19046,11 +18586,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -19104,11 +18640,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -19664,10 +19196,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -19699,10 +19228,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -19945,10 +19471,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -20009,10 +19532,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -20055,10 +19575,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -20088,11 +19605,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -20145,11 +19658,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -20202,11 +19711,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -20333,10 +19838,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -20366,10 +19868,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -20399,10 +19898,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -20432,11 +19928,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -20540,11 +20032,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -20660,11 +20148,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "is_managed": true,
@@ -21113,10 +20597,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -21203,10 +20684,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -21264,10 +20742,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             is_managed: true
@@ -21298,11 +20773,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -21379,11 +20850,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -22293,10 +21760,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -22357,10 +21821,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -22402,11 +21863,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -22965,11 +22422,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -23141,11 +22594,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -23210,11 +22659,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -23696,10 +23141,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -24137,10 +23579,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -24241,10 +23680,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -24284,10 +23720,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -24323,11 +23756,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "network_id": "network_id",
                   },
@@ -24387,11 +23816,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -24505,10 +23930,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             network_id: network_id
           response:
@@ -24540,10 +23962,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -24577,11 +23996,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "ends_daily_at": "ends_daily_at",
@@ -24662,11 +24077,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "noise_threshold_id": "noise_threshold_id",
@@ -24740,11 +24151,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "noise_threshold_id": "noise_threshold_id",
                   },
@@ -24807,11 +24214,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -24877,11 +24280,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "noise_threshold_id": "noise_threshold_id",
@@ -25085,10 +24484,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             starts_daily_at: starts_daily_at
@@ -25141,10 +24537,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             noise_threshold_id: noise_threshold_id
             device_id: device_id
@@ -25182,10 +24575,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             noise_threshold_id: noise_threshold_id
           response:
@@ -25225,10 +24615,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -25278,10 +24665,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             noise_threshold_id: noise_threshold_id
             device_id: device_id
@@ -25318,11 +24702,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -25419,10 +24799,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -25452,11 +24829,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -25501,11 +24874,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -25652,10 +25021,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -25686,10 +25052,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -25744,11 +25107,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -26022,10 +25381,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -26089,11 +25445,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -26160,11 +25512,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -26470,11 +25818,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -26541,11 +25885,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -26614,11 +25954,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -26742,11 +26078,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -26811,11 +26143,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -26882,11 +26210,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "default_climate_setting": {},
                     "device_id": "device_id",
@@ -27509,10 +26833,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -27550,10 +26871,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -27783,10 +27101,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -27830,10 +27145,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -27890,10 +27202,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -27960,10 +27269,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -28005,10 +27311,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -28045,10 +27348,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             default_climate_setting: {}
@@ -28079,11 +27379,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "schedule_ends_at": "schedule_ends_at",
@@ -28163,11 +27459,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "climate_setting_schedule_id": "climate_setting_schedule_id",
                   },
@@ -28220,11 +27512,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -28305,11 +27593,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                   },
@@ -28386,11 +27670,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "climate_setting_schedule_id": "climate_setting_schedule_id",
                   },
@@ -28639,10 +27919,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
             schedule_starts_at: schedule_starts_at
@@ -28692,10 +27969,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             climate_setting_schedule_id: climate_setting_schedule_id
           response:
@@ -28730,10 +28004,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -28782,10 +28053,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             device_id: device_id
           response:
@@ -28845,10 +28113,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             climate_setting_schedule_id: climate_setting_schedule_id
           response:
@@ -28896,11 +28161,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                     "user_identity_id": "user_identity_id",
@@ -28963,11 +28224,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -29048,11 +28305,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -29105,11 +28358,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -29157,11 +28406,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "user_identity_id": "user_identity_id",
@@ -29224,11 +28469,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {},
                   "response": {
                     "body": {
@@ -29292,11 +28533,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -29446,11 +28683,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -29535,11 +28768,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -29618,11 +28847,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "acs_user_id": "acs_user_id",
                     "user_identity_id": "user_identity_id",
@@ -29685,11 +28910,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "device_id": "device_id",
                     "user_identity_id": "user_identity_id",
@@ -29752,11 +28973,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -30141,10 +29358,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             acs_user_id: acs_user_id
@@ -30185,10 +29399,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -30226,10 +29437,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -30254,10 +29462,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -30300,10 +29505,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             device_id: device_id
@@ -30335,10 +29537,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request: {}
           response:
             body:
@@ -30377,10 +29576,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -30479,10 +29675,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -30536,10 +29729,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -30594,10 +29784,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             acs_user_id: acs_user_id
@@ -30632,10 +29819,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             device_id: device_id
@@ -30679,10 +29863,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -30712,11 +29893,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "enrollment_automation_id": "enrollment_automation_id",
                   },
@@ -30769,11 +29946,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "enrollment_automation_id": "enrollment_automation_id",
                   },
@@ -30834,11 +30007,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "credential_manager_acs_system_id": "credential_manager_acs_system_id",
                     "user_identity_id": "user_identity_id",
@@ -30929,11 +30098,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "user_identity_id": "user_identity_id",
                   },
@@ -31172,10 +30337,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             enrollment_automation_id: enrollment_automation_id
           response:
@@ -31206,10 +30368,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             enrollment_automation_id: enrollment_automation_id
           response:
@@ -31259,10 +30418,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
             credential_manager_acs_system_id: credential_manager_acs_system_id
@@ -31301,10 +30457,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             user_identity_id: user_identity_id
           response:
@@ -31340,11 +30493,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "url": "url",
                   },
@@ -31407,11 +30556,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "webhook_id": "webhook_id",
                   },
@@ -31456,11 +30601,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "webhook_id": "webhook_id",
                   },
@@ -31514,11 +30655,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "ok": true,
@@ -31559,11 +30696,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "event_types": [
                       "event_types",
@@ -31724,10 +30857,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             url: url
           response:
@@ -31760,10 +30890,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             webhook_id: webhook_id
           response:
@@ -31791,10 +30918,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             webhook_id: webhook_id
           response:
@@ -31822,10 +30946,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               webhooks:
@@ -31857,10 +30978,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             webhook_id: webhook_id
             event_types:
@@ -31892,11 +31010,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                   },
@@ -31964,11 +31078,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "ok": true,
@@ -32006,11 +31116,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "ok": true,
@@ -32050,11 +31156,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "client-session-token": "client-session-token",
-                    "seam-client-session-token": "seam-client-session-token",
-                    "seam-workspace": "seam-workspace",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "action_attempt": {
@@ -32218,10 +31320,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           request:
             name: name
           response:
@@ -32249,10 +31348,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               workspace:
@@ -32278,10 +31374,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               workspaces:
@@ -32307,10 +31400,7 @@ service:
         - root.BadRequestError
         - root.UnauthorizedError
       examples:
-        - headers:
-            seam-workspace: seam-workspace
-            seam-client-session-token: seam-client-session-token
-            client-session-token: client-session-token
+        - headers: {}
           response:
             body:
               action_attempt:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/speechify.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/speechify.json
@@ -812,9 +812,7 @@ types:
               "docs": "Create a new API key for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "api_key": "api_key",
@@ -844,9 +842,7 @@ types:
               "docs": "Deletes the given API key for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -870,9 +866,7 @@ types:
               "docs": "Fetches all the API keys for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "response": {
                     "body": [
                       {
@@ -904,9 +898,7 @@ types:
               "docs": "Update API key name for the logged in user",
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -969,8 +961,7 @@ service:
         type: list<root.ApiKey>
         status-code: 200
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           response:
             body:
               - api_key: api_key
@@ -993,8 +984,7 @@ service:
         type: root.ApiKey
         status-code: 200
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           response:
             body:
               api_key: api_key
@@ -1017,8 +1007,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            Authorization: Authorization
+          headers: {}
     UpdateApiKey:
       path: /v1/token/{id}
       method: PATCH
@@ -1042,8 +1031,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            Authorization: Authorization
+          headers: {}
           request: string
           response:
             body:
@@ -1078,9 +1066,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "input": "input",
                     "voice_id": "voice_id",
@@ -1151,9 +1137,7 @@ simba-turbo ModelTurbo",
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "input": "input",
                     "voice_id": "voice_id",
@@ -1246,7 +1230,6 @@ simba-turbo ModelTurbo",
                 {
                   "headers": {
                     "Accept": "audio/mpeg",
-                    "Authorization": "Authorization",
                   },
                   "request": {
                     "input": "input",
@@ -1612,8 +1595,7 @@ service:
         - root.ForbiddenError
         - root.InternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             input: input
             voice_id: voice_id
@@ -1693,8 +1675,7 @@ service:
         - root.ForbiddenError
         - root.InternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             input: input
             voice_id: voice_id
@@ -1782,7 +1763,6 @@ service:
       examples:
         - headers:
             Accept: audio/mpeg
-            Authorization: Authorization
           request:
             input: input
             voice_id: voice_id
@@ -1811,9 +1791,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "grant_type": "client_credentials",
                   },
@@ -1965,8 +1943,7 @@ service:
       errors:
         - root.BadRequestError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             grant_type: client_credentials
           response:
@@ -1999,9 +1976,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "request": {
                     "consent": "consent",
                     "name": "name",
@@ -2072,9 +2047,7 @@ This should include the fullName and email of the consenting individual.",
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "id": "id",
                   },
@@ -2102,9 +2075,7 @@ This should include the fullName and email of the consenting individual.",
               ],
               "examples": [
                 {
-                  "headers": {
-                    "Authorization": "Authorization",
-                  },
+                  "headers": {},
                   "response": {
                     "body": [
                       {
@@ -2164,8 +2135,7 @@ service:
         - root.NotFoundError
         - root.InternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           response:
             body:
               - avatar_image: avatar_image
@@ -2218,8 +2188,7 @@ service:
         - root.PaymentRequiredError
         - root.InternalServerError
       examples:
-        - headers:
-            Authorization: Authorization
+        - headers: {}
           request:
             name: name
             consent: consent
@@ -2250,8 +2219,7 @@ service:
       examples:
         - path-parameters:
             id: id
-          headers:
-            Authorization: Authorization
+          headers: {}
   source:
     openapi: ../openapi.json
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/superagent.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/superagent.json
@@ -112,9 +112,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                     "type": "type",
@@ -176,9 +174,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -213,9 +209,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -247,9 +241,7 @@ types:
               "docs": "List all agents",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -278,9 +270,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -324,9 +314,7 @@ types:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "agentId": "agentId",
                   },
@@ -398,8 +386,7 @@ types:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -436,8 +423,7 @@ types:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             name: name
             type: type
@@ -463,8 +449,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -487,8 +472,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -515,8 +499,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           request:
             key: value
           response:
@@ -551,8 +534,7 @@ types:
       examples:
         - path-parameters:
             agentId: agentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           request:
             input:
               key: value
@@ -584,9 +566,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "description": "description",
                   },
@@ -630,9 +610,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "tokenId": "tokenId",
                   },
@@ -667,9 +645,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "tokenId": "tokenId",
                   },
@@ -701,9 +677,7 @@ imports:
               "docs": "List all API tokens",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -746,8 +720,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -772,8 +745,7 @@ imports:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             description: description
           response:
@@ -798,8 +770,7 @@ imports:
       examples:
         - path-parameters:
             tokenId: tokenId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -822,8 +793,7 @@ imports:
       examples:
         - path-parameters:
             tokenId: tokenId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -852,9 +822,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "email": "email",
                     "password": "password",
@@ -900,9 +868,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "email": "email",
                     "password": "password",
@@ -978,8 +944,7 @@ service:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             email: email
             password: password
@@ -1011,8 +976,7 @@ service:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             email: email
             password: password
@@ -1042,9 +1006,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                     "type": "type",
@@ -1107,9 +1069,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "documentId": "documentId",
                   },
@@ -1144,9 +1104,7 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "documentId": "documentId",
                   },
@@ -1178,9 +1136,7 @@ service:
               "docs": "List all documents",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -1223,8 +1179,7 @@ service:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -1261,8 +1216,7 @@ service:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             type: type
             url: url
@@ -1289,8 +1243,7 @@ service:
       examples:
         - path-parameters:
             documentId: documentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1313,8 +1266,7 @@ service:
       examples:
         - path-parameters:
             documentId: documentId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1343,9 +1295,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "input_variables": [],
                     "name": "name",
@@ -1395,9 +1345,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "promptId": "promptId",
                   },
@@ -1432,9 +1380,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "promptId": "promptId",
                   },
@@ -1466,9 +1412,7 @@ imports:
               "docs": "List all prompts",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -1497,9 +1441,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "promptId": "promptId",
                   },
@@ -1557,8 +1499,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -1586,8 +1527,7 @@ imports:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             name: name
             input_variables: []
@@ -1614,8 +1554,7 @@ imports:
       examples:
         - path-parameters:
             promptId: promptId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1638,8 +1577,7 @@ imports:
       examples:
         - path-parameters:
             promptId: promptId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1666,8 +1604,7 @@ imports:
       examples:
         - path-parameters:
             promptId: promptId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           request:
             key: value
           response:
@@ -1698,9 +1635,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "request": {
                     "name": "name",
                     "type": "type",
@@ -1749,9 +1684,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "toolId": "toolId",
                   },
@@ -1786,9 +1719,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "toolId": "toolId",
                   },
@@ -1820,9 +1751,7 @@ imports:
               "docs": "List all tools",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -1865,8 +1794,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -1894,8 +1822,7 @@ imports:
       errors:
         - root.UnprocessableEntityError
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           request:
             name: name
             type: type
@@ -1921,8 +1848,7 @@ imports:
       examples:
         - path-parameters:
             toolId: toolId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1945,8 +1871,7 @@ imports:
       examples:
         - path-parameters:
             toolId: toolId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value
@@ -1969,9 +1894,7 @@ imports:
               "docs": "List all agent traces",
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -2014,8 +1937,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -2042,9 +1964,7 @@ imports:
               ],
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "path-parameters": {
                     "userId": "userId",
                   },
@@ -2076,9 +1996,7 @@ imports:
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
-                  },
+                  "headers": {},
                   "response": {
                     "body": {
                       "key": "value",
@@ -2120,8 +2038,7 @@ imports:
         type: unknown
         status-code: 200
       examples:
-        - headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+        - headers: {}
           response:
             body:
               key: value
@@ -2143,8 +2060,7 @@ imports:
       examples:
         - path-parameters:
             userId: userId
-          headers:
-            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
+          headers: {}
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-streaming-with-stream-condition.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-streaming-with-stream-condition.json
@@ -15,10 +15,7 @@
               "docs": "Create a chat while specifying the default retrieval parameters used by the prompt.",
               "examples": [
                 {
-                  "headers": {
-                    "Request-Timeout": "Request-Timeout",
-                    "Request-Timeout-Millis": "Request-Timeout-Millis",
-                  },
+                  "headers": {},
                   "request": {
                     "query": "How can I use the Vectara platform?",
                     "stream_response": false,
@@ -69,10 +66,7 @@
               "docs": "Create a chat while specifying the default retrieval parameters used by the prompt.",
               "examples": [
                 {
-                  "headers": {
-                    "Request-Timeout": "Request-Timeout",
-                    "Request-Timeout-Millis": "Request-Timeout-Millis",
-                  },
+                  "headers": {},
                   "request": {
                     "query": "How can I use the Vectara platform?",
                     "stream_response": true,
@@ -189,9 +183,7 @@
         type: ChatStreamedResponse
         format: json
       examples:
-        - headers:
-            Request-Timeout: Request-Timeout
-            Request-Timeout-Millis: Request-Timeout-Millis
+        - headers: {}
           request:
             query: How can I use the Vectara platform?
             stream_response: true
@@ -224,9 +216,7 @@
         type: ChatFullResponse
         status-code: 200
       examples:
-        - headers:
-            Request-Timeout: Request-Timeout
-            Request-Timeout-Millis: Request-Timeout-Millis
+        - headers: {}
           request:
             query: How can I use the Vectara platform?
             stream_response: false

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-token-variable-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-token-variable-name.json
@@ -53,9 +53,7 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "X-API-Key": "X-API-Key",
-                  },
+                  "headers": {},
                   "request": {
                     "prompt": "prompt",
                   },
@@ -117,8 +115,7 @@
         type: string
         status-code: 200
       examples:
-        - headers:
-            X-API-Key: X-API-Key
+        - headers: {}
           request:
             prompt: prompt
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-version.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-version.json
@@ -53,9 +53,7 @@
               "docs": undefined,
               "examples": [
                 {
-                  "headers": {
-                    "X-API-Key": "X-API-Key",
-                  },
+                  "headers": {},
                   "request": {
                     "prompt": "prompt",
                   },
@@ -117,8 +115,7 @@
         type: string
         status-code: 200
       examples:
-        - headers:
-            X-API-Key: X-API-Key
+        - headers: {}
           request:
             prompt: prompt
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -90,7 +90,7 @@ export function buildEndpointExample({
                         literal: (literal) => {
                             if (literal.type === "string") {
                                 return literal.string;
-                            } else if (literal.type == "boolean") {
+                            } else if (literal.type === "boolean") {
                                 return literal.boolean.toString();
                             }
                             return undefined;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -74,8 +74,8 @@ export function buildEndpointExample({
                         name: header,
                         value: FullExample.literal(LiteralExample.string(valueToUse as string))
                     });
-                    // otherwise, use the header name as the example
                 } else {
+                    // otherwise, use the header name as the example
                     namedFullExamples.push({
                         name: header,
                         value: FullExample.primitive(PrimitiveExample.string(header))

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -1,8 +1,5 @@
 import { isNonNullish, noop } from "@fern-api/core-utils";
-import {
-    RawSchemas,
-    recursivelyVisitRawTypeReference,
-} from "@fern-api/fern-definition-schema";
+import { RawSchemas, recursivelyVisitRawTypeReference } from "@fern-api/fern-definition-schema";
 import {
     EndpointExample,
     FullExample,
@@ -56,7 +53,7 @@ export function buildEndpointExample({
         // Auth header handling
         if (endpointExample.headers != null) {
             for (const header of endpointExample.headers) {
-                // ignore auth headers for example generation 
+                // ignore auth headers for example generation
                 if (header.name !== context.builder.getAuthHeaderName()) {
                     namedFullExamples.push(header);
                 }
@@ -69,7 +66,7 @@ export function buildEndpointExample({
             if (endpointHeaderNames.has(header)) {
                 continue;
             }
-            
+
             // set global header example value
             if (info != null && typeof info === "object" && info.type != null) {
                 // handling literal header types
@@ -79,8 +76,8 @@ export function buildEndpointExample({
                     validation: undefined,
                     // generic visitor to extract the string value from the literal
                     // todo: add handling for other types in this visitor
-                    visitor: {  
-                        primitive: noop,  
+                    visitor: {
+                        primitive: noop,
                         map: noop,
                         list: noop,
                         optional: noop,
@@ -105,7 +102,6 @@ export function buildEndpointExample({
                         value: FullExample.literal(LiteralExample.string(valueToUse))
                     });
                 }
-
             } else {
                 // handling all other types
                 namedFullExamples.push({
@@ -113,7 +109,6 @@ export function buildEndpointExample({
                     value: FullExample.primitive(PrimitiveExample.string(header))
                 });
             }
-            
         }
 
         example.headers = convertHeaderExamples({

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -46,7 +46,7 @@ export function buildEndpointExample({
 
     const endpointHeaderNames = new Set(endpointExample.headers?.map((header) => header.name) ?? []);
 
-    // generate examples for headers, but ensure there are no duplicates from global and auth headers 
+    // generate examples for headers, but ensure there are no duplicates from global and auth headers
     if (hasEndpointHeaders || hasGlobalHeaders) {
         const namedFullExamples: NamedFullExample[] = [];
 
@@ -74,13 +74,12 @@ export function buildEndpointExample({
                         name: header,
                         value: FullExample.literal(LiteralExample.string(valueToUse as string))
                     });
-                // otherwise, use the header name as the example
+                    // otherwise, use the header name as the example
                 } else {
                     namedFullExamples.push({
                         name: header,
                         value: FullExample.primitive(PrimitiveExample.string(header))
                     });
-
                 }
             }
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix in endpoint example gen: literal type headers should use the literal value for example
+      type: feat
+  irVersion: 58
+  createdAt: "2025-08-04"
+  version: 0.65.45
+
+- changelogEntry:
+    - summary: |
         Escape $ signs when converting from OpenAPI -> Fern Definition (for enums), because the Fern Definition treats 
         $ sign examples as references. 
       type: feat


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
When headers of the "literal" type were added, the examples that were generated in the fern definition defaulted to using the name of the header itself. A validation rule down the line yelled about this and fern check failed. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
Use the value of the literal as the example directly. Otherwise, fallback to using the header name.

## Testing
<!-- Describe how you tested these changes -->
[X] Manual testing

