### PR TITLE
chore(rust): bump rust sdk version for initial release

### DIFF
--- a/generators/rust/model/package.json
+++ b/generators/rust/model/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fern-api/rust-model",
+  "name": "@fern-api/fern-rust-model",
   "version": "0.0.0",
   "repository": {
     "type": "git",

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.1
+  createdAt: '2025-08-11'
+  changelogEntry:
+    - type: feat
+      summary: First stable release with core model generation functionality.
+  irVersion: 58
+
 - version: 0.0.0
   createdAt: '2025-07-25'
   changelogEntry:

--- a/generators/rust/sdk/package.json
+++ b/generators/rust/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fern-api/rust-sdk",
+  "name": "@fern-api/fern-rust-sdk",
   "version": "0.0.0",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/rust-base": "workspace:*",
     "@fern-api/rust-codegen": "workspace:*",
-    "@fern-api/rust-model": "workspace:*",
+    "@fern-api/fern-rust-model": "workspace:*",
     "@fern-fern/generator-cli-sdk": "0.0.28",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -2,7 +2,7 @@ import { GeneratorNotificationService } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { AbstractRustGeneratorCli, RustFile } from "@fern-api/rust-base";
 import { Module, ModuleDeclaration, UseStatement } from "@fern-api/rust-codegen";
-import { generateModels } from "@fern-api/rust-model";
+import { generateModels } from "@fern-api/fern-rust-model";
 
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";

--- a/generators/rust/sdk/src/SdkGeneratorContext.ts
+++ b/generators/rust/sdk/src/SdkGeneratorContext.ts
@@ -1,6 +1,6 @@
 import { GeneratorNotificationService } from "@fern-api/base-generator";
 import { AbstractRustGeneratorContext, AsIsFileDefinition, AsIsFiles } from "@fern-api/rust-base";
-import { ModelCustomConfigSchema, ModelGeneratorContext } from "@fern-api/rust-model";
+import { ModelCustomConfigSchema, ModelGeneratorContext } from "@fern-api/fern-rust-model";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { HttpService, IntermediateRepresentation, ServiceId, Subpackage, SubpackageId } from "@fern-fern/ir-sdk/api";
 import { RustGeneratorAgent } from "./RustGeneratorAgent";

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1,7 +1,7 @@
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { RustFile } from "@fern-api/rust-base";
 import { UseStatement, rust } from "@fern-api/rust-codegen";
-import { generateRustTypeForTypeReference } from "@fern-api/rust-model";
+import { generateRustTypeForTypeReference } from "@fern-api/fern-rust-model";
 
 import {
     ApiAuth,

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.1
+  createdAt: "2025-08-11"
+  changelogEntry:
+    - type: feat
+      summary: First stable release with core SDK functionality.
+  irVersion: 58
+
 - version: 0.0.0
   createdAt: "2025-07-25"
   changelogEntry:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1961,6 +1961,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../packages/configs
+      '@fern-api/fern-rust-model':
+        specifier: workspace:*
+        version: link:../model
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
@@ -1973,9 +1976,6 @@ importers:
       '@fern-api/rust-codegen':
         specifier: workspace:*
         version: link:../codegen
-      '@fern-api/rust-model':
-        specifier: workspace:*
-        version: link:../model
       '@fern-fern/generator-cli-sdk':
         specifier: 0.0.28
         version: 0.0.28


### PR DESCRIPTION
## Description

This PR introduces initial Rust SDK generator functionality to Fern, adding support for generating Rust SDKs from API definitions through the Fern IR system.

## Changes Made

- Added initial Rust SDK generator with core functionality
- Created version configuration files for Rust model and SDK generators
- Renamed Rust generator packages for consistency

## Testing

- [x] Manual testing completed