### PR TITLE
fix(csharp): Ensure that idempotent headers are added to the headers in the request

### DIFF
--- a/generators/csharp/base/src/AsIs.ts
+++ b/generators/csharp/base/src/AsIs.ts
@@ -73,7 +73,8 @@ export const AsIsFiles = {
             AdditionalParametersTests: "test/RawClientTests/AdditionalParametersTests.Template.cs",
             MultipartFormTests: "test/RawClientTests/MultipartFormTests.Template.cs",
             RetriesTests: "test/RawClientTests/RetriesTests.Template.cs",
-            QueryParameterTests: "test/RawClientTests/QueryParameterTests.Template.cs"
+            QueryParameterTests: "test/RawClientTests/QueryParameterTests.Template.cs",
+            IdempotentHeadersTests: "test/RawClientTests/IdempotentHeadersTests.Template.cs"
         },
         Utils: {
             JsonElementComparer: "test/Utils/JsonElementComparer.Template.cs",

--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -178,6 +178,12 @@ internal partial class RawClient(ClientOptions clientOptions)
         MergeAdditionalHeaders(mergedHeaders, Options.AdditionalHeaders);
         MergeHeaders(mergedHeaders, request.Headers);
         MergeHeaders(mergedHeaders, request.Options?.Headers);
+        <% if (idempotencyHeaders) { %>
+        if (request.Options is IIdempotentRequestOptions idempotentRequest)
+        {
+            MergeHeaders(mergedHeaders, idempotentRequest.GetIdempotencyHeaders());
+        }
+        <% } %>
 
         MergeAdditionalHeaders(mergedHeaders, request.Options?.AdditionalHeaders ?? []);
         SetHeaders(httpRequest, mergedHeaders);

--- a/generators/csharp/base/src/asIs/test/RawClientTests/IdempotentHeadersTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/RawClientTests/IdempotentHeadersTests.Template.cs
@@ -1,0 +1,175 @@
+using NUnit.Framework;
+using WireMock.Matchers;
+using WireMock.Server;
+using SystemTask = global::System.Threading.Tasks.Task;
+using WireMockRequest = WireMock.RequestBuilders.Request;
+using WireMockResponse = WireMock.ResponseBuilders.Response;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+using <%= namespace%>.Core;
+
+namespace <%= namespace%>.Test.Core.RawClientTests;
+
+[Serializable]
+public partial class IdempotentRequestOptions : IIdempotentRequestOptions
+{
+    /// <summary>
+    /// The http headers sent with the request.
+    /// </summary>
+    Headers IRequestOptions.Headers { get; init; } = new();
+
+    /// <summary>
+    /// The Base URL for the API.
+    /// </summary>
+    public string? BaseUrl { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// The http client used to make requests.
+    /// </summary>
+    public HttpClient? HttpClient { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// Additional headers to be sent with the request.
+    /// Headers previously set with matching keys will be overwritten.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, string?>> AdditionalHeaders { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    } = [];
+
+    /// <summary>
+    /// The http client used to make requests.
+    /// </summary>
+    public int? MaxRetries { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// The timeout for the request.
+    /// </summary>
+    public TimeSpan? Timeout { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// Additional query parameters sent with the request.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, string>> AdditionalQueryParameters { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    } = Enumerable.Empty<KeyValuePair<string, string>>();
+
+    /// <summary>
+    /// Additional body properties sent with the request.
+    /// This is only applied to JSON requests.
+    /// </summary>
+    public object? AdditionalBodyProperties { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    public int IdempotencyExpiration { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    public string? IdempotencyKey { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    Headers IIdempotentRequestOptions.GetIdempotencyHeaders()
+    {
+        return new Headers(
+            new Dictionary<string, string> { ["IDEMPOTENCY-KEY"] = IdempotencyKey }
+        );
+    }
+}
+
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class IdempotentHeadersTests
+{
+    private WireMockServer _server;
+    private HttpClient _httpClient;
+    private RawClient _rawClient;
+    private string _baseUrl;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _server = WireMockServer.Start();
+        _baseUrl = _server.Url ?? "";
+        _httpClient = new HttpClient { BaseAddress = new Uri(_baseUrl) };
+        _rawClient = new RawClient(new ClientOptions { HttpClient = _httpClient });
+    }
+
+    [Test]
+    public void CheckForIdempotencyHeadersSupport()
+    {
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").WithParam("foo", "bar").UsingGet())
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        var request = _rawClient.CreateHttpRequest(new JsonRequest()
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Get,
+            Path = "/test",
+            Query = new Dictionary<string, object>(),
+            Options = new IdempotentRequestOptions
+            {
+                IdempotencyKey = "1234567890"
+            }
+            
+        });
+
+        request.Headers.TryGetValues("IDEMPOTENCY-KEY", out var idempotencyKey);
+        Assert.That(idempotencyKey?.First(), Is.EqualTo("1234567890"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _server.Dispose();
+        _httpClient.Dispose();
+    }
+}

--- a/generators/csharp/sdk/src/SdkGeneratorContext.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorContext.ts
@@ -258,6 +258,9 @@ export class SdkGeneratorContext extends AbstractCsharpGeneratorContext<SdkCusto
             AsIsFiles.Test.RawClientTests.RetriesTests,
             AsIsFiles.Test.RawClientTests.QueryParameterTests
         ];
+        if (this.hasIdempotencyHeaders()) {
+            files.push(AsIsFiles.Test.RawClientTests.IdempotentHeadersTests);
+        }
         if (this.generateNewAdditionalProperties()) {
             files.push(AsIsFiles.Test.Json.AdditionalPropertiesTests);
         }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.8
+  changelogEntry:
+    - type: fix
+      summary: Idempotent headers are added to the headers in the request
+  createdAt: '2025-08-11'
+  irVersion: 58
+
 - version: 2.1.7
   changelogEntry:
     - type: fix

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/IdempotentHeadersTests.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/IdempotentHeadersTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using NUnit.Framework;
+using SeedIdempotencyHeaders.Core;
+using WireMock.Matchers;
+using WireMock.Server;
+using SystemTask = global::System.Threading.Tasks.Task;
+using WireMockRequest = WireMock.RequestBuilders.Request;
+using WireMockResponse = WireMock.ResponseBuilders.Response;
+
+namespace SeedIdempotencyHeaders.Test.Core.RawClientTests;
+
+[Serializable]
+public partial class IdempotentRequestOptions : IIdempotentRequestOptions
+{
+    /// <summary>
+    /// The http headers sent with the request.
+    /// </summary>
+    Headers IRequestOptions.Headers { get; init; } = new();
+
+    /// <summary>
+    /// The Base URL for the API.
+    /// </summary>
+    public string? BaseUrl { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// The http client used to make requests.
+    /// </summary>
+    public HttpClient? HttpClient { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// Additional headers to be sent with the request.
+    /// Headers previously set with matching keys will be overwritten.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, string?>> AdditionalHeaders { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    } = [];
+
+    /// <summary>
+    /// The http client used to make requests.
+    /// </summary>
+    public int? MaxRetries { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// The timeout for the request.
+    /// </summary>
+    public TimeSpan? Timeout { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// Additional query parameters sent with the request.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, string>> AdditionalQueryParameters { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    } = Enumerable.Empty<KeyValuePair<string, string>>();
+
+    /// <summary>
+    /// Additional body properties sent with the request.
+    /// This is only applied to JSON requests.
+    /// </summary>
+    public object? AdditionalBodyProperties { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    public int IdempotencyExpiration { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    public string? IdempotencyKey { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    Headers IIdempotentRequestOptions.GetIdempotencyHeaders()
+    {
+        return new Headers(new Dictionary<string, string> { ["IDEMPOTENCY-KEY"] = IdempotencyKey });
+    }
+}
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class IdempotentHeadersTests
+{
+    private WireMockServer _server;
+    private HttpClient _httpClient;
+    private RawClient _rawClient;
+    private string _baseUrl;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _server = WireMockServer.Start();
+        _baseUrl = _server.Url ?? "";
+        _httpClient = new HttpClient { BaseAddress = new Uri(_baseUrl) };
+        _rawClient = new RawClient(new ClientOptions { HttpClient = _httpClient });
+    }
+
+    [Test]
+    public void CheckForIdempotencyHeadersSupport()
+    {
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").WithParam("foo", "bar").UsingGet())
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        var request = _rawClient.CreateHttpRequest(
+            new JsonRequest()
+            {
+                BaseUrl = _baseUrl,
+                Method = HttpMethod.Get,
+                Path = "/test",
+                Query = new Dictionary<string, object>(),
+                Options = new IdempotentRequestOptions { IdempotencyKey = "1234567890" },
+            }
+        );
+
+        request.Headers.TryGetValues("IDEMPOTENCY-KEY", out var idempotencyKey);
+        Assert.That(idempotencyKey?.First(), Is.EqualTo("1234567890"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _server.Dispose();
+        _httpClient.Dispose();
+    }
+}

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
@@ -181,6 +181,11 @@ internal partial class RawClient(ClientOptions clientOptions)
         MergeHeaders(mergedHeaders, request.Headers);
         MergeHeaders(mergedHeaders, request.Options?.Headers);
 
+        if (request.Options is IIdempotentRequestOptions idempotentRequest)
+        {
+            MergeHeaders(mergedHeaders, idempotentRequest.GetIdempotencyHeaders());
+        }
+
         MergeAdditionalHeaders(mergedHeaders, request.Options?.AdditionalHeaders ?? []);
         SetHeaders(httpRequest, mergedHeaders);
         return httpRequest;


### PR DESCRIPTION
## Description
Makes a call to merge the Idempotent headers into the request when they are present

## Changes Made
- added check for idempotent headers, and when used make a call to `MergeHeaders`
- added unit test 

## Testing
- [x] Unit tests added/updated

