### PR TITLE
fix(ci): Don't attempt to sync changelogs, just update

### DIFF
--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -44,28 +44,28 @@ jobs:
           path: docs
 
       - name: update csharp-sdk changelog
-        run: rsync -avu --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/overview/csharp/changelog"
+        run: rsync -av --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/overview/csharp/changelog"
 
       - name: update go-sdk changelog
-        run: rsync -avu --delete "changelogs/go-sdk/" "docs/fern/products/sdks/overview/go/changelog"
+        run: rsync -av --delete "changelogs/go-sdk/" "docs/fern/products/sdks/overview/go/changelog"
 
       - name: update java-sdk changelog
-        run: rsync -avu --delete "changelogs/java-sdk/" "docs/fern/products/sdks/overview/java/changelog"
+        run: rsync -av --delete "changelogs/java-sdk/" "docs/fern/products/sdks/overview/java/changelog"
 
       - name: update php-sdk changelog
-        run: rsync -avu --delete "changelogs/php-sdk/" "docs/fern/products/sdks/overview/php/changelog"
+        run: rsync -av --delete "changelogs/php-sdk/" "docs/fern/products/sdks/overview/php/changelog"
 
       - name: update python-sdk changelog
-        run: rsync -avu --delete "changelogs/python-sdk/" "docs/fern/products/sdks/overview/python/changelog"
+        run: rsync -av --delete "changelogs/python-sdk/" "docs/fern/products/sdks/overview/python/changelog"
 
       - name: update ruby-sdk changelog
-        run: rsync -avu --delete "changelogs/ruby-sdk/" "docs/fern/products/sdks/overview/ruby/changelog"
+        run: rsync -av --delete "changelogs/ruby-sdk/" "docs/fern/products/sdks/overview/ruby/changelog"
 
       - name: update ts-sdk changelog
-        run: rsync -avu --delete "changelogs/ts-sdk/" "docs/fern/products/sdks/overview/typescript/changelog"
+        run: rsync -av --delete "changelogs/ts-sdk/" "docs/fern/products/sdks/overview/typescript/changelog"
 
       - name: update cli changelog
-        run: rsync -avu --delete "changelogs/cli/" "docs/fern/products/cli-api-reference/cli-changelog"
+        run: rsync -av --delete "changelogs/cli/" "docs/fern/products/cli-api-reference/cli-changelog"
 
       - name: create PR
         id: cpr


### PR DESCRIPTION
## Description
I was trying to be clever and only update files that had been changed recently, that was dumb, just update everything.

## Changes Made
- remove the update flag from the rsync cmd

## Testing
Tested locally, will run in CI once merged

