### PR TITLE
Fix/java boolean tostring path param

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/PoetTypeNameStringifier.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/PoetTypeNameStringifier.java
@@ -37,6 +37,8 @@ public final class PoetTypeNameStringifier {
             return CodeBlock.of("$T.toString($L)", Double.class, reference);
         } else if (typeName.equals(TypeName.INT)) {
             return CodeBlock.of("$T.toString($L)", Integer.class, reference);
+        } else if (typeName.equals(TypeName.BOOLEAN)) {
+            return CodeBlock.of("$T.toString($L)", Boolean.class, reference);
         } else {
             return CodeBlock.of("$L.toString()", reference);
         }

--- a/generators/java/sdk/src/test/java/com/fern/java/client/JavaSdkCustomConfigTest.java
+++ b/generators/java/sdk/src/test/java/com/fern/java/client/JavaSdkCustomConfigTest.java
@@ -1,0 +1,21 @@
+package com.fern.java.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class JavaSdkCustomConfigTest {
+
+    @Test
+    public void testPublishToDefaultsToCentral() {
+        JavaSdkCustomConfig config = JavaSdkCustomConfig.builder().build();
+        assertEquals("central", config.publishTo());
+    }
+
+    @Test
+    public void testPublishToCanBeOverridden() {
+        JavaSdkCustomConfig config =
+                JavaSdkCustomConfig.builder().publishTo("ossrh").build();
+        assertEquals("ossrh", config.publishTo());
+    }
+}

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClient.java
@@ -54,7 +54,7 @@ public class AsyncSeedExhaustiveClient {
         return this.reqWithHeadersClient.get();
     }
 
