### PR TITLE
chore(java): fix spring deployment

### DIFF
--- a/seed/java-spring/seed.yml
+++ b/seed/java-spring/seed.yml
@@ -5,7 +5,6 @@ image: fernapi/fern-java-spring
 publish:
   workingDirectory: generators/java
   preBuildCommands:
-    - cd generators/java
     - ./gradlew :spring:distTar
   docker: 
     file: ./generators/java/spring/Dockerfile
@@ -14,6 +13,7 @@ publish:
 test:
   docker:
     image: fernapi/fern-java-spring:latest
+    context: .
     command: 
       - cd generators/java
       - ./gradlew :spring:distTar


### PR DESCRIPTION
## Description
The Java Spring deployment was failing. https://github.com/fern-api/fern/actions/runs/16810076506/job/47612861770. These is because the `seed.yml` had a redundant `cd generators/java` command when the working directory was already set. The cd command can't be spawned as a subprocess causing an ENOENT error.

## Changes Made
  - Removed redundant cd generators/java from preBuildCommands in seed.yml
  - Fixed test Docker context from ./generators/java to . to match Java SDK pattern
  - Built and tagged Docker image fernapi/fern-java-spring:1.7.0 locally for testing

