### PR TITLE
chore(python): fix version to pyproject

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.25.7
+  changelogEntry:
+    - summary: |
+        Fix: allow setting of package name and version in local docker generation
+      type: feat
+  createdAt: '2025-08-05'
+  irVersion: 58
+
 - version: 4.25.7-rc2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -42,9 +42,14 @@ class AbstractGenerator(ABC):
         if ir.publish_config is not None:
             ir_publish_config = ir.publish_config.get_as_union()
             if ir_publish_config.type == "filesystem" and ir_publish_config.generate_full_project:
+                package_version = "0.0.0"
+                if ir_publish_config.publish_target is not None: 
+                    publish_target = ir_publish_config.publish_target.get_as_union()
+                    if publish_target.type == "pypi" and publish_target.version is not None: 
+                        package_version = publish_target.version
                 project_config = ProjectConfig(
                     package_name='default_package_name', # ir_publish_config.publish_target.package_version, 
-                    package_version=ir_publish_config.publish_target.version
+                    package_version=package_version
                 )
         maybe_github_output_mode = generator_config.output.mode.visit(
             download_files=lambda: None,

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -42,13 +42,19 @@ class AbstractGenerator(ABC):
         if ir.publish_config is not None:
             ir_publish_config = ir.publish_config.get_as_union()
             if ir_publish_config.type == "filesystem" and ir_publish_config.generate_full_project:
+                
                 package_version = "0.0.0"
+                package_name = 'default_package_name'
                 if ir_publish_config.publish_target is not None: 
                     publish_target = ir_publish_config.publish_target.get_as_union()
-                    if publish_target.type == "pypi" and publish_target.version is not None: 
-                        package_version = publish_target.version
+                    if publish_target.type == "pypi":
+                        if publish_target.version is not None: 
+                            package_version = publish_target.version
+                        if publish_target.package_name is not None:
+                            package_name = publish_target.package_name
+
                 project_config = ProjectConfig(
-                    package_name='default_package_name', # ir_publish_config.publish_target.package_version, 
+                    package_name=package_name, 
                     package_version=package_version
                 )
         maybe_github_output_mode = generator_config.output.mode.visit(

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix: allow setting of PyPI package name and version in local docker generation
+      type: feat
+  irVersion: 58
+  createdAt: "2025-08-05"
+  version: 0.65.46
+
+- changelogEntry:
+    - summary: |
         Fix in endpoint example gen: literal type headers should use the literal value for example
       type: feat
   irVersion: 58

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -215,7 +215,7 @@ function getPublishConfig({
         }
 
         return FernIr.PublishingConfig.filesystem({
-            generateFullProject: true,// todo: uncomment this - org?.selfHostedSdKs ?? false,
+            generateFullProject: org?.selfHostedSdKs ?? false,
             publishTarget
         });
     }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -5,7 +5,7 @@ import tmp from "tmp-promise";
 
 import { FernToken, getAccessToken } from "@fern-api/auth";
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
-import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
+import { fernConfigJson, GeneratorInvocation, generatorsYml } from "@fern-api/configuration";
 import { createVenusService } from "@fern-api/core";
 import { ContainerRunner, replaceEnvVariables } from "@fern-api/core-utils";
 import { AbsoluteFilePath, RelativeFilePath, join } from "@fern-api/fs-utils";
@@ -101,9 +101,7 @@ export async function runLocalGenerationForWorkspace({
                 // Set the publish config on the intermediateRepresentation if available
 
                 // grabs generator.yml > config > package_name
-                const packageName =typeof generatorInvocation.raw?.config === "object" && generatorInvocation.raw?.config !== null
-                ? (generatorInvocation.raw.config as { package_name?: string }).package_name
-                : undefined  
+                const packageName = getPackageNameFromGeneratorConfig(generatorInvocation);
 
                 const publishConfig = getPublishConfig({
                     generatorInvocation,
@@ -166,6 +164,12 @@ export async function runLocalGenerationForWorkspace({
     if (results.some((didSucceed) => !didSucceed)) {
         context.failAndThrow();
     }
+}
+
+function getPackageNameFromGeneratorConfig(generatorInvocation: GeneratorInvocation): string | undefined {
+    return typeof generatorInvocation.raw?.config === "object" && generatorInvocation.raw?.config !== null
+        ? (generatorInvocation.raw.config as { package_name?: string }).package_name
+        : undefined;
 }
 
 export async function getWorkspaceTempDir(): Promise<tmp.DirectoryResult> {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -102,7 +102,8 @@ export async function runLocalGenerationForWorkspace({
                 const publishConfig = getPublishConfig({
                     generatorInvocation,
                     org: organization.ok ? organization.body : undefined,
-                    version
+                    version,
+                    context
                 });
                 if (publishConfig != null) {
                     intermediateRepresentation.publishConfig = publishConfig;
@@ -172,11 +173,13 @@ export async function getWorkspaceTempDir(): Promise<tmp.DirectoryResult> {
 function getPublishConfig({
     generatorInvocation,
     org,
-    version
+    version,
+    context,
 }: {
     generatorInvocation: generatorsYml.GeneratorInvocation;
     org?: FernVenusApi.Organization;
     version?: string;
+    context: TaskContext;
 }): FernIr.PublishingConfig | undefined {
     if (generatorInvocation.raw?.github != null && isGithubSelfhosted(generatorInvocation.raw.github)) {
         return FernIr.PublishingConfig.github({
@@ -195,10 +198,11 @@ function getPublishConfig({
     if (generatorInvocation.raw?.output?.location === "local-file-system") {
         let publishTarget: PublishTarget | undefined = undefined;
         if (generatorInvocation.language === "python") {
-            publishTarget = PublishTarget.pypi({
+            publishTarget = FernIr.PublishTarget.pypi({
                 version,
                 packageName: undefined
             });
+            context.logger.debug("Publish target set to PyPI for Python language.");
         }
 
         return FernIr.PublishingConfig.filesystem({


### PR DESCRIPTION
## Description
On local docker SDK generation (`fern generate --local`) was having issues:

- doesn't respect the version given by arg `--version`
- doesn't respect the package name given in `generators.yml` 

## Changes Made

- Added a new PyPiPublish Target
- Added handling for this publish target in the local generation flow 

## Testing
[] Unit tests added/updated
[x] Manual testing completed