### PR TITLE
fix(go): Fix go sse event stream handling

### DIFF
--- a/generators/go-v2/base/src/asIs/core/stream.go_
+++ b/generators/go-v2/base/src/asIs/core/stream.go_
@@ -2,10 +2,25 @@ package core
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
+)
+
+type StreamFormat string
+
+const (
+	StreamFormatSSE   StreamFormat = "sse"
+	StreamFormatEmpty StreamFormat = ""
+)
+
+const (
+	defaultMaxBufSize = 64 * 1024 // 64KB
 )
 
 // defaultStreamDelimiter is the default stream delimiter used to split messages.
@@ -44,6 +59,15 @@ func WithPrefix(prefix string) StreamOption {
 func WithTerminator(terminator string) StreamOption {
 	return func(opts *streamOptions) {
 		opts.terminator = terminator
+	}
+}
+
+// WithFormat overrides the isSSE flag for the Stream.
+//
+// By default, the Stream is not SSE.
+func WithFormat(format StreamFormat) StreamOption {
+	return func(opts *streamOptions) {
+		opts.format = format
 	}
 }
 
@@ -91,33 +115,39 @@ type streamReader interface {
 // split on custom delimiters.
 func newStreamReader(reader io.Reader, options *streamOptions) streamReader {
 	if !options.isEmpty() {
+		if options.maxBufSize == 0 {
+			options.maxBufSize = defaultMaxBufSize
+		}
 		if options.delimiter == "" {
 			options.delimiter = string(defaultStreamDelimiter)
+		}
+		if options.format == StreamFormatSSE {
+			return newSseStreamReader(reader, options)
 		}
 		return newScannerStreamReader(reader, options)
 	}
 	return newBufferStreamReader(reader)
 }
 
-// bufferStreamReader reads data from a *bufio.Reader, which splits
+// BufferStreamReader reads data from a *bufio.Reader, which splits
 // on newlines.
-type bufferStreamReader struct {
+type BufferStreamReader struct {
 	reader *bufio.Reader
 }
 
-func newBufferStreamReader(reader io.Reader) *bufferStreamReader {
-	return &bufferStreamReader{
+func newBufferStreamReader(reader io.Reader) *BufferStreamReader {
+	return &BufferStreamReader{
 		reader: bufio.NewReader(reader),
 	}
 }
 
-func (b *bufferStreamReader) ReadFromStream() ([]byte, error) {
+func (b *BufferStreamReader) ReadFromStream() ([]byte, error) {
 	return b.reader.ReadBytes(defaultStreamDelimiter)
 }
 
-// scannerStreamReader reads data from a *bufio.Scanner, which allows for
+// ScannerStreamReader reads data from a *bufio.Scanner, which allows for
 // configurable delimiters.
-type scannerStreamReader struct {
+type ScannerStreamReader struct {
 	scanner *bufio.Scanner
 	options *streamOptions
 }
@@ -125,9 +155,9 @@ type scannerStreamReader struct {
 func newScannerStreamReader(
 	reader io.Reader,
 	options *streamOptions,
-) *scannerStreamReader {
+) *ScannerStreamReader {
 	scanner := bufio.NewScanner(reader)
-	stream := &scannerStreamReader{
+	stream := &ScannerStreamReader{
 		scanner: scanner,
 		options: options,
 	}
@@ -144,7 +174,7 @@ func newScannerStreamReader(
 	return stream
 }
 
-func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
+func (s *ScannerStreamReader) ReadFromStream() ([]byte, error) {
 	if s.scanner.Scan() {
 		return s.scanner.Bytes(), nil
 	}
@@ -154,7 +184,7 @@ func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
 	return nil, io.EOF
 }
 
-func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
+func (s *ScannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	var startIndex int
 	if s.options != nil && s.options.prefix != "" {
 		if i := strings.Index(string(bytes), s.options.prefix); i >= 0 {
@@ -172,7 +202,7 @@ func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	return n, parsedData, nil
 }
 
-func (s *scannerStreamReader) isTerminated(bytes []byte) bool {
+func (s *ScannerStreamReader) isTerminated(bytes []byte) bool {
 	if s.options == nil || s.options.terminator == "" {
 		return false
 	}
@@ -183,8 +213,116 @@ type streamOptions struct {
 	delimiter  string
 	prefix     string
 	terminator string
+	format     StreamFormat
+	maxBufSize int
 }
 
 func (s *streamOptions) isEmpty() bool {
-	return s.delimiter == "" && s.prefix == "" && s.terminator == ""
+	return s.delimiter == "" && s.prefix == "" && s.terminator == "" && s.format == StreamFormatEmpty
 }
+
+// SseStreamReader reads data from a *bufio.Scanner, which allows for
+// configurable delimiters.
+type SseStreamReader struct {
+	scanner *bufio.Scanner
+	options *streamOptions
+}
+
+func newSseStreamReader(
+	reader io.Reader,
+	options *streamOptions,
+) *SseStreamReader {
+	scanner := bufio.NewScanner(reader)
+	stream := &SseStreamReader{
+		scanner: scanner,
+		options: options,
+	}
+	scanner.Buffer(make([]byte, slices.Min([]int{4096, options.maxBufSize})), options.maxBufSize)
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := strings.Index(string(data), stream.options.delimiter+stream.options.delimiter); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+
+		if atEOF || stream.isTerminated(data) {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+	return stream
+}
+
+func (s *SseStreamReader) isTerminated(bytes []byte) bool {
+	if s.options == nil || s.options.terminator == "" {
+		return false
+	}
+	return strings.Contains(string(bytes), s.options.terminator)
+}
+
+func (s *SseStreamReader) ReadFromStream() ([]byte, error) {
+
+	event, err := s.nextEvent()
+	if err != nil {
+		return nil, err
+	}
+	return event.data, nil
+}
+
+func (s *SseStreamReader) nextEvent() (*SseEvent, error) {
+
+	event := SseEvent{}
+	if s.scanner.Scan() {
+		rawEvent := s.scanner.Bytes()
+
+		lines := strings.Split(string(rawEvent), s.options.delimiter)
+		for _, line := range lines {
+			s.parseSseLine([]byte(line), &event)
+		}
+
+		if event.size() > s.options.maxBufSize {
+			return nil, errors.New("SseStreamReader.ReadFromStream: buffer limit exceeded")
+		}
+		return &event, nil
+	}
+	return &event, io.EOF
+}
+
+func (s *SseStreamReader) parseSseLine(_bytes []byte, event *SseEvent) error {
+	if bytes.HasPrefix(_bytes, sseDataPrefix) {
+		if len(event.data) > 0 {
+			event.data = append(event.data, s.options.delimiter...)
+		}
+		event.data = append(event.data, _bytes[len(sseDataPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseIdPrefix) {
+		event.id = append(event.id, _bytes[len(sseIdPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseEventPrefix) {
+		event.event = append(event.event, _bytes[len(sseEventPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseRetryPrefix) {
+		event.retry = append(event.retry, _bytes[len(sseRetryPrefix):]...)
+	}
+	return nil
+}
+
+func (event *SseEvent) size() int {
+	return len(event.id) + len(event.data) + len(event.event) + len(event.retry)
+}
+
+func (event *SseEvent) String() string {
+	return fmt.Sprintf("SseEvent{id: %q, event: %q, data: %q, retry: %q}", event.id, event.event, event.data, event.retry)
+}
+
+type SseEvent struct {
+	id    []byte
+	data  []byte
+	event []byte
+	retry []byte
+}
+
+var (
+	sseIdPrefix    = []byte("id: ")
+	sseDataPrefix  = []byte("data: ")
+	sseEventPrefix = []byte("event: ")
+	sseRetryPrefix = []byte("retry: ")
+)

--- a/generators/go-v2/base/src/asIs/internal/streamer.go_
+++ b/generators/go-v2/base/src/asIs/internal/streamer.go_
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/fern-api/fern-go/internal/generator/sdk/core"
+	"github.com/fern-api/stream-go/v2/core"
 )
 
 const (
@@ -39,11 +39,12 @@ type StreamParams struct {
 	Terminator      string
 	MaxAttempts     uint
 	Headers         http.Header
-	BodyProperties  map[string]any
+	BodyProperties  map[string]interface{}
 	QueryParameters url.Values
 	Client          HTTPClient
-	Request         any
+	Request         interface{}
 	ErrorDecoder    ErrorDecoder
+	Format          core.StreamFormat
 }
 
 // Stream issues an API streaming call according to the given stream parameters.
@@ -108,6 +109,9 @@ func (s *Streamer[T]) Stream(ctx context.Context, params *StreamParams) (*core.S
 	}
 	if params.Terminator != "" {
 		opts = append(opts, core.WithTerminator(params.Terminator))
+	}
+	if params.Format != core.StreamFormatEmpty {
+		opts = append(opts, core.WithFormat(params.Format))
 	}
 
 	return core.NewStream[T](resp, opts...), nil

--- a/generators/go-v2/sdk/src/internal/Streamer.ts
+++ b/generators/go-v2/sdk/src/internal/Streamer.ts
@@ -132,6 +132,13 @@ export class Streamer {
                 value: terminator
             });
         }
+        const format = this.getStreamFormat(args.streamingResponse);
+        if (format != null) {
+            arguments_.push({
+                name: "Format",
+                value: format
+            });
+        }
         if (args.request != null) {
             arguments_.push({
                 name: "Request",
@@ -188,6 +195,18 @@ export class Streamer {
         }
     }
 
+    private getStreamFormat(streamingResponse: StreamingResponse): go.TypeInstantiation | undefined {
+        switch (streamingResponse.type) {
+            case "sse":
+                return go.TypeInstantiation.reference(this.getStreamFormatSseTypeReference());
+            case "json":
+            case "text":
+                return undefined;
+            default:
+                assertNever(streamingResponse);
+        }
+    }
+
     private getSSETerminatorTypeReference(sse: SseStreamChunk): go.TypeInstantiation {
         if (sse.terminator != null) {
             return go.TypeInstantiation.string(sse.terminator);
@@ -206,6 +225,13 @@ export class Streamer {
         return go.typeReference({
             name: "DefaultSSEDataPrefix",
             importPath: this.context.getInternalImportPath()
+        });
+    }
+
+    private getStreamFormatSseTypeReference(): go.TypeReference {
+        return go.typeReference({
+            name: "StreamFormatSSE",
+            importPath: this.context.getCoreImportPath()
         });
     }
 }

--- a/generators/go/internal/generator/sdk/core/stream.go
+++ b/generators/go/internal/generator/sdk/core/stream.go
@@ -2,10 +2,25 @@ package core
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
+)
+
+type StreamFormat string
+
+const (
+	StreamFormatSSE   StreamFormat = "sse"
+	StreamFormatEmpty StreamFormat = ""
+)
+
+const (
+	defaultMaxBufSize = 64 * 1024 // 64KB
 )
 
 // defaultStreamDelimiter is the default stream delimiter used to split messages.
@@ -44,6 +59,15 @@ func WithPrefix(prefix string) StreamOption {
 func WithTerminator(terminator string) StreamOption {
 	return func(opts *streamOptions) {
 		opts.terminator = terminator
+	}
+}
+
+// WithFormat overrides the isSSE flag for the Stream.
+//
+// By default, the Stream is not SSE.
+func WithFormat(format StreamFormat) StreamOption {
+	return func(opts *streamOptions) {
+		opts.format = format
 	}
 }
 
@@ -91,33 +115,39 @@ type streamReader interface {
 // split on custom delimiters.
 func newStreamReader(reader io.Reader, options *streamOptions) streamReader {
 	if !options.isEmpty() {
+		if options.maxBufSize == 0 {
+			options.maxBufSize = defaultMaxBufSize
+		}
 		if options.delimiter == "" {
 			options.delimiter = string(defaultStreamDelimiter)
+		}
+		if options.format == StreamFormatSSE {
+			return newSseStreamReader(reader, options)
 		}
 		return newScannerStreamReader(reader, options)
 	}
 	return newBufferStreamReader(reader)
 }
 
-// bufferStreamReader reads data from a *bufio.Reader, which splits
+// BufferStreamReader reads data from a *bufio.Reader, which splits
 // on newlines.
-type bufferStreamReader struct {
+type BufferStreamReader struct {
 	reader *bufio.Reader
 }
 
-func newBufferStreamReader(reader io.Reader) *bufferStreamReader {
-	return &bufferStreamReader{
+func newBufferStreamReader(reader io.Reader) *BufferStreamReader {
+	return &BufferStreamReader{
 		reader: bufio.NewReader(reader),
 	}
 }
 
-func (b *bufferStreamReader) ReadFromStream() ([]byte, error) {
+func (b *BufferStreamReader) ReadFromStream() ([]byte, error) {
 	return b.reader.ReadBytes(defaultStreamDelimiter)
 }
 
-// scannerStreamReader reads data from a *bufio.Scanner, which allows for
+// ScannerStreamReader reads data from a *bufio.Scanner, which allows for
 // configurable delimiters.
-type scannerStreamReader struct {
+type ScannerStreamReader struct {
 	scanner *bufio.Scanner
 	options *streamOptions
 }
@@ -125,9 +155,9 @@ type scannerStreamReader struct {
 func newScannerStreamReader(
 	reader io.Reader,
 	options *streamOptions,
-) *scannerStreamReader {
+) *ScannerStreamReader {
 	scanner := bufio.NewScanner(reader)
-	stream := &scannerStreamReader{
+	stream := &ScannerStreamReader{
 		scanner: scanner,
 		options: options,
 	}
@@ -144,7 +174,7 @@ func newScannerStreamReader(
 	return stream
 }
 
-func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
+func (s *ScannerStreamReader) ReadFromStream() ([]byte, error) {
 	if s.scanner.Scan() {
 		return s.scanner.Bytes(), nil
 	}
@@ -154,7 +184,7 @@ func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
 	return nil, io.EOF
 }
 
-func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
+func (s *ScannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	var startIndex int
 	if s.options != nil && s.options.prefix != "" {
 		if i := strings.Index(string(bytes), s.options.prefix); i >= 0 {
@@ -172,7 +202,7 @@ func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	return n, parsedData, nil
 }
 
-func (s *scannerStreamReader) isTerminated(bytes []byte) bool {
+func (s *ScannerStreamReader) isTerminated(bytes []byte) bool {
 	if s.options == nil || s.options.terminator == "" {
 		return false
 	}
@@ -183,8 +213,116 @@ type streamOptions struct {
 	delimiter  string
 	prefix     string
 	terminator string
+	format     StreamFormat
+	maxBufSize int
 }
 
 func (s *streamOptions) isEmpty() bool {
-	return s.delimiter == "" && s.prefix == "" && s.terminator == ""
+	return s.delimiter == "" && s.prefix == "" && s.terminator == "" && s.format == StreamFormatEmpty
 }
+
+// SseStreamReader reads data from a *bufio.Scanner, which allows for
+// configurable delimiters.
+type SseStreamReader struct {
+	scanner *bufio.Scanner
+	options *streamOptions
+}
+
+func newSseStreamReader(
+	reader io.Reader,
+	options *streamOptions,
+) *SseStreamReader {
+	scanner := bufio.NewScanner(reader)
+	stream := &SseStreamReader{
+		scanner: scanner,
+		options: options,
+	}
+	scanner.Buffer(make([]byte, slices.Min([]int{4096, options.maxBufSize})), options.maxBufSize)
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := strings.Index(string(data), stream.options.delimiter+stream.options.delimiter); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+
+		if atEOF || stream.isTerminated(data) {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+	return stream
+}
+
+func (s *SseStreamReader) isTerminated(bytes []byte) bool {
+	if s.options == nil || s.options.terminator == "" {
+		return false
+	}
+	return strings.Contains(string(bytes), s.options.terminator)
+}
+
+func (s *SseStreamReader) ReadFromStream() ([]byte, error) {
+
+	event, err := s.nextEvent()
+	if err != nil {
+		return nil, err
+	}
+	return event.data, nil
+}
+
+func (s *SseStreamReader) nextEvent() (*SseEvent, error) {
+
+	event := SseEvent{}
+	if s.scanner.Scan() {
+		rawEvent := s.scanner.Bytes()
+
+		lines := strings.Split(string(rawEvent), s.options.delimiter)
+		for _, line := range lines {
+			s.parseSseLine([]byte(line), &event)
+		}
+
+		if event.size() > s.options.maxBufSize {
+			return nil, errors.New("SseStreamReader.ReadFromStream: buffer limit exceeded")
+		}
+		return &event, nil
+	}
+	return &event, io.EOF
+}
+
+func (s *SseStreamReader) parseSseLine(_bytes []byte, event *SseEvent) error {
+	if bytes.HasPrefix(_bytes, sseDataPrefix) {
+		if len(event.data) > 0 {
+			event.data = append(event.data, s.options.delimiter...)
+		}
+		event.data = append(event.data, _bytes[len(sseDataPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseIdPrefix) {
+		event.id = append(event.id, _bytes[len(sseIdPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseEventPrefix) {
+		event.event = append(event.event, _bytes[len(sseEventPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseRetryPrefix) {
+		event.retry = append(event.retry, _bytes[len(sseRetryPrefix):]...)
+	}
+	return nil
+}
+
+func (event *SseEvent) size() int {
+	return len(event.id) + len(event.data) + len(event.event) + len(event.retry)
+}
+
+func (event *SseEvent) String() string {
+	return fmt.Sprintf("SseEvent{id: %q, event: %q, data: %q, retry: %q}", event.id, event.event, event.data, event.retry)
+}
+
+type SseEvent struct {
+	id    []byte
+	data  []byte
+	event []byte
+	retry []byte
+}
+
+var (
+	sseIdPrefix    = []byte("id: ")
+	sseDataPrefix  = []byte("data: ")
+	sseEventPrefix = []byte("event: ")
+	sseRetryPrefix = []byte("retry: ")
+)

--- a/generators/go/internal/generator/sdk/internal/streamer.go
+++ b/generators/go/internal/generator/sdk/internal/streamer.go
@@ -44,6 +44,7 @@ type StreamParams struct {
 	Client          HTTPClient
 	Request         interface{}
 	ErrorDecoder    ErrorDecoder
+	Format          core.StreamFormat
 }
 
 // Stream issues an API streaming call according to the given stream parameters.
@@ -108,6 +109,9 @@ func (s *Streamer[T]) Stream(ctx context.Context, params *StreamParams) (*core.S
 	}
 	if params.Terminator != "" {
 		opts = append(opts, core.WithTerminator(params.Terminator))
+	}
+	if params.Format != core.StreamFormatEmpty {
+		opts = append(opts, core.WithFormat(params.Format))
 	}
 
 	return core.NewStream[T](resp, opts...), nil

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.5.7-rc0
+  changelogEntry:
+    - summary: |
+        Fix go sse event stream handling.
+      type: fix
+  createdAt: '2025-08-07'
+  irVersion: 58
+
 - version: 1.5.6
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/server-sent-event-examples/completions/client.go
+++ b/seed/go-sdk/server-sent-event-examples/completions/client.go
@@ -64,6 +64,7 @@ func (c *Client) Stream(
 			Client:          options.HTTPClient,
 			Prefix:          internal.DefaultSSEDataPrefix,
 			Terminator:      "[[DONE]]",
+			Format:          core.StreamFormatSSE,
 			Request:         request,
 		},
 	)

--- a/seed/go-sdk/server-sent-event-examples/core/stream.go
+++ b/seed/go-sdk/server-sent-event-examples/core/stream.go
@@ -2,10 +2,25 @@ package core
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
+)
+
+type StreamFormat string
+
+const (
+	StreamFormatSSE   StreamFormat = "sse"
+	StreamFormatEmpty StreamFormat = ""
+)
+
+const (
+	defaultMaxBufSize = 64 * 1024 // 64KB
 )
 
 // defaultStreamDelimiter is the default stream delimiter used to split messages.
@@ -44,6 +59,15 @@ func WithPrefix(prefix string) StreamOption {
 func WithTerminator(terminator string) StreamOption {
 	return func(opts *streamOptions) {
 		opts.terminator = terminator
+	}
+}
+
+// WithFormat overrides the isSSE flag for the Stream.
+//
+// By default, the Stream is not SSE.
+func WithFormat(format StreamFormat) StreamOption {
+	return func(opts *streamOptions) {
+		opts.format = format
 	}
 }
 
@@ -91,33 +115,39 @@ type streamReader interface {
 // split on custom delimiters.
 func newStreamReader(reader io.Reader, options *streamOptions) streamReader {
 	if !options.isEmpty() {
+		if options.maxBufSize == 0 {
+			options.maxBufSize = defaultMaxBufSize
+		}
 		if options.delimiter == "" {
 			options.delimiter = string(defaultStreamDelimiter)
+		}
+		if options.format == StreamFormatSSE {
+			return newSseStreamReader(reader, options)
 		}
 		return newScannerStreamReader(reader, options)
 	}
 	return newBufferStreamReader(reader)
 }
 
-// bufferStreamReader reads data from a *bufio.Reader, which splits
+// BufferStreamReader reads data from a *bufio.Reader, which splits
 // on newlines.
-type bufferStreamReader struct {
+type BufferStreamReader struct {
 	reader *bufio.Reader
 }
 
-func newBufferStreamReader(reader io.Reader) *bufferStreamReader {
-	return &bufferStreamReader{
+func newBufferStreamReader(reader io.Reader) *BufferStreamReader {
+	return &BufferStreamReader{
 		reader: bufio.NewReader(reader),
 	}
 }
 
-func (b *bufferStreamReader) ReadFromStream() ([]byte, error) {
+func (b *BufferStreamReader) ReadFromStream() ([]byte, error) {
 	return b.reader.ReadBytes(defaultStreamDelimiter)
 }
 
-// scannerStreamReader reads data from a *bufio.Scanner, which allows for
+// ScannerStreamReader reads data from a *bufio.Scanner, which allows for
 // configurable delimiters.
-type scannerStreamReader struct {
+type ScannerStreamReader struct {
 	scanner *bufio.Scanner
 	options *streamOptions
 }
@@ -125,9 +155,9 @@ type scannerStreamReader struct {
 func newScannerStreamReader(
 	reader io.Reader,
 	options *streamOptions,
-) *scannerStreamReader {
+) *ScannerStreamReader {
 	scanner := bufio.NewScanner(reader)
-	stream := &scannerStreamReader{
+	stream := &ScannerStreamReader{
 		scanner: scanner,
 		options: options,
 	}
@@ -144,7 +174,7 @@ func newScannerStreamReader(
 	return stream
 }
 
-func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
+func (s *ScannerStreamReader) ReadFromStream() ([]byte, error) {
 	if s.scanner.Scan() {
 		return s.scanner.Bytes(), nil
 	}
@@ -154,7 +184,7 @@ func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
 	return nil, io.EOF
 }
 
-func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
+func (s *ScannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	var startIndex int
 	if s.options != nil && s.options.prefix != "" {
 		if i := strings.Index(string(bytes), s.options.prefix); i >= 0 {
@@ -172,7 +202,7 @@ func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	return n, parsedData, nil
 }
 
-func (s *scannerStreamReader) isTerminated(bytes []byte) bool {
+func (s *ScannerStreamReader) isTerminated(bytes []byte) bool {
 	if s.options == nil || s.options.terminator == "" {
 		return false
 	}
@@ -183,8 +213,116 @@ type streamOptions struct {
 	delimiter  string
 	prefix     string
 	terminator string
+	format     StreamFormat
+	maxBufSize int
 }
 
 func (s *streamOptions) isEmpty() bool {
-	return s.delimiter == "" && s.prefix == "" && s.terminator == ""
+	return s.delimiter == "" && s.prefix == "" && s.terminator == "" && s.format == StreamFormatEmpty
 }
+
+// SseStreamReader reads data from a *bufio.Scanner, which allows for
+// configurable delimiters.
+type SseStreamReader struct {
+	scanner *bufio.Scanner
+	options *streamOptions
+}
+
+func newSseStreamReader(
+	reader io.Reader,
+	options *streamOptions,
+) *SseStreamReader {
+	scanner := bufio.NewScanner(reader)
+	stream := &SseStreamReader{
+		scanner: scanner,
+		options: options,
+	}
+	scanner.Buffer(make([]byte, slices.Min([]int{4096, options.maxBufSize})), options.maxBufSize)
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := strings.Index(string(data), stream.options.delimiter+stream.options.delimiter); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+
+		if atEOF || stream.isTerminated(data) {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+	return stream
+}
+
+func (s *SseStreamReader) isTerminated(bytes []byte) bool {
+	if s.options == nil || s.options.terminator == "" {
+		return false
+	}
+	return strings.Contains(string(bytes), s.options.terminator)
+}
+
+func (s *SseStreamReader) ReadFromStream() ([]byte, error) {
+
+	event, err := s.nextEvent()
+	if err != nil {
+		return nil, err
+	}
+	return event.data, nil
+}
+
+func (s *SseStreamReader) nextEvent() (*SseEvent, error) {
+
+	event := SseEvent{}
+	if s.scanner.Scan() {
+		rawEvent := s.scanner.Bytes()
+
+		lines := strings.Split(string(rawEvent), s.options.delimiter)
+		for _, line := range lines {
+			s.parseSseLine([]byte(line), &event)
+		}
+
+		if event.size() > s.options.maxBufSize {
+			return nil, errors.New("SseStreamReader.ReadFromStream: buffer limit exceeded")
+		}
+		return &event, nil
+	}
+	return &event, io.EOF
+}
+
+func (s *SseStreamReader) parseSseLine(_bytes []byte, event *SseEvent) error {
+	if bytes.HasPrefix(_bytes, sseDataPrefix) {
+		if len(event.data) > 0 {
+			event.data = append(event.data, s.options.delimiter...)
+		}
+		event.data = append(event.data, _bytes[len(sseDataPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseIdPrefix) {
+		event.id = append(event.id, _bytes[len(sseIdPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseEventPrefix) {
+		event.event = append(event.event, _bytes[len(sseEventPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseRetryPrefix) {
+		event.retry = append(event.retry, _bytes[len(sseRetryPrefix):]...)
+	}
+	return nil
+}
+
+func (event *SseEvent) size() int {
+	return len(event.id) + len(event.data) + len(event.event) + len(event.retry)
+}
+
+func (event *SseEvent) String() string {
+	return fmt.Sprintf("SseEvent{id: %q, event: %q, data: %q, retry: %q}", event.id, event.event, event.data, event.retry)
+}
+
+type SseEvent struct {
+	id    []byte
+	data  []byte
+	event []byte
+	retry []byte
+}
+
+var (
+	sseIdPrefix    = []byte("id: ")
+	sseDataPrefix  = []byte("data: ")
+	sseEventPrefix = []byte("event: ")
+	sseRetryPrefix = []byte("retry: ")
+)

--- a/seed/go-sdk/server-sent-event-examples/internal/streamer.go
+++ b/seed/go-sdk/server-sent-event-examples/internal/streamer.go
@@ -44,6 +44,7 @@ type StreamParams struct {
 	Client          HTTPClient
 	Request         interface{}
 	ErrorDecoder    ErrorDecoder
+	Format          core.StreamFormat
 }
 
 // Stream issues an API streaming call according to the given stream parameters.
@@ -108,6 +109,9 @@ func (s *Streamer[T]) Stream(ctx context.Context, params *StreamParams) (*core.S
 	}
 	if params.Terminator != "" {
 		opts = append(opts, core.WithTerminator(params.Terminator))
+	}
+	if params.Format != core.StreamFormatEmpty {
+		opts = append(opts, core.WithFormat(params.Format))
 	}
 
 	return core.NewStream[T](resp, opts...), nil

--- a/seed/go-sdk/server-sent-events/completions/client.go
+++ b/seed/go-sdk/server-sent-events/completions/client.go
@@ -64,6 +64,7 @@ func (c *Client) Stream(
 			Client:          options.HTTPClient,
 			Prefix:          internal.DefaultSSEDataPrefix,
 			Terminator:      "[[DONE]]",
+			Format:          core.StreamFormatSSE,
 			Request:         request,
 		},
 	)

--- a/seed/go-sdk/server-sent-events/core/stream.go
+++ b/seed/go-sdk/server-sent-events/core/stream.go
@@ -2,10 +2,25 @@ package core
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
+)
+
+type StreamFormat string
+
+const (
+	StreamFormatSSE   StreamFormat = "sse"
+	StreamFormatEmpty StreamFormat = ""
+)
+
+const (
+	defaultMaxBufSize = 64 * 1024 // 64KB
 )
 
 // defaultStreamDelimiter is the default stream delimiter used to split messages.
@@ -44,6 +59,15 @@ func WithPrefix(prefix string) StreamOption {
 func WithTerminator(terminator string) StreamOption {
 	return func(opts *streamOptions) {
 		opts.terminator = terminator
+	}
+}
+
+// WithFormat overrides the isSSE flag for the Stream.
+//
+// By default, the Stream is not SSE.
+func WithFormat(format StreamFormat) StreamOption {
+	return func(opts *streamOptions) {
+		opts.format = format
 	}
 }
 
@@ -91,33 +115,39 @@ type streamReader interface {
 // split on custom delimiters.
 func newStreamReader(reader io.Reader, options *streamOptions) streamReader {
 	if !options.isEmpty() {
+		if options.maxBufSize == 0 {
+			options.maxBufSize = defaultMaxBufSize
+		}
 		if options.delimiter == "" {
 			options.delimiter = string(defaultStreamDelimiter)
+		}
+		if options.format == StreamFormatSSE {
+			return newSseStreamReader(reader, options)
 		}
 		return newScannerStreamReader(reader, options)
 	}
 	return newBufferStreamReader(reader)
 }
 
-// bufferStreamReader reads data from a *bufio.Reader, which splits
+// BufferStreamReader reads data from a *bufio.Reader, which splits
 // on newlines.
-type bufferStreamReader struct {
+type BufferStreamReader struct {
 	reader *bufio.Reader
 }
 
-func newBufferStreamReader(reader io.Reader) *bufferStreamReader {
-	return &bufferStreamReader{
+func newBufferStreamReader(reader io.Reader) *BufferStreamReader {
+	return &BufferStreamReader{
 		reader: bufio.NewReader(reader),
 	}
 }
 
-func (b *bufferStreamReader) ReadFromStream() ([]byte, error) {
+func (b *BufferStreamReader) ReadFromStream() ([]byte, error) {
 	return b.reader.ReadBytes(defaultStreamDelimiter)
 }
 
-// scannerStreamReader reads data from a *bufio.Scanner, which allows for
+// ScannerStreamReader reads data from a *bufio.Scanner, which allows for
 // configurable delimiters.
-type scannerStreamReader struct {
+type ScannerStreamReader struct {
 	scanner *bufio.Scanner
 	options *streamOptions
 }
@@ -125,9 +155,9 @@ type scannerStreamReader struct {
 func newScannerStreamReader(
 	reader io.Reader,
 	options *streamOptions,
-) *scannerStreamReader {
+) *ScannerStreamReader {
 	scanner := bufio.NewScanner(reader)
-	stream := &scannerStreamReader{
+	stream := &ScannerStreamReader{
 		scanner: scanner,
 		options: options,
 	}
@@ -144,7 +174,7 @@ func newScannerStreamReader(
 	return stream
 }
 
-func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
+func (s *ScannerStreamReader) ReadFromStream() ([]byte, error) {
 	if s.scanner.Scan() {
 		return s.scanner.Bytes(), nil
 	}
@@ -154,7 +184,7 @@ func (s *scannerStreamReader) ReadFromStream() ([]byte, error) {
 	return nil, io.EOF
 }
 
-func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
+func (s *ScannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	var startIndex int
 	if s.options != nil && s.options.prefix != "" {
 		if i := strings.Index(string(bytes), s.options.prefix); i >= 0 {
@@ -172,7 +202,7 @@ func (s *scannerStreamReader) parse(bytes []byte) (int, []byte, error) {
 	return n, parsedData, nil
 }
 
-func (s *scannerStreamReader) isTerminated(bytes []byte) bool {
+func (s *ScannerStreamReader) isTerminated(bytes []byte) bool {
 	if s.options == nil || s.options.terminator == "" {
 		return false
 	}
@@ -183,8 +213,116 @@ type streamOptions struct {
 	delimiter  string
 	prefix     string
 	terminator string
+	format     StreamFormat
+	maxBufSize int
 }
 
 func (s *streamOptions) isEmpty() bool {
-	return s.delimiter == "" && s.prefix == "" && s.terminator == ""
+	return s.delimiter == "" && s.prefix == "" && s.terminator == "" && s.format == StreamFormatEmpty
 }
+
+// SseStreamReader reads data from a *bufio.Scanner, which allows for
+// configurable delimiters.
+type SseStreamReader struct {
+	scanner *bufio.Scanner
+	options *streamOptions
+}
+
+func newSseStreamReader(
+	reader io.Reader,
+	options *streamOptions,
+) *SseStreamReader {
+	scanner := bufio.NewScanner(reader)
+	stream := &SseStreamReader{
+		scanner: scanner,
+		options: options,
+	}
+	scanner.Buffer(make([]byte, slices.Min([]int{4096, options.maxBufSize})), options.maxBufSize)
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := strings.Index(string(data), stream.options.delimiter+stream.options.delimiter); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+
+		if atEOF || stream.isTerminated(data) {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+	return stream
+}
+
+func (s *SseStreamReader) isTerminated(bytes []byte) bool {
+	if s.options == nil || s.options.terminator == "" {
+		return false
+	}
+	return strings.Contains(string(bytes), s.options.terminator)
+}
+
+func (s *SseStreamReader) ReadFromStream() ([]byte, error) {
+
+	event, err := s.nextEvent()
+	if err != nil {
+		return nil, err
+	}
+	return event.data, nil
+}
+
+func (s *SseStreamReader) nextEvent() (*SseEvent, error) {
+
+	event := SseEvent{}
+	if s.scanner.Scan() {
+		rawEvent := s.scanner.Bytes()
+
+		lines := strings.Split(string(rawEvent), s.options.delimiter)
+		for _, line := range lines {
+			s.parseSseLine([]byte(line), &event)
+		}
+
+		if event.size() > s.options.maxBufSize {
+			return nil, errors.New("SseStreamReader.ReadFromStream: buffer limit exceeded")
+		}
+		return &event, nil
+	}
+	return &event, io.EOF
+}
+
+func (s *SseStreamReader) parseSseLine(_bytes []byte, event *SseEvent) error {
+	if bytes.HasPrefix(_bytes, sseDataPrefix) {
+		if len(event.data) > 0 {
+			event.data = append(event.data, s.options.delimiter...)
+		}
+		event.data = append(event.data, _bytes[len(sseDataPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseIdPrefix) {
+		event.id = append(event.id, _bytes[len(sseIdPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseEventPrefix) {
+		event.event = append(event.event, _bytes[len(sseEventPrefix):]...)
+	} else if bytes.HasPrefix(_bytes, sseRetryPrefix) {
+		event.retry = append(event.retry, _bytes[len(sseRetryPrefix):]...)
+	}
+	return nil
+}
+
+func (event *SseEvent) size() int {
+	return len(event.id) + len(event.data) + len(event.event) + len(event.retry)
+}
+
+func (event *SseEvent) String() string {
+	return fmt.Sprintf("SseEvent{id: %q, event: %q, data: %q, retry: %q}", event.id, event.event, event.data, event.retry)
+}
+
+type SseEvent struct {
+	id    []byte
+	data  []byte
+	event []byte
+	retry []byte
+}
+
+var (
+	sseIdPrefix    = []byte("id: ")
+	sseDataPrefix  = []byte("data: ")
+	sseEventPrefix = []byte("event: ")
+	sseRetryPrefix = []byte("retry: ")
+)

--- a/seed/go-sdk/server-sent-events/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events/internal/streamer.go
@@ -44,6 +44,7 @@ type StreamParams struct {
 	Client          HTTPClient
 	Request         interface{}
 	ErrorDecoder    ErrorDecoder
+	Format          core.StreamFormat
 }
 
 // Stream issues an API streaming call according to the given stream parameters.
@@ -108,6 +109,9 @@ func (s *Streamer[T]) Stream(ctx context.Context, params *StreamParams) (*core.S
 	}
 	if params.Terminator != "" {
 		opts = append(opts, core.WithTerminator(params.Terminator))
+	}
+	if params.Format != core.StreamFormatEmpty {
+		opts = append(opts, core.WithFormat(params.Format))
 	}
 
 	return core.NewStream[T](resp, opts...), nil


### PR DESCRIPTION
## Description
- Overflow issues
  - Messages larger than bufio's default scanner buffer of 4kb were causing failures.
- Multiline issues
  - The go generator expected all data payloads to be on a single line:
    `data: {"firstName": "John", "lastName": "Doe"}`
    
  - The SSE spec allows data to be spread across multiple lines (useful when payloads are large):
    `data: {`
    `data:   "firstName": "John",`
    `data:   "lastName": "Doe"`
    `data: }`

  - The generated go sdk failed to parse events in these cases.

## Changes Made
- Added default max buffer size so it errors on messages > 64kb
- Added type SseStreamReader to the stream.go (boilerplate)
- Threaded the StreamFormat variable through in several places to enable this stream reader type when appropriate
  - streamer.ts (boilerplate)
  - Streamer.ts


## Testing
- ~~[ ] Unit tests added/updated~~
- [x] Manual testing completed
  - [x] Verified manually adjusted generated sdk handles multiline messages coming from a mocked server endpoint
  - [x] Ran seed run against the sandbox fern config
  - [x] Ran seed test against the send-stream-events and send-stream-examples fixtures

