### PR TITLE
fix(typescript): use type import for BinaryResponse in typescript files

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.6.8
+  changelogEntry:
+    - summary: Export BinaryResponse using `export type { BinaryResponse } ...` syntax to fix an issue with the SWC compiler.
+      type: fix
+  createdAt: "2025-08-06"
+  irVersion: 58
+
 - version: 2.6.7
   changelogEntry:
     - summary: Improve logging inside of wire tests for when a JSON body fails to parse to JSON.

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/index.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse";
 export type { RawResponse, WithRawResponse } from "./RawResponse";
 export { HttpResponsePromise } from "./HttpResponsePromise";
-export { BinaryResponse } from "./BinaryResponse";
+export type { BinaryResponse } from "./BinaryResponse";

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/Fetcher.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/Fetcher.test.template.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/accept-header/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/alias/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/alias/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/any-auth/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/any-auth/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/any-auth/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/any-auth/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/auth-environment-variables/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/circular-references/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/content-type/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/cross-package-type-names/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/custom-auth/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/custom-auth/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/custom-auth/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/custom-auth/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/empty-clients/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/empty-clients/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/enum/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/enum/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/enum/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/enum/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/bundle/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/bundle/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/jsr/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/index.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/index.d.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/index.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/index.d.mts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.mjs";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.mjs";
 export type { RawResponse, WithRawResponse } from "./RawResponse.mjs";
 export { HttpResponsePromise } from "./HttpResponsePromise.mjs";
-export { BinaryResponse } from "./BinaryResponse.mjs";
+export type { BinaryResponse } from "./BinaryResponse.mjs";

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../../../src/test-packagePath/core/fetcher/Fetcher.js";
-import { BinaryResponse } from "../../../../../src/test-packagePath/core/index.js";
+import type { BinaryResponse } from "../../../../../src/test-packagePath/core/index.js";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/extends/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/extends/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-download/stream/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-download/stream/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-download/stream/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/stream/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-download/wrapper/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-download/wrapper/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-download/wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-download/wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/folders/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/folders/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/http-head/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/license/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/license/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/literal/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/literal/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/no-environment/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/nullable/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/oauth-client-credentials/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/object/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/object/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/optional/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/optional/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/package-yml/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/pagination/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/pagination/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/pagination/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/pagination/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/path-parameters/default/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/path-parameters/default/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/path-parameters/default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/default/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/plain-text/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/public-object/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/query-parameters-openapi/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/query-parameters-openapi/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/query-parameters-openapi/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/query-parameters/serde-layer-query/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/response-property/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/simple-api/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/simple-api/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/simple-api/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/simple-api/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/streaming/no-serde-layer/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/trace/serde-trace/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/trace/serde-trace/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/trace/serde-trace/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/unions/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/unions/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/unions/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/unions/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/validation/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/validation/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/variables/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/variables/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/version/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/version/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/index.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/index.ts
@@ -6,4 +6,4 @@ export { Supplier } from "./Supplier.js";
 export { abortRawResponse, toRawResponse, unknownRawResponse } from "./RawResponse.js";
 export type { RawResponse, WithRawResponse } from "./RawResponse.js";
 export { HttpResponsePromise } from "./HttpResponsePromise.js";
-export { BinaryResponse } from "./BinaryResponse.js";
+export type { BinaryResponse } from "./BinaryResponse.js";

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/Fetcher.test.ts
@@ -3,7 +3,7 @@ import stream from "stream";
 import { join } from "path";
 
 import { Fetcher, fetcherImpl } from "../../../src/core/fetcher/Fetcher";
-import { BinaryResponse } from "../../../src/core";
+import type { BinaryResponse } from "../../../src/core";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {


### PR DESCRIPTION
## Description
BinaryResponse is a TS type. It is being imported and exported without using the `type` keyword. This is causing compilers like `SWC` to generate incorrect javascript code - the compiled .js code contains this export { ... } line but no actual object in BinaryResponse file gets created since it was just a type.

## Changes Made
Change all import/export of BinaryResponse to use the `type` keyword.

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

