### PR TITLE
fix(cli): Add "vendor" to set of reserved keywords for go generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- changelogEntry:
+    - summary: Add 'vendor' to set of reservved keywords for go.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-08-11"
+  version: 0.66.1
 
 - changelogEntry:
     - summary: Add support for generating inferred auth in IR and expand bearer auth in Fern Definition for inference.

--- a/packages/commons/casings-generator/src/reserved.ts
+++ b/packages/commons/casings-generator/src/reserved.ts
@@ -269,6 +269,7 @@ export const RESERVED_KEYWORDS: Record<generatorsYml.GenerationLanguage, Set<str
         "switch",
         "type",
         "var",
+        "vendor",
         // Technically allowed as identifiers, but should be avoided.
         "any",
         "bool",


### PR DESCRIPTION
## Description
If an api spec had a package called "vendor" it was colliding with go's reserved vendor folder used for dependencies.
This fixes that by modifying the folder name for the api and references to it.

## Changes Made
- Add "vendor" to set of reserved keywords for go generation

## Testing
- [x] Manual testing completed