### PR TITLE
chore(internal): allow case-insensitivity for securityScheme.scheme

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -52,7 +52,7 @@ function convertSecuritySchemeHelper(
             tokenEnvVar: bearerNames?.env
         });
     } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "basic") {
-      // ^ case insensitivity for securityScheme.scheme required in OAS
+        // ^ case insensitivity for securityScheme.scheme required in OAS
         const basicSecuritySchemeNamingAndEnvvar = getBasicSecuritySchemeNameAndEnvvar(securityScheme);
         const basicSecuritySchemeNaming = getBasicSecuritySchemeNames(securityScheme);
         return SecurityScheme.basic({

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -42,7 +42,8 @@ function convertSecuritySchemeHelper(
                 headerNames?.name ?? getExtension<string>(securityScheme, FernOpenAPIExtension.HEADER_VARIABLE_NAME),
             headerEnvVar: headerNames?.env
         });
-    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "bearer") { // case insensitivity required in OAS
+    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "bearer") {
+        // ^ case insensitivity for securityScheme.scheme required in OAS
         const bearerNames = getExtension<SecuritySchemeNames>(securityScheme, FernOpenAPIExtension.FERN_BEARER_TOKEN);
         return SecurityScheme.bearer({
             tokenVariableName:
@@ -50,7 +51,8 @@ function convertSecuritySchemeHelper(
                 getExtension<string>(securityScheme, FernOpenAPIExtension.BEARER_TOKEN_VARIABLE_NAME),
             tokenEnvVar: bearerNames?.env
         });
-    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "basic") { // case insensitivity required in OAS
+    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "basic") {
+      // ^ case insensitivity for securityScheme.scheme required in OAS
         const basicSecuritySchemeNamingAndEnvvar = getBasicSecuritySchemeNameAndEnvvar(securityScheme);
         const basicSecuritySchemeNaming = getBasicSecuritySchemeNames(securityScheme);
         return SecurityScheme.basic({

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -42,7 +42,7 @@ function convertSecuritySchemeHelper(
                 headerNames?.name ?? getExtension<string>(securityScheme, FernOpenAPIExtension.HEADER_VARIABLE_NAME),
             headerEnvVar: headerNames?.env
         });
-    } else if (securityScheme.type === "http" && securityScheme.scheme === "bearer") {
+    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "bearer") { // case insensitivity required in OAS
         const bearerNames = getExtension<SecuritySchemeNames>(securityScheme, FernOpenAPIExtension.FERN_BEARER_TOKEN);
         return SecurityScheme.bearer({
             tokenVariableName:
@@ -50,7 +50,7 @@ function convertSecuritySchemeHelper(
                 getExtension<string>(securityScheme, FernOpenAPIExtension.BEARER_TOKEN_VARIABLE_NAME),
             tokenEnvVar: bearerNames?.env
         });
-    } else if (securityScheme.type === "http" && securityScheme.scheme === "basic") {
+    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "basic") { // case insensitivity required in OAS
         const basicSecuritySchemeNamingAndEnvvar = getBasicSecuritySchemeNameAndEnvvar(securityScheme);
         const basicSecuritySchemeNaming = getBasicSecuritySchemeNames(securityScheme);
         return SecurityScheme.basic({

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/ada.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/ada.json
@@ -1097,7 +1097,7 @@
       "securitySchemes": {
         "BearerAuth": {
           "type": "http",
-          "scheme": "bearer"
+          "scheme": "Bearer"
         }
       }
     },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ada/openapi.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ada/openapi.json
@@ -832,7 +832,7 @@
         "securitySchemes": {
             "BearerAuth": {
                 "type": "http",
-                "scheme": "bearer"
+                "scheme": "Bearer"
             }
         }
     },

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Allow 'securityScheme.scheme' to be case-insensitive.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-08-11"
+  version: 0.66.11
+
+- changelogEntry:
     - summary: Add 'vendor' to set of reservved keywords for go.
       type: fix
   irVersion: 59


### PR DESCRIPTION
## Description
this is required as per https://swagger.io/specification/#security-scheme-object (RFC7235), that "basic" and "bearer" can be in any case

## Changes Made
just two `?.toLowerCase()` additions in the relevant spots

## Testing
- [X] Manual testing completed

