### PR TITLE
chore(cli): handle end of line comments in .fernignore

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- changelogEntry:
+    - summary: |
+        Handle end of line comments in .fernignore
+      type: feat
+  irVersion: 58
+  createdAt: "2025-08-08"
+  version: 0.65.48
 
 - changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -192,6 +192,14 @@ async function getFernIgnorePaths({
         ...fernIgnoreFileContents
             .trim()
             .split(NEW_LINE_REGEX)
-            .filter((line) => !line.startsWith("#") && line.length > 0)
+            .map((line) => {
+                // Remove comments at the end of the line
+                const commentIndex = line.indexOf("#");
+                if (commentIndex !== -1) {
+                    return line.slice(0, commentIndex).trim();
+                }
+                return line.trim();
+            })
+            .filter((line) => line.length > 0)
     ];
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
If you added end of line comments in `.fernignore`, it wouldn't parse the files properly and tries to pass that comment in the `git reset -- . [paths]` command. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Simple parsing fix to ignore those comments

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed

