### PR TITLE
fix(java): properly handle primitive boolean toString() conversion 

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/PoetTypeNameStringifier.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/PoetTypeNameStringifier.java
@@ -37,6 +37,8 @@ public final class PoetTypeNameStringifier {
             return CodeBlock.of("$T.toString($L)", Double.class, reference);
         } else if (typeName.equals(TypeName.INT)) {
             return CodeBlock.of("$T.toString($L)", Integer.class, reference);
+        } else if (typeName.equals(TypeName.BOOLEAN)) {
+            return CodeBlock.of("$T.toString($L)", Boolean.class, reference);
         } else {
             return CodeBlock.of("$L.toString()", reference);
         }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 2.39.3
+  changelogEntry:
+    - summary: |
+        Fix compilation error when using boolean path parameters by properly handling primitive boolean to String conversion
+      type: fix
+  createdAt: '2025-08-04'
+  irVersion: 58
+
 - version: 2.39.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
When the `typeName` is a primitive boolean it falls through to the default case and tries to call .toString() on the primitive, which is invalid in Java. 

Changes 
-   Added handling for TypeName.BOOLEAN in `PoetTypeNameStringifier` to use Boolean.toString(value) instead of value.toString(), matching the pattern used for other primitive types (int, long, double).