-    public static AsyncSeedExhaustiveClientBuilder builder() {
-        return new AsyncSeedExhaustiveClientBuilder();
+    public static AsyncSeedExhaustiveClientBuilder.Impl builder() {
+        return new AsyncSeedExhaustiveClientBuilder.Impl();
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -8,7 +8,7 @@ import com.seed.exhaustive.core.Environment;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
-public class AsyncSeedExhaustiveClientBuilder {
+public abstract class AsyncSeedExhaustiveClientBuilder<T extends AsyncSeedExhaustiveClientBuilder<T>> {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
@@ -19,41 +19,43 @@ public class AsyncSeedExhaustiveClientBuilder {
 
     private OkHttpClient httpClient;
 
+    protected abstract T self();
+
     /**
      * Sets token
      */
-    public AsyncSeedExhaustiveClientBuilder token(String token) {
+    public T token(String token) {
         this.token = token;
-        return this;
+        return self();
     }
 
-    public AsyncSeedExhaustiveClientBuilder url(String url) {
+    public T url(String url) {
         this.environment = Environment.custom(url);
-        return this;
+        return self();
     }
 
     /**
      * Sets the timeout (in seconds) for the client. Defaults to 60 seconds.
      */
-    public AsyncSeedExhaustiveClientBuilder timeout(int timeout) {
+    public T timeout(int timeout) {
         this.timeout = Optional.of(timeout);
-        return this;
+        return self();
     }
 
     /**
      * Sets the maximum number of retries for the client. Defaults to 2 retries.
      */
-    public AsyncSeedExhaustiveClientBuilder maxRetries(int maxRetries) {
+    public T maxRetries(int maxRetries) {
         this.maxRetries = Optional.of(maxRetries);
-        return this;
+        return self();
     }
 
     /**
      * Sets the underlying OkHttp client
      */
-    public AsyncSeedExhaustiveClientBuilder httpClient(OkHttpClient httpClient) {
+    public T httpClient(OkHttpClient httpClient) {
         this.httpClient = httpClient;
-        return this;
+        return self();
     }
 
     protected ClientOptions buildClientOptions() {
@@ -173,5 +175,12 @@ public class AsyncSeedExhaustiveClientBuilder {
     public AsyncSeedExhaustiveClient build() {
         validateConfiguration();
         return new AsyncSeedExhaustiveClient(buildClientOptions());
+    }
+
+    public static final class Impl extends AsyncSeedExhaustiveClientBuilder<Impl> {
+        @Override
+        protected Impl self() {
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClient.java
@@ -54,7 +54,7 @@ public class SeedExhaustiveClient {
         return this.reqWithHeadersClient.get();
     }
 
-    public static SeedExhaustiveClientBuilder builder() {
-        return new SeedExhaustiveClientBuilder();
+    public static SeedExhaustiveClientBuilder.Impl builder() {
+        return new SeedExhaustiveClientBuilder.Impl();
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -8,7 +8,7 @@ import com.seed.exhaustive.core.Environment;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
-public class SeedExhaustiveClientBuilder {
+public abstract class SeedExhaustiveClientBuilder<T extends SeedExhaustiveClientBuilder<T>> {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
@@ -19,41 +19,43 @@ public class SeedExhaustiveClientBuilder {
 
     private OkHttpClient httpClient;
 
+    protected abstract T self();
+
     /**
      * Sets token
      */
-    public SeedExhaustiveClientBuilder token(String token) {
+    public T token(String token) {
         this.token = token;
-        return this;
+        return self();
     }
 
-    public SeedExhaustiveClientBuilder url(String url) {
+    public T url(String url) {
         this.environment = Environment.custom(url);
-        return this;
+        return self();
     }
 
     /**
      * Sets the timeout (in seconds) for the client. Defaults to 60 seconds.
      */
-    public SeedExhaustiveClientBuilder timeout(int timeout) {
+    public T timeout(int timeout) {
         this.timeout = Optional.of(timeout);
-        return this;
+        return self();
     }
 
     /**
      * Sets the maximum number of retries for the client. Defaults to 2 retries.
      */
-    public SeedExhaustiveClientBuilder maxRetries(int maxRetries) {
+    public T maxRetries(int maxRetries) {
         this.maxRetries = Optional.of(maxRetries);
-        return this;
+        return self();
     }
 
     /**
      * Sets the underlying OkHttp client
      */
-    public SeedExhaustiveClientBuilder httpClient(OkHttpClient httpClient) {
+    public T httpClient(OkHttpClient httpClient) {
         this.httpClient = httpClient;
-        return this;
+        return self();
     }
 
     protected ClientOptions buildClientOptions() {
@@ -173,5 +175,12 @@ public class SeedExhaustiveClientBuilder {
     public SeedExhaustiveClient build() {
         validateConfiguration();
         return new SeedExhaustiveClient(buildClientOptions());
+    }
+
+    public static final class Impl extends SeedExhaustiveClientBuilder<Impl> {
+        @Override
+        protected Impl self() {
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/AsyncSeedBuilderExtensionClient.java
+++ b/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/AsyncSeedBuilderExtensionClient.java
@@ -22,7 +22,7 @@ public class AsyncSeedBuilderExtensionClient {
         return this.serviceClient.get();
     }
 
-    public static AsyncSeedBuilderExtensionClientBuilder builder() {
-        return new AsyncSeedBuilderExtensionClientBuilder();
+    public static AsyncSeedBuilderExtensionClientBuilder.Impl builder() {
+        return new AsyncSeedBuilderExtensionClientBuilder.Impl();
     }
 }

--- a/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/AsyncSeedBuilderExtensionClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/AsyncSeedBuilderExtensionClientBuilder.java
@@ -8,7 +8,7 @@ import com.seed.builderExtension.core.Environment;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
-public class AsyncSeedBuilderExtensionClientBuilder {
+public abstract class AsyncSeedBuilderExtensionClientBuilder<T extends AsyncSeedBuilderExtensionClientBuilder<T>> {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
@@ -19,46 +19,48 @@ public class AsyncSeedBuilderExtensionClientBuilder {
 
     private OkHttpClient httpClient;
 
+    protected abstract T self();
+
     /**
      * Sets token
      */
-    public AsyncSeedBuilderExtensionClientBuilder token(String token) {
+    public T token(String token) {
         this.token = token;
-        return this;
+        return self();
     }
 
-    public AsyncSeedBuilderExtensionClientBuilder environment(Environment environment) {
+    public T environment(Environment environment) {
         this.environment = environment;
-        return this;
+        return self();
     }
 
-    public AsyncSeedBuilderExtensionClientBuilder url(String url) {
+    public T url(String url) {
         this.environment = Environment.custom(url);
-        return this;
+        return self();
     }
 
     /**
      * Sets the timeout (in seconds) for the client. Defaults to 60 seconds.
      */
-    public AsyncSeedBuilderExtensionClientBuilder timeout(int timeout) {
+    public T timeout(int timeout) {
         this.timeout = Optional.of(timeout);
-        return this;
+        return self();
     }
 
     /**
      * Sets the maximum number of retries for the client. Defaults to 2 retries.
      */
-    public AsyncSeedBuilderExtensionClientBuilder maxRetries(int maxRetries) {
+    public T maxRetries(int maxRetries) {
         this.maxRetries = Optional.of(maxRetries);
-        return this;
+        return self();
     }
 
     /**
      * Sets the underlying OkHttp client
      */
-    public AsyncSeedBuilderExtensionClientBuilder httpClient(OkHttpClient httpClient) {
+    public T httpClient(OkHttpClient httpClient) {
         this.httpClient = httpClient;
-        return this;
+        return self();
     }
 
     protected ClientOptions buildClientOptions() {
@@ -181,5 +183,12 @@ public class AsyncSeedBuilderExtensionClientBuilder {
         }
         validateConfiguration();
         return new AsyncSeedBuilderExtensionClient(buildClientOptions());
+    }
+
+    public static final class Impl extends AsyncSeedBuilderExtensionClientBuilder<Impl> {
+        @Override
+        protected Impl self() {
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/SeedBuilderExtensionClient.java
+++ b/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/SeedBuilderExtensionClient.java
@@ -22,7 +22,7 @@ public class SeedBuilderExtensionClient {
         return this.serviceClient.get();
     }
 
-    public static SeedBuilderExtensionClientBuilder builder() {
-        return new SeedBuilderExtensionClientBuilder();
+    public static SeedBuilderExtensionClientBuilder.Impl builder() {
+        return new SeedBuilderExtensionClientBuilder.Impl();
     }
 }

--- a/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/SeedBuilderExtensionClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/src/main/java/com/seed/builderExtension/SeedBuilderExtensionClientBuilder.java
@@ -8,7 +8,7 @@ import com.seed.builderExtension.core.Environment;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
-public class SeedBuilderExtensionClientBuilder {
+public abstract class SeedBuilderExtensionClientBuilder<T extends SeedBuilderExtensionClientBuilder<T>> {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
@@ -19,46 +19,48 @@ public class SeedBuilderExtensionClientBuilder {
 
     private OkHttpClient httpClient;
 
+    protected abstract T self();
+
     /**
      * Sets token
      */
-    public SeedBuilderExtensionClientBuilder token(String token) {
+    public T token(String token) {
         this.token = token;
-        return this;
+        return self();
     }
 
-    public SeedBuilderExtensionClientBuilder environment(Environment environment) {
+    public T environment(Environment environment) {
         this.environment = environment;
-        return this;
+        return self();
     }
 
-    public SeedBuilderExtensionClientBuilder url(String url) {
+    public T url(String url) {
         this.environment = Environment.custom(url);
-        return this;
+        return self();
     }
 
     /**
      * Sets the timeout (in seconds) for the client. Defaults to 60 seconds.
      */
-    public SeedBuilderExtensionClientBuilder timeout(int timeout) {
+    public T timeout(int timeout) {
         this.timeout = Optional.of(timeout);
-        return this;
+        return self();
     }
 
     /**
      * Sets the maximum number of retries for the client. Defaults to 2 retries.
      */
-    public SeedBuilderExtensionClientBuilder maxRetries(int maxRetries) {
+    public T maxRetries(int maxRetries) {
         this.maxRetries = Optional.of(maxRetries);
-        return this;
+        return self();
     }
 
     /**
      * Sets the underlying OkHttp client
      */
-    public SeedBuilderExtensionClientBuilder httpClient(OkHttpClient httpClient) {
+    public T httpClient(OkHttpClient httpClient) {
         this.httpClient = httpClient;
-        return this;
+        return self();
     }
 
     protected ClientOptions buildClientOptions() {
@@ -181,5 +183,12 @@ public class SeedBuilderExtensionClientBuilder {
         }
         validateConfiguration();
         return new SeedBuilderExtensionClient(buildClientOptions());
+    }
+
+    public static final class Impl extends SeedBuilderExtensionClientBuilder<Impl> {
+        @Override
+        protected Impl self() {
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/java-builder-extension/src/test/java/com/seed/builderExtension/BuilderExtensionTest.java
+++ b/seed/java-sdk/java-builder-extension/src/test/java/com/seed/builderExtension/BuilderExtensionTest.java
@@ -1,0 +1,89 @@
+package com.seed.builderExtension;
+
+import com.seed.builderExtension.core.ClientOptions;
+import com.seed.builderExtension.core.Environment;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class BuilderExtensionTest {
+    
+    /**
+     * Test that demonstrates the builder extension pattern
+     */
+    @Test
+    public void testBuilderExtension() {
+        // Create a custom client class that extends the base client
+        class CustomClient extends SeedBuilderExtensionClient {
+            private final String customField;
+            
+            public CustomClient(ClientOptions clientOptions, String customField) {
+                super(clientOptions);
+                this.customField = customField;
+            }
+            
+            public String getCustomField() {
+                return customField;
+            }
+            
+            public static CustomClientBuilder builder() {
+                return new CustomClientBuilder();
+            }
+        }
+        
+        // Create a custom builder that extends the base builder
+        class CustomClientBuilder extends SeedBuilderExtensionClientBuilder<CustomClientBuilder> {
+            private String customField;
+            
+            @Override
+            protected CustomClientBuilder self() {
+                return this;
+            }
+            
+            public CustomClientBuilder customField(String customField) {
+                this.customField = customField;
+                return self();
+            }
+            
+            @Override
+            protected void setEnvironment(ClientOptions.Builder builder) {
+                // Example: expand environment variables in URLs
+                String url = Environment.DEVELOPMENT.getUrl();
+                if (url.contains("${DEV_NAMESPACE}")) {
+                    url = url.replace("${DEV_NAMESPACE}", "test-namespace");
+                }
+                builder.environment(Environment.custom(url));
+            }
+            
+            @Override
+            protected void setAdditional(ClientOptions.Builder builder) {
+                // Add custom headers
+                builder.addHeader("X-Custom-Header", "custom-value");
+            }
+            
+            @Override
+            public CustomClient build() {
+                validateConfiguration();
+                return new CustomClient(buildClientOptions(), customField);
+            }
+        }
+        
+        // Test that method chaining works correctly
+        CustomClient client = CustomClient.builder()
+            .token("test-token")
+            .environment(Environment.DEVELOPMENT)  // This should return CustomClientBuilder
+            .timeout(30)                          // This should return CustomClientBuilder
+            .customField("my-custom-value")       // This should return CustomClientBuilder
+            .build();                             // This should return CustomClient
+        
+        // Verify the custom client was created properly
+        assertNotNull(client);
+        assertEquals("my-custom-value", client.getCustomField());
+        
+        SeedBuilderExtensionClient baseClient = SeedBuilderExtensionClient.builder()
+            .token("test-token")
+            .environment(Environment.PRODUCTION)
+            .build();
+        
+        assertNotNull(baseClient);
+    }
+}


### PR DESCRIPTION
When the `typeName` is a primitive boolean it falls through to the default case and tries to call .toString() on the primitive, which is 