### PR TITLE
chore(cli): fix --runner arg

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
 - changelogEntry:
+    - summary: Improved plumbing of the --runner arg for local SDK generation.
+      type: chore
+  irVersion: 59
+  createdAt: "2025-08-11"
+  version: 0.66.01
+
+
+- changelogEntry:
     - summary: Add support for generating inferred auth in IR and expand bearer auth in Fern Definition for inference.
       type: feat
   irVersion: 59

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/DockerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/DockerExecutionEnvironment.ts
@@ -27,7 +27,8 @@ export class DockerExecutionEnvironment implements ExecutionEnvironment {
         snippetPath,
         snippetTemplatePath,
         context,
-        inspect
+        inspect,
+        runner
     }: ExecutionEnvironment.ExecuteArgs): Promise<void> {
         context.logger.info(`Executing generator ${generatorName} using Docker image: ${this.dockerImage}`);
 
@@ -59,7 +60,7 @@ export class DockerExecutionEnvironment implements ExecutionEnvironment {
             envVars,
             ports,
             removeAfterCompletion: !this.keepDocker,
-            runner: undefined
+            runner
         });
     }
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ExecutionEnvironment.ts
@@ -1,3 +1,4 @@
+import { ContainerRunner } from "@fern-api/core-utils/src/types";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 
@@ -11,6 +12,7 @@ export declare namespace ExecutionEnvironment {
         snippetTemplatePath?: AbsoluteFilePath;
         context: TaskContext;
         inspect: boolean;
+        runner: ContainerRunner | undefined;
     }
 }
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
@@ -220,7 +220,8 @@ export class GenerationRunner {
             includeOptionalRequestPropertyExamples: true,
             inspect,
             executionEnvironment: this.executionEnvironment,
-            ir: rawIr
+            ir: rawIr,
+            runner: undefined
         });
 
         return { ir, generatorConfig };

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -27,6 +27,7 @@ import { ExecutionEnvironment } from "./ExecutionEnvironment";
 import { DockerExecutionEnvironment } from "./DockerExecutionEnvironment";
 import { GeneratorConfig } from "@fern-fern/generator-exec-sdk/serialization";
 import { join } from "path";
+import { ContainerRunner } from "@fern-api/core-utils/src/types";
 
 export interface GeneratorRunResponse {
     ir: IntermediateRepresentation;
@@ -56,6 +57,7 @@ export async function writeFilesToDiskAndRunGenerator({
     includeOptionalRequestPropertyExamples,
     inspect,
     executionEnvironment,
+    runner,
     ir
 }: {
     organization: string;
@@ -78,6 +80,7 @@ export async function writeFilesToDiskAndRunGenerator({
     includeOptionalRequestPropertyExamples: boolean;
     inspect: boolean;
     executionEnvironment?: ExecutionEnvironment;
+    runner: ContainerRunner | undefined;
     ir: IntermediateRepresentation;
 }): Promise<{ ir: IntermediateRepresentation; generatorConfig: FernGeneratorExec.GeneratorConfig }> {
     const { latest, migrated } = await getIntermediateRepresentation({
@@ -178,7 +181,8 @@ export async function writeFilesToDiskAndRunGenerator({
         snippetPath: absolutePathToTmpSnippetJSON,
         snippetTemplatePath: absolutePathToTmpSnippetTemplatesJSON,
         context,
-        inspect
+        inspect,
+        runner
     });
 
     const taskHandler = new LocalTaskHandler({

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -153,7 +153,8 @@ export async function runLocalGenerationForWorkspace({
                     includeOptionalRequestPropertyExamples: false,
                     inspect,
                     executionEnvironment: undefined, // This should use the Docker fallback with proper image name
-                    ir: intermediateRepresentation
+                    ir: intermediateRepresentation,
+                    runner
                 });
 
                 interactiveTaskContext.logger.info(chalk.green("Wrote files to " + absolutePathToLocalOutput));


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
The `--runner` argument given the the command line would not properly propagate the runner all the way to the docker environment, running a docker container for generation regardless of this specification. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Fixed the plumbing of `runner` all the way to the `DockerExecutionEnvironment` 

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed

