### PR TITLE
feat(swift): support `header`, `bearer` and `basic` auth schemes

### DIFF
--- a/generators/swift/base/src/asIs/ClientConfig.swift
+++ b/generators/swift/base/src/asIs/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/generators/swift/base/src/asIs/ClientConfig.swift
+++ b/generators/swift/base/src/asIs/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/generators/swift/base/src/asIs/ClientConfig.swift
+++ b/generators/swift/base/src/asIs/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/generators/swift/base/src/asIs/ClientConfig.swift
+++ b/generators/swift/base/src/asIs/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/generators/swift/codegen/src/ast/Expression.ts
+++ b/generators/swift/codegen/src/ast/Expression.ts
@@ -73,6 +73,7 @@ type MethodCallWithTrailingClosure = {
     target: Expression;
     methodName: string;
     closureBody: Expression;
+    multiline?: true;
 };
 
 type ContextualMethodCall = {
@@ -198,9 +199,21 @@ export class Expression extends AstNode {
                 this.internalExpression.target.write(writer);
                 writer.write(".");
                 writer.write(this.internalExpression.methodName);
-                writer.write(" { ");
+                writer.write(" {");
+                if (this.internalExpression.multiline) {
+                    writer.newLine();
+                    writer.indent();
+                } else {
+                    writer.write(" ");
+                }
                 this.internalExpression.closureBody.write(writer);
-                writer.write(" }");
+                if (this.internalExpression.multiline) {
+                    writer.newLine();
+                    writer.dedent();
+                } else {
+                    writer.write(" ");
+                }
+                writer.write("}");
                 break;
             case "contextual-method-call":
                 writer.write(".");

--- a/generators/swift/codegen/src/ast/Expression.ts
+++ b/generators/swift/codegen/src/ast/Expression.ts
@@ -382,6 +382,10 @@ export class Expression extends AstNode {
         return new this({ type: "raw-value", value: `"${value}"` });
     }
 
+    public static nil(): Expression {
+        return new this({ type: "raw-value", value: "nil" });
+    }
+
     public static rawValue(value: string): Expression {
         return new this({ type: "raw-value", value });
     }

--- a/generators/swift/codegen/src/ast/Initializer.ts
+++ b/generators/swift/codegen/src/ast/Initializer.ts
@@ -1,7 +1,8 @@
 import { AccessLevel } from "./AccessLevel";
 import { CodeBlock } from "./CodeBlock";
-import { FunctionParameter } from "./FunctionParameter";
 import { AstNode, Writer } from "./core";
+import { DocComment } from "./DocComment";
+import { FunctionParameter } from "./FunctionParameter";
 
 export declare namespace Initializer {
     interface Args {
@@ -13,6 +14,7 @@ export declare namespace Initializer {
         parameters?: FunctionParameter[];
         body?: CodeBlock;
         multiline?: true;
+        docs?: DocComment;
     }
 }
 
@@ -23,8 +25,9 @@ export class Initializer extends AstNode {
     public readonly parameters: FunctionParameter[];
     public readonly body: CodeBlock;
     public readonly multiline?: true;
+    public readonly docs?: DocComment;
 
-    constructor({ accessLevel, failable, throws, parameters, body, multiline }: Initializer.Args) {
+    constructor({ accessLevel, failable, throws, parameters, body, multiline, docs }: Initializer.Args) {
         super();
         this.accessLevel = accessLevel;
         this.failable = failable;
@@ -32,9 +35,13 @@ export class Initializer extends AstNode {
         this.parameters = parameters ?? [];
         this.body = body ?? CodeBlock.empty();
         this.multiline = multiline;
+        this.docs = docs;
     }
 
     public write(writer: Writer): void {
+        if (this.docs != null) {
+            this.docs.write(writer);
+        }
         if (this.accessLevel != null) {
             writer.write(this.accessLevel);
             writer.write(" ");

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -70,20 +70,39 @@ export class RootClientGenerator {
             clientConfigArgs.push(
                 swift.functionArgument({
                     label: "headerAuth",
-                    value: swift.Expression.contextualMethodCall({
-                        methodName: "init",
-                        arguments_: [
-                            swift.functionArgument({
-                                label: "key",
-                                value: swift.Expression.reference(authSchemes.header.param.unsafeName)
-                            }),
-                            swift.functionArgument({
-                                label: "header",
-                                value: swift.Expression.rawStringValue(authSchemes.header.wireValue)
-                            })
-                        ],
-                        multiline: true
-                    })
+                    value: authSchemes.header.param.type.isOptional
+                        ? swift.Expression.methodCallWithTrailingClosure({
+                              target: swift.Expression.reference(authSchemes.header.param.unsafeName),
+                              methodName: "map",
+                              closureBody: swift.Expression.contextualMethodCall({
+                                  methodName: "init",
+                                  arguments_: [
+                                      swift.functionArgument({
+                                          label: "key",
+                                          value: swift.Expression.rawValue("$0")
+                                      }),
+                                      swift.functionArgument({
+                                          label: "header",
+                                          value: swift.Expression.rawStringValue(authSchemes.header.wireValue)
+                                      })
+                                  ]
+                              }),
+                              multiline: true
+                          })
+                        : swift.Expression.contextualMethodCall({
+                              methodName: "init",
+                              arguments_: [
+                                  swift.functionArgument({
+                                      label: "key",
+                                      value: swift.Expression.reference(authSchemes.header.param.unsafeName)
+                                  }),
+                                  swift.functionArgument({
+                                      label: "header",
+                                      value: swift.Expression.rawStringValue(authSchemes.header.wireValue)
+                                  })
+                              ],
+                              multiline: true
+                          })
                 })
             );
         }

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -111,20 +111,30 @@ export class RootClientGenerator {
             clientConfigArgs.push(
                 swift.functionArgument({
                     label: "bearerAuth",
-                    // TODO(kafkas): No .map when it's not optional
-                    value: swift.Expression.methodCallWithTrailingClosure({
-                        target: swift.Expression.reference(authSchemes.bearer.param.unsafeName),
-                        methodName: "map",
-                        closureBody: swift.Expression.contextualMethodCall({
-                            methodName: "init",
-                            arguments_: [
-                                swift.functionArgument({
-                                    label: "token",
-                                    value: swift.Expression.rawValue("$0")
-                                })
-                            ]
-                        })
-                    })
+                    value: authSchemes.bearer.param.type.isOptional
+                        ? swift.Expression.methodCallWithTrailingClosure({
+                              target: swift.Expression.reference(authSchemes.bearer.param.unsafeName),
+                              methodName: "map",
+                              closureBody: swift.Expression.contextualMethodCall({
+                                  methodName: "init",
+                                  arguments_: [
+                                      swift.functionArgument({
+                                          label: "token",
+                                          value: swift.Expression.rawValue("$0")
+                                      })
+                                  ]
+                              }),
+                              multiline: true
+                          })
+                        : swift.Expression.contextualMethodCall({
+                              methodName: "init",
+                              arguments_: [
+                                  swift.functionArgument({
+                                      label: "token",
+                                      value: swift.Expression.reference(authSchemes.bearer.param.unsafeName)
+                                  })
+                              ]
+                          })
                 })
             );
         }

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.1.0
+  createdAt: "2025-08-08"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Implements support for header, bearer and basic authentication schemes in the Swift SDK.
+    - type: fix
+      summary: |
+        The root client initializer is now generated based on the auth schemes defined in the API, replacing the previous static signature.
+  irVersion: 58
+
 - version: 0.0.0
   createdAt: "2025-08-06"
   changelogEntry:

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -6,7 +6,6 @@ public final class AcceptClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class AcceptClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class AcceptClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class AcceptClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -13,7 +13,7 @@ public final class AcceptClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class AcceptClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -21,7 +21,7 @@ public final class AcceptClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -21,7 +21,6 @@ public final class AcceptClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
@@ -5,16 +5,12 @@ public final class AliasExtendsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
@@ -18,8 +18,6 @@ public final class AliasExtendsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class AliasExtendsClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class AliasExtendsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/alias/Sources/AliasClient.swift
+++ b/seed/swift-sdk/alias/Sources/AliasClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class AliasClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class AliasClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/alias/Sources/AliasClient.swift
+++ b/seed/swift-sdk/alias/Sources/AliasClient.swift
@@ -5,16 +5,12 @@ public final class AliasClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/alias/Sources/AliasClient.swift
+++ b/seed/swift-sdk/alias/Sources/AliasClient.swift
@@ -18,8 +18,6 @@ public final class AliasClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -27,7 +27,9 @@ public final class AnyAuthClient: Sendable {
             headerAuth: apiKey.map {
                 .init(key: $0, header: "X-API-Key")
             },
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -7,16 +7,16 @@ public final class AnyAuthClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key to use for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-    /// - Parameter apiKey: The apiKey to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
         apiKey: String?,
+        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -24,7 +24,10 @@ public final class AnyAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
+            apiKey: .init(
+                key: apiKey,
+                header: "X-API-Key"
+            ),
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -7,16 +7,16 @@ public final class AnyAuthClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter apiKey: The apiKey to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
+        apiKey: String?,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -24,10 +24,9 @@ public final class AnyAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            headerAuth: .init(
-                key: apiKey,
-                header: "X-API-Key"
-            ),
+            headerAuth: apiKey.map {
+                .init(key: $0, header: "X-API-Key")
+            },
             bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -15,7 +15,7 @@ public final class AnyAuthClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
+        apiKey: String? = nil,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -24,11 +24,11 @@ public final class AnyAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: .init(
+            headerAuth: .init(
                 key: apiKey,
                 header: "X-API-Key"
             ),
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class AnyAuthClient: Sendable {
     public let auth: AuthClient
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class AnyAuthClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiWideBasePathClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ApiWideBasePathClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
@@ -19,8 +19,6 @@ public final class ApiWideBasePathClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
@@ -6,16 +6,12 @@ public final class ApiWideBasePathClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
+++ b/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class AudiencesClient: Sendable {
     public let commons: CommonsClient
     public let folderA: FolderAClient
@@ -16,9 +8,18 @@ public final class AudiencesClient: Sendable {
     public let foo: FooClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = AudiencesEnvironment.environmentA.rawValue,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -31,6 +32,7 @@ public final class AudiencesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.commons = CommonsClient(config: config)

--- a/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
+++ b/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
@@ -11,16 +11,12 @@ public final class AudiencesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = AudiencesEnvironment.environmentA.rawValue,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
+++ b/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
@@ -24,8 +24,6 @@ public final class AudiencesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -13,7 +13,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
+        apiKey: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: .init(
+            headerAuth: .init(
                 key: apiKey,
                 header: "X-FERN-API-KEY"
             ),

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -21,10 +21,9 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            headerAuth: .init(
-                key: apiKey,
-                header: "X-FERN-API-KEY"
-            ),
+            headerAuth: apiKey.map {
+                .init(key: $0, header: "X-FERN-API-KEY")
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -6,7 +6,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The apiKey to use for authentication.
+    /// - Parameter apiKey: The API key to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
@@ -21,8 +21,10 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
+            apiKey: .init(
+                key: apiKey,
+                header: "X-FERN-API-KEY"
+            ),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class AuthEnvironmentVariablesClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -6,8 +6,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter apiKey: The apiKey to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
@@ -15,7 +14,6 @@ public final class AuthEnvironmentVariablesClient: Sendable {
     public init(
         baseURL: String,
         apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
@@ -20,8 +20,6 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
@@ -7,16 +7,12 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class BasicAuthEnvironmentVariablesClient: Sendable {
     public let basicAuth: BasicAuthClient
     public let errors: ErrorsClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.basicAuth = BasicAuthClient(config: config)

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
@@ -7,12 +7,16 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter username: The username to use for authentication.
+    /// - Parameter accessToken: The password to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
+        username: String,
+        accessToken: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -20,6 +24,7 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
+            basicAuth: .init(username: username, password: accessToken),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class BasicAuthClient: Sendable {
     public let basicAuth: BasicAuthClient_
     public let errors: ErrorsClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class BasicAuthClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.basicAuth = BasicAuthClient_(config: config)

--- a/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
@@ -20,8 +20,6 @@ public final class BasicAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
@@ -7,12 +7,16 @@ public final class BasicAuthClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter username: The username to use for authentication.
+    /// - Parameter password: The password to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
+        username: String,
+        password: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -20,6 +24,7 @@ public final class BasicAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
+            basicAuth: .init(username: username, password: password),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
@@ -7,16 +7,12 @@ public final class BasicAuthClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -13,7 +13,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: apiKey,
+            bearerAuth: apiKey.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -21,7 +21,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: apiKey.map { .init(token: $0) },
+            bearerAuth: .init(token: apiKey),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class BearerTokenEnvironmentVariableClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -6,7 +6,6 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -6,14 +6,14 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter apiKey: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
+        apiKey: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,8 +21,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
+            token: apiKey,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
@@ -6,16 +6,12 @@ public final class BytesDownloadClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class BytesDownloadClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class BytesDownloadClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
@@ -19,8 +19,6 @@ public final class BytesDownloadClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
@@ -6,16 +6,12 @@ public final class BytesUploadClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
@@ -19,8 +19,6 @@ public final class BytesUploadClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class BytesUploadClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class BytesUploadClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
@@ -7,16 +7,12 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     public let a: AClient
     public let ast: AstClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.a = AClient(config: config)

--- a/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
@@ -20,8 +20,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/circular-references/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/ApiClient.swift
@@ -7,16 +7,12 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/circular-references/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/ApiClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     public let a: AClient
     public let ast: AstClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.a = AClient(config: config)

--- a/seed/swift-sdk/circular-references/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/ApiClient.swift
@@ -20,8 +20,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
+++ b/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
@@ -19,8 +19,6 @@ public final class ContentTypesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
+++ b/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ContentTypesClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ContentTypesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
+++ b/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
@@ -6,16 +6,12 @@ public final class ContentTypesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/content-type/Sources/Requests/PatchComplexRequest.swift
+++ b/seed/swift-sdk/content-type/Sources/Requests/PatchComplexRequest.swift
@@ -1,0 +1,60 @@
+public struct PatchComplexRequest: Codable, Hashable, Sendable {
+    public let name: String?
+    public let email: JSONValue?
+    public let age: Int?
+    public let active: Bool?
+    public let metadata: [String: JSONValue]?
+    public let tags: [String]?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        name: String? = nil,
+        email: JSONValue? = nil,
+        age: Int? = nil,
+        active: Bool? = nil,
+        metadata: [String: JSONValue]? = nil,
+        tags: [String]? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.name = name
+        self.email = email
+        self.age = age
+        self.active = active
+        self.metadata = metadata
+        self.tags = tags
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.email = try container.decodeIfPresent(JSONValue.self, forKey: .email)
+        self.age = try container.decodeIfPresent(Int.self, forKey: .age)
+        self.active = try container.decodeIfPresent(Bool.self, forKey: .active)
+        self.metadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .metadata)
+        self.tags = try container.decodeIfPresent([String].self, forKey: .tags)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.name, forKey: .name)
+        try container.encodeIfPresent(self.email, forKey: .email)
+        try container.encodeIfPresent(self.age, forKey: .age)
+        try container.encodeIfPresent(self.active, forKey: .active)
+        try container.encodeIfPresent(self.metadata, forKey: .metadata)
+        try container.encodeIfPresent(self.tags, forKey: .tags)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case name
+        case email
+        case age
+        case active
+        case metadata
+        case tags
+    }
+}

--- a/seed/swift-sdk/content-type/Sources/Requests/RegularPatchRequest.swift
+++ b/seed/swift-sdk/content-type/Sources/Requests/RegularPatchRequest.swift
@@ -1,0 +1,36 @@
+public struct RegularPatchRequest: Codable, Hashable, Sendable {
+    public let field1: String?
+    public let field2: Int?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        field1: String? = nil,
+        field2: Int? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.field1 = field1
+        self.field2 = field2
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.field1 = try container.decodeIfPresent(String.self, forKey: .field1)
+        self.field2 = try container.decodeIfPresent(Int.self, forKey: .field2)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.field1, forKey: .field1)
+        try container.encodeIfPresent(self.field2, forKey: .field2)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case field1
+        case field2
+    }
+}

--- a/seed/swift-sdk/content-type/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Resources/Service/ServiceClient.swift
@@ -13,4 +13,28 @@ public final class ServiceClient: Sendable {
             requestOptions: requestOptions
         )
     }
+
+    /// Update with JSON merge patch - complex types
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func patchComplex(id: String, request: PatchComplexRequest, requestOptions: RequestOptions? = nil) async throws -> Void {
+        return try await httpClient.performRequest(
+            method: .patch,
+            path: "/complex/\(id)",
+            body: request,
+            requestOptions: requestOptions
+        )
+    }
+
+    /// Regular PATCH endpoint without merge-patch semantics
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func regularPatch(id: String, request: RegularPatchRequest, requestOptions: RequestOptions? = nil) async throws -> Void {
+        return try await httpClient.performRequest(
+            method: .patch,
+            path: "/regular/\(id)",
+            body: request,
+            requestOptions: requestOptions
+        )
+    }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
@@ -24,8 +24,6 @@ public final class CrossPackageTypeNamesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class CrossPackageTypeNamesClient: Sendable {
     public let commons: CommonsClient
     public let folderA: FolderAClient
@@ -16,9 +8,18 @@ public final class CrossPackageTypeNamesClient: Sendable {
     public let foo: FooClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -31,6 +32,7 @@ public final class CrossPackageTypeNamesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.commons = CommonsClient(config: config)

--- a/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
@@ -11,16 +11,12 @@ public final class CrossPackageTypeNamesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
@@ -7,7 +7,7 @@ public final class CustomAuthClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter customAuthScheme: The customAuthScheme to use for authentication.
+    /// - Parameter customAuthScheme: The API key to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
@@ -22,8 +22,10 @@ public final class CustomAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
+            apiKey: .init(
+                key: customAuthScheme,
+                header: "X-API-KEY"
+            ),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class CustomAuthClient: Sendable {
     public let customAuth: CustomAuthClient_
     public let errors: ErrorsClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class CustomAuthClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.customAuth = CustomAuthClient_(config: config)

--- a/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
@@ -22,7 +22,7 @@ public final class CustomAuthClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: .init(
+            headerAuth: .init(
                 key: customAuthScheme,
                 header: "X-API-KEY"
             ),

--- a/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
@@ -7,16 +7,14 @@ public final class CustomAuthClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter customAuthScheme: The customAuthScheme to use for authentication.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
+        customAuthScheme: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
@@ -19,8 +19,6 @@ public final class EmptyClientsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
@@ -6,16 +6,12 @@ public final class EmptyClientsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class EmptyClientsClient: Sendable {
     public let level1: Level1Client
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class EmptyClientsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.level1 = Level1Client(config: config)

--- a/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/enum/Sources/EnumClient.swift
+++ b/seed/swift-sdk/enum/Sources/EnumClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class EnumClient: Sendable {
     public let headers: HeadersClient
     public let inlinedRequest: InlinedRequestClient
@@ -15,9 +7,18 @@ public final class EnumClient: Sendable {
     public let unknown: UnknownClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -30,6 +31,7 @@ public final class EnumClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.headers = HeadersClient(config: config)

--- a/seed/swift-sdk/enum/Sources/EnumClient.swift
+++ b/seed/swift-sdk/enum/Sources/EnumClient.swift
@@ -10,16 +10,12 @@ public final class EnumClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/enum/Sources/EnumClient.swift
+++ b/seed/swift-sdk/enum/Sources/EnumClient.swift
@@ -23,8 +23,6 @@ public final class EnumClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
+++ b/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ErrorPropertyClient: Sendable {
     public let errors: ErrorsClient
     public let propertyBasedError: PropertyBasedErrorClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class ErrorPropertyClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.errors = ErrorsClient(config: config)

--- a/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
+++ b/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
@@ -20,8 +20,6 @@ public final class ErrorPropertyClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
+++ b/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
@@ -7,16 +7,12 @@ public final class ErrorPropertyClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/examples/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/Sources/ExamplesClient.swift
@@ -25,7 +25,6 @@ public final class ExamplesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/examples/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/Sources/ExamplesClient.swift
@@ -10,7 +10,6 @@ public final class ExamplesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -18,7 +17,6 @@ public final class ExamplesClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = ExamplesEnvironment.production.rawValue,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/examples/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/Sources/ExamplesClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ExamplesClient: Sendable {
     public let commons: CommonsClient
     public let file: FileClient
@@ -15,9 +7,18 @@ public final class ExamplesClient: Sendable {
     public let types: TypesClient_
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = ExamplesEnvironment.production.rawValue,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -30,6 +31,7 @@ public final class ExamplesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.commons = CommonsClient(config: config)

--- a/seed/swift-sdk/examples/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/Sources/ExamplesClient.swift
@@ -25,7 +25,9 @@ public final class ExamplesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/examples/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/Sources/ExamplesClient.swift
@@ -25,7 +25,7 @@ public final class ExamplesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/examples/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -27,7 +27,9 @@ public final class ExhaustiveClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ExhaustiveClient: Sendable {
     public let endpoints: EndpointsClient
     public let generalErrors: GeneralErrorsClient
@@ -17,9 +9,18 @@ public final class ExhaustiveClient: Sendable {
     public let types: TypesClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -32,6 +33,7 @@ public final class ExhaustiveClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.endpoints = EndpointsClient(config: config)

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -27,7 +27,6 @@ public final class ExhaustiveClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -27,7 +27,7 @@ public final class ExhaustiveClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -12,7 +12,6 @@ public final class ExhaustiveClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -20,7 +19,6 @@ public final class ExhaustiveClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/extends/Sources/ExtendsClient.swift
+++ b/seed/swift-sdk/extends/Sources/ExtendsClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ExtendsClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class ExtendsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/extends/Sources/ExtendsClient.swift
+++ b/seed/swift-sdk/extends/Sources/ExtendsClient.swift
@@ -18,8 +18,6 @@ public final class ExtendsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/extends/Sources/ExtendsClient.swift
+++ b/seed/swift-sdk/extends/Sources/ExtendsClient.swift
@@ -5,16 +5,12 @@ public final class ExtendsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
@@ -19,8 +19,6 @@ public final class ExtraPropertiesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
@@ -6,16 +6,12 @@ public final class ExtraPropertiesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ExtraPropertiesClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ExtraPropertiesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
+++ b/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class FileDownloadClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class FileDownloadClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
+++ b/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
@@ -6,16 +6,12 @@ public final class FileDownloadClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
+++ b/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
@@ -19,8 +19,6 @@ public final class FileDownloadClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class FileUploadClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class FileUploadClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
@@ -6,16 +6,12 @@ public final class FileUploadClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
@@ -19,8 +19,6 @@ public final class FileUploadClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/folders/Sources/ApiClient.swift
+++ b/seed/swift-sdk/folders/Sources/ApiClient.swift
@@ -7,16 +7,12 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/folders/Sources/ApiClient.swift
+++ b/seed/swift-sdk/folders/Sources/ApiClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     public let a: AClient
     public let folder: FolderClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.a = AClient(config: config)

--- a/seed/swift-sdk/folders/Sources/ApiClient.swift
+++ b/seed/swift-sdk/folders/Sources/ApiClient.swift
@@ -20,8 +20,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
+++ b/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
@@ -19,8 +19,6 @@ public final class HttpHeadClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
+++ b/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
@@ -6,16 +6,12 @@ public final class HttpHeadClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
+++ b/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class HttpHeadClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class HttpHeadClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -6,7 +6,6 @@ public final class IdempotencyHeadersClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class IdempotencyHeadersClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -21,7 +21,7 @@ public final class IdempotencyHeadersClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -13,7 +13,7 @@ public final class IdempotencyHeadersClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class IdempotencyHeadersClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class IdempotencyHeadersClient: Sendable {
     public let payment: PaymentClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class IdempotencyHeadersClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.payment = PaymentClient(config: config)

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -21,7 +21,6 @@ public final class IdempotencyHeadersClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -21,7 +21,7 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -6,7 +6,6 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class ApiClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -21,7 +21,9 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     public let imdb: ImdbClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.imdb = ImdbClient(config: config)

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -21,7 +21,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/license/Sources/LicenseClient.swift
+++ b/seed/swift-sdk/license/Sources/LicenseClient.swift
@@ -5,16 +5,12 @@ public final class LicenseClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/license/Sources/LicenseClient.swift
+++ b/seed/swift-sdk/license/Sources/LicenseClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class LicenseClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class LicenseClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/license/Sources/LicenseClient.swift
+++ b/seed/swift-sdk/license/Sources/LicenseClient.swift
@@ -18,8 +18,6 @@ public final class LicenseClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/literal/Sources/LiteralClient.swift
+++ b/seed/swift-sdk/literal/Sources/LiteralClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class LiteralClient: Sendable {
     public let headers: HeadersClient
     public let inlined: InlinedClient
@@ -15,9 +7,18 @@ public final class LiteralClient: Sendable {
     public let reference: ReferenceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -30,6 +31,7 @@ public final class LiteralClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.headers = HeadersClient(config: config)

--- a/seed/swift-sdk/literal/Sources/LiteralClient.swift
+++ b/seed/swift-sdk/literal/Sources/LiteralClient.swift
@@ -10,16 +10,12 @@ public final class LiteralClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/literal/Sources/LiteralClient.swift
+++ b/seed/swift-sdk/literal/Sources/LiteralClient.swift
@@ -23,8 +23,6 @@ public final class LiteralClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/literal/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class MixedCaseClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class MixedCaseClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
@@ -6,16 +6,12 @@ public final class MixedCaseClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
@@ -19,8 +19,6 @@ public final class MixedCaseClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class MixedFileDirectoryClient: Sendable {
     public let organization: OrganizationClient
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class MixedFileDirectoryClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.organization = OrganizationClient(config: config)

--- a/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
@@ -7,16 +7,12 @@ public final class MixedFileDirectoryClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
@@ -20,8 +20,6 @@ public final class MixedFileDirectoryClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
@@ -19,8 +19,6 @@ public final class MultiLineDocsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
@@ -6,16 +6,12 @@ public final class MultiLineDocsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class MultiLineDocsClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class MultiLineDocsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     public let ec2: Ec2Client
     public let s3: S3Client
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.ec2 = Ec2Client(config: config)

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -14,7 +14,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -22,7 +22,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -22,7 +22,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -7,7 +7,6 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -15,7 +14,6 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -22,7 +22,6 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -22,7 +22,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -14,7 +14,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -22,7 +22,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -7,7 +7,6 @@ public final class MultiUrlEnvironmentClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -15,7 +14,6 @@ public final class MultiUrlEnvironmentClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class MultiUrlEnvironmentClient: Sendable {
     public let ec2: Ec2Client
     public let s3: S3Client
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.ec2 = Ec2Client(config: config)

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -22,7 +22,6 @@ public final class MultiUrlEnvironmentClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -21,7 +21,7 @@ public final class NoEnvironmentClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -6,7 +6,6 @@ public final class NoEnvironmentClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class NoEnvironmentClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -21,7 +21,6 @@ public final class NoEnvironmentClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -13,7 +13,7 @@ public final class NoEnvironmentClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class NoEnvironmentClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class NoEnvironmentClient: Sendable {
     public let dummy: DummyClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class NoEnvironmentClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.dummy = DummyClient(config: config)

--- a/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/nullable/Sources/NullableClient.swift
+++ b/seed/swift-sdk/nullable/Sources/NullableClient.swift
@@ -19,8 +19,6 @@ public final class NullableClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/nullable/Sources/NullableClient.swift
+++ b/seed/swift-sdk/nullable/Sources/NullableClient.swift
@@ -6,16 +6,12 @@ public final class NullableClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/nullable/Sources/NullableClient.swift
+++ b/seed/swift-sdk/nullable/Sources/NullableClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class NullableClient: Sendable {
     public let nullable: NullableClient_
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class NullableClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.nullable = NullableClient_(config: config)

--- a/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class OauthClientCredentialsClient: Sendable {
     public let auth: AuthClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class OauthClientCredentialsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
@@ -6,16 +6,12 @@ public final class OauthClientCredentialsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
@@ -19,8 +19,6 @@ public final class OauthClientCredentialsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
@@ -6,16 +6,12 @@ public final class OauthClientCredentialsDefaultClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class OauthClientCredentialsDefaultClient: Sendable {
     public let auth: AuthClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class OauthClientCredentialsDefaultClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
@@ -19,8 +19,6 @@ public final class OauthClientCredentialsDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
@@ -19,8 +19,6 @@ public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
@@ -6,16 +6,12 @@ public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
     public let auth: AuthClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class OauthClientCredentialsClient: Sendable {
     public let auth: AuthClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class OauthClientCredentialsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
@@ -6,16 +6,12 @@ public final class OauthClientCredentialsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
@@ -19,8 +19,6 @@ public final class OauthClientCredentialsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
@@ -20,8 +20,6 @@ public final class OauthClientCredentialsWithVariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class OauthClientCredentialsWithVariablesClient: Sendable {
     public let auth: AuthClient
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class OauthClientCredentialsWithVariablesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
@@ -7,16 +7,12 @@ public final class OauthClientCredentialsWithVariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class OauthClientCredentialsClient: Sendable {
     public let auth: AuthClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class OauthClientCredentialsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.auth = AuthClient(config: config)

--- a/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
@@ -6,16 +6,12 @@ public final class OauthClientCredentialsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
@@ -19,8 +19,6 @@ public final class OauthClientCredentialsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/object/Sources/ObjectClient.swift
+++ b/seed/swift-sdk/object/Sources/ObjectClient.swift
@@ -5,16 +5,12 @@ public final class ObjectClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/object/Sources/ObjectClient.swift
+++ b/seed/swift-sdk/object/Sources/ObjectClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ObjectClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class ObjectClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/object/Sources/ObjectClient.swift
+++ b/seed/swift-sdk/object/Sources/ObjectClient.swift
@@ -18,8 +18,6 @@ public final class ObjectClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
@@ -7,16 +7,12 @@ public final class ObjectsWithImportsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ObjectsWithImportsClient: Sendable {
     public let commons: CommonsClient
     public let file: FileClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class ObjectsWithImportsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.commons = CommonsClient(config: config)

--- a/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
@@ -20,8 +20,6 @@ public final class ObjectsWithImportsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
@@ -19,8 +19,6 @@ public final class ObjectsWithImportsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
@@ -6,16 +6,12 @@ public final class ObjectsWithImportsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ObjectsWithImportsClient: Sendable {
     public let optional: OptionalClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ObjectsWithImportsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.optional = OptionalClient(config: config)

--- a/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PackageYmlClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class PackageYmlClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
@@ -6,16 +6,12 @@ public final class PackageYmlClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
@@ -19,8 +19,6 @@ public final class PackageYmlClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PaginationClient: Sendable {
     public let users: UsersClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class PaginationClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.users = UsersClient(config: config)

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -21,7 +21,9 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -6,7 +6,6 @@ public final class PaginationClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class PaginationClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -21,7 +21,6 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -21,7 +21,7 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -22,7 +22,6 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -7,7 +7,6 @@ public final class PaginationClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -15,7 +14,6 @@ public final class PaginationClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -22,7 +22,9 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -22,7 +22,7 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PaginationClient: Sendable {
     public let complex: ComplexClient
     public let users: UsersClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class PaginationClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.complex = ComplexClient(config: config)

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -22,7 +22,6 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -7,7 +7,6 @@ public final class PaginationClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -15,7 +14,6 @@ public final class PaginationClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -22,7 +22,9 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -22,7 +22,7 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PaginationClient: Sendable {
     public let complex: ComplexClient
     public let users: UsersClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class PaginationClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.complex = ComplexClient(config: config)

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -22,7 +22,6 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -7,7 +7,6 @@ public final class PaginationClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -15,7 +14,6 @@ public final class PaginationClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -22,7 +22,9 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -22,7 +22,7 @@ public final class PaginationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PaginationClient: Sendable {
     public let complex: ComplexClient
     public let users: UsersClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class PaginationClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.complex = ComplexClient(config: config)

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
@@ -1,20 +1,21 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PathParametersClient: Sendable {
     public let organizations: OrganizationsClient
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -27,6 +28,7 @@ public final class PathParametersClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.organizations = OrganizationsClient(config: config)

--- a/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
@@ -7,16 +7,12 @@ public final class PathParametersClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
@@ -20,8 +20,6 @@ public final class PathParametersClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
@@ -19,8 +19,6 @@ public final class PlainTextClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PlainTextClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class PlainTextClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
@@ -6,16 +6,12 @@ public final class PlainTextClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
+++ b/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class PublicObjectClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class PublicObjectClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
+++ b/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
@@ -6,16 +6,12 @@ public final class PublicObjectClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
+++ b/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
@@ -19,8 +19,6 @@ public final class PublicObjectClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
@@ -18,8 +18,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
@@ -5,16 +5,12 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
@@ -18,8 +18,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
@@ -5,16 +5,12 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
@@ -19,8 +19,6 @@ public final class QueryParametersClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class QueryParametersClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class QueryParametersClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
@@ -6,16 +6,12 @@ public final class QueryParametersClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
@@ -19,8 +19,6 @@ public final class RequestParametersClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class RequestParametersClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class RequestParametersClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
@@ -6,16 +6,12 @@ public final class RequestParametersClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
@@ -19,8 +19,6 @@ public final class NurseryApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
@@ -6,16 +6,12 @@ public final class NurseryApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class NurseryApiClient: Sendable {
     public let package: PackageClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class NurseryApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.package = PackageClient(config: config)

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
+++ b/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ResponsePropertyClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ResponsePropertyClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
+++ b/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
@@ -19,8 +19,6 @@ public final class ResponsePropertyClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
+++ b/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
@@ -6,16 +6,12 @@ public final class ResponsePropertyClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
@@ -19,8 +19,6 @@ public final class ServerSentEventsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ServerSentEventsClient: Sendable {
     public let completions: CompletionsClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ServerSentEventsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.completions = CompletionsClient(config: config)

--- a/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
@@ -6,16 +6,12 @@ public final class ServerSentEventsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
@@ -19,8 +19,6 @@ public final class ServerSentEventsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ServerSentEventsClient: Sendable {
     public let completions: CompletionsClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class ServerSentEventsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.completions = CompletionsClient(config: config)

--- a/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
@@ -6,16 +6,12 @@ public final class ServerSentEventsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -13,7 +13,7 @@ public final class SimpleApiClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SimpleApiEnvironment.production.rawValue,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class SimpleApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -21,7 +21,7 @@ public final class SimpleApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -6,7 +6,6 @@ public final class SimpleApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class SimpleApiClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SimpleApiEnvironment.production.rawValue,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -21,7 +21,6 @@ public final class SimpleApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class SimpleApiClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SimpleApiEnvironment.production.rawValue,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class SimpleApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
@@ -18,8 +18,6 @@ public final class ApiClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
@@ -5,16 +5,12 @@ public final class ApiClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class ApiClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -21,7 +21,6 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -13,7 +13,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SingleUrlEnvironmentDefaultEnvironment.production.rawValue,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -21,7 +21,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -6,7 +6,6 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SingleUrlEnvironmentDefaultEnvironment.production.rawValue,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class SingleUrlEnvironmentDefaultClient: Sendable {
     public let dummy: DummyClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SingleUrlEnvironmentDefaultEnvironment.production.rawValue,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.dummy = DummyClient(config: config)

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     public let dummy: DummyClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SingleUrlEnvironmentNoDefaultEnvironment.production.rawValue,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.dummy = DummyClient(config: config)

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -13,7 +13,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SingleUrlEnvironmentNoDefaultEnvironment.production.rawValue,
-        token: String? = nil,
+        token: String,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -21,7 +21,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -21,7 +21,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: .init(token: token),
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -6,7 +6,6 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -14,7 +13,6 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = SingleUrlEnvironmentNoDefaultEnvironment.production.rawValue,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -21,7 +21,6 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
@@ -6,16 +6,12 @@ public final class StreamingClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class StreamingClient: Sendable {
     public let dummy: DummyClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class StreamingClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.dummy = DummyClient(config: config)

--- a/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
@@ -19,8 +19,6 @@ public final class StreamingClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/streaming/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming/Sources/StreamingClient.swift
@@ -6,16 +6,12 @@ public final class StreamingClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/streaming/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming/Sources/StreamingClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class StreamingClient: Sendable {
     public let dummy: DummyClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class StreamingClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.dummy = DummyClient(config: config)

--- a/seed/swift-sdk/streaming/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming/Sources/StreamingClient.swift
@@ -19,8 +19,6 @@ public final class StreamingClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -30,7 +30,6 @@ public final class TraceClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
             token: token,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -30,7 +30,7 @@ public final class TraceClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            token: token,
+            bearerAuth: token.map { .init(token: $0) },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -15,7 +15,6 @@ public final class TraceClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
@@ -23,7 +22,6 @@ public final class TraceClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = TraceEnvironment.prod.rawValue,
-        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -1,12 +1,4 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class TraceClient: Sendable {
     public let v2: V2Client
     public let admin: AdminClient
@@ -20,9 +12,18 @@ public final class TraceClient: Sendable {
     public let sysprop: SyspropClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String = TraceEnvironment.prod.rawValue,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -35,6 +36,7 @@ public final class TraceClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.v2 = V2Client(config: config)

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -30,7 +30,9 @@ public final class TraceClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            bearerAuth: token.map { .init(token: $0) },
+            bearerAuth: token.map {
+                .init(token: $0)
+            },
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
@@ -6,16 +6,12 @@ public final class UndiscriminatedUnionsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class UndiscriminatedUnionsClient: Sendable {
     public let union: UnionClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class UndiscriminatedUnionsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.union = UnionClient(config: config)

--- a/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
@@ -19,8 +19,6 @@ public final class UndiscriminatedUnionsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/unions/Sources/UnionsClient.swift
+++ b/seed/swift-sdk/unions/Sources/UnionsClient.swift
@@ -8,16 +8,12 @@ public final class UnionsClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/unions/Sources/UnionsClient.swift
+++ b/seed/swift-sdk/unions/Sources/UnionsClient.swift
@@ -21,8 +21,6 @@ public final class UnionsClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/unions/Sources/UnionsClient.swift
+++ b/seed/swift-sdk/unions/Sources/UnionsClient.swift
@@ -1,21 +1,22 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class UnionsClient: Sendable {
     public let bigunion: BigunionClient
     public let types: TypesClient
     public let union: UnionClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -28,6 +29,7 @@ public final class UnionsClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.bigunion = BigunionClient(config: config)

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
+++ b/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
@@ -19,8 +19,6 @@ public final class UnknownAsAnyClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
+++ b/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class UnknownAsAnyClient: Sendable {
     public let unknown: UnknownClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class UnknownAsAnyClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.unknown = UnknownClient(config: config)

--- a/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
+++ b/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
@@ -6,16 +6,12 @@ public final class UnknownAsAnyClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/validation/Sources/ValidationClient.swift
+++ b/seed/swift-sdk/validation/Sources/ValidationClient.swift
@@ -5,16 +5,12 @@ public final class ValidationClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/validation/Sources/ValidationClient.swift
+++ b/seed/swift-sdk/validation/Sources/ValidationClient.swift
@@ -18,8 +18,6 @@ public final class ValidationClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/validation/Sources/ValidationClient.swift
+++ b/seed/swift-sdk/validation/Sources/ValidationClient.swift
@@ -1,18 +1,19 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class ValidationClient: Sendable {
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -25,6 +26,7 @@ public final class ValidationClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/variables/Sources/VariablesClient.swift
+++ b/seed/swift-sdk/variables/Sources/VariablesClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class VariablesClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class VariablesClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.service = ServiceClient(config: config)

--- a/seed/swift-sdk/variables/Sources/VariablesClient.swift
+++ b/seed/swift-sdk/variables/Sources/VariablesClient.swift
@@ -6,16 +6,12 @@ public final class VariablesClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/variables/Sources/VariablesClient.swift
+++ b/seed/swift-sdk/variables/Sources/VariablesClient.swift
@@ -19,8 +19,6 @@ public final class VariablesClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
@@ -6,16 +6,12 @@ public final class VersionClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
@@ -19,8 +19,6 @@ public final class VersionClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class VersionClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class VersionClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/version/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version/Sources/VersionClient.swift
@@ -6,16 +6,12 @@ public final class VersionClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,

--- a/seed/swift-sdk/version/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version/Sources/VersionClient.swift
@@ -19,8 +19,6 @@ public final class VersionClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/version/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version/Sources/VersionClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class VersionClient: Sendable {
     public let user: UserClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class VersionClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.user = UserClient(config: config)

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -183,11 +183,14 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKeyConfig = clientConfig.apiKey {
-            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let token = requestOptions?.token ?? clientConfig.token {
-            headers["Authorization"] = "Bearer \(token)"
+        if let basicAuth = clientConfig.basicAuth {
+            headers["Authorization"] = "Basic \(basicAuth.token)"
+        }
+        if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
+            headers["Authorization"] = "Bearer \(bearerToken)"
         }
         for (key, value) in requestHeaders {
             headers[key] = value

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -186,8 +186,8 @@ final class HTTPClient: Sendable {
         if let headerAuth = clientConfig.headerAuth {
             headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
         }
-        if let basicAuth = clientConfig.basicAuth {
-            headers["Authorization"] = "Basic \(basicAuth.token)"
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
         }
         if let bearerToken = requestOptions?.token ?? clientConfig.bearerAuth?.token {
             headers["Authorization"] = "Bearer \(bearerToken)"

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -183,8 +183,8 @@ final class HTTPClient: Sendable {
     ) -> [String: String] {
         var headers = clientConfig.headers ?? [:]
         headers["Content-Type"] = requestContentType.rawValue
-        if let apiKey = requestOptions?.apiKey ?? clientConfig.apiKey {
-            headers["api_key"] = apiKey
+        if let apiKeyConfig = clientConfig.apiKey {
+            headers[apiKeyConfig.header] = requestOptions?.apiKey ?? apiKeyConfig.key
         }
         if let token = requestOptions?.token ?? clientConfig.token {
             headers["Authorization"] = "Bearer \(token)"

--- a/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
@@ -8,6 +8,8 @@ public final class ClientConfig: Sendable {
     let apiKey: String?
     let token: String?
     let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
     let urlSession: URLSession
 
     init(
@@ -16,18 +18,21 @@ public final class ClientConfig: Sendable {
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
+        maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.token = token
         self.headers = headers
-        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: timeout)
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int?) -> URLSession {
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
     let configuration = URLSessionConfiguration.default
-    configuration.timeoutIntervalForRequest = .init(timeoutSeconds ?? ClientConfig.Defaults.timeout)
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
@@ -4,14 +4,30 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
-    struct ApiKeyConfig {
+    struct HeaderAuth {
         let key: String
         let header: String
     }
 
+    struct BearerAuth {
+        let token: String
+    }
+
+    struct BasicAuth {
+        let username: String
+        let password: String
+
+        var token: String {
+            let credentials: String = "\(username):\(password)"
+            let data = credentials.data(using: .utf8) ?? Data()
+            return data.base64EncodedString()
+        }
+    }
+
     let baseURL: String
-    let apiKey: ApiKeyConfig?
-    let token: String?
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
     let headers: [String: String]?
     let timeout: Int
     let maxRetries: Int
@@ -19,16 +35,18 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: ApiKeyConfig? = nil,
-        token: String? = nil,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: URLSession? = nil
     ) {
         self.baseURL = baseURL
-        self.apiKey = apiKey
-        self.token = token
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
         self.headers = headers
         self.timeout = timeout ?? Defaults.timeout
         self.maxRetries = maxRetries ?? Defaults.maxRetries

--- a/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
@@ -14,13 +14,16 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String
-        let password: String
+        let username: String?
+        let password: String?
 
-        var token: String {
-            let credentials: String = "\(username):\(password)"
-            let data = credentials.data(using: .utf8) ?? Data()
-            return data.base64EncodedString()
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
         }
     }
 

--- a/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
@@ -4,8 +4,13 @@ public final class ClientConfig: Sendable {
         static let maxRetries: Int = 2
     }
 
+    struct ApiKeyConfig {
+        let key: String
+        let header: String
+    }
+
     let baseURL: String
-    let apiKey: String?
+    let apiKey: ApiKeyConfig?
     let token: String?
     let headers: [String: String]?
     let timeout: Int
@@ -14,7 +19,7 @@ public final class ClientConfig: Sendable {
 
     init(
         baseURL: String,
-        apiKey: String? = nil,
+        apiKey: ApiKeyConfig? = nil,
         token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,

--- a/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
+++ b/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
@@ -19,8 +19,6 @@ public final class WebsocketClient: Sendable {
     ) {
         let config = ClientConfig(
             baseURL: baseURL,
-            apiKey: apiKey,
-            token: token,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
+++ b/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
@@ -1,19 +1,20 @@
 /// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
-///
-/// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-/// - Parameter apiKey: The API key for authentication.
-/// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
-/// - Parameter headers: Additional headers to send with each request.
-/// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-/// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
-/// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
 public final class WebsocketClient: Sendable {
     public let realtime: RealtimeClient
     private let httpClient: HTTPClient
 
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter apiKey: The API key for authentication.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String,
+        apiKey: String?,
         token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
@@ -26,6 +27,7 @@ public final class WebsocketClient: Sendable {
             token: token,
             headers: headers,
             timeout: timeout,
+            maxRetries: maxRetries,
             urlSession: urlSession
         )
         self.realtime = RealtimeClient(config: config)

--- a/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
+++ b/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
@@ -6,16 +6,12 @@ public final class WebsocketClient: Sendable {
     /// Initialize the client with the specified configuration.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
-    /// - Parameter apiKey: The API key for authentication.
-    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public init(
         baseURL: String,
-        apiKey: String?,
-        token: String? = nil,
         headers: [String: String]? = [:],
         timeout: Int? = nil,
         maxRetries: Int? = nil,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Implements support for three authentication schemes in the Swift SDK. The root client initializer is now generated based on the API’s auth schemes, replacing the previous static signature. We also update `ClientConfig.swift` and `HTTPClient.swift` in the Swift “as-is” code to handle these schemes.

**Notes**:
- The IR returns auth schemes as an array. Multiple schemes of the same type are assumed not to occur, so only the last instance of each type is used.
- We'll implement `oauth` support in a separate PR as it's a bit more involved and we currently have several other priorities.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Expanded `ClientConfig.swift` with nested structs to support multiple auth schemes
- Modified `HttpClient.swift` to send appropriate auth headers
- Added `multiline` option for `MethodCallWithTrailingClosure` expression
- Added `docs` option for `Initializer`
- Updated `RootClientGenerator` to generate generate scheme-aware initializers
- Moved the `parameters` section of the root client docs to the initializer. This needs to be specified at the initializer level because we'll soon need to add at least 2 more public convenience initializers each of which will have a different signature
- Updated seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

