### PR TITLE
fix(internal): specify earliest Swift generator version for IR v58

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Specify the earliest Swift generator version for IR v58.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-08-13"
+  version: 0.66.14
+
+- changelogEntry:
     - summary: Upload dynamic IR JSON instead of upload URL.
       type: fix
   irVersion: 59

--- a/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
@@ -39,7 +39,7 @@ export const V58_TO_V57_MIGRATION: IrMigration<
         [GeneratorName.CSHARP_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.CSHARP_SDK]: "1.17.5",
         [GeneratorName.SWIFT_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
-        [GeneratorName.SWIFT_SDK]: GeneratorWasNeverUpdatedToConsumeNewIR,
+        [GeneratorName.SWIFT_SDK]: "0.1.0",
         [GeneratorName.PHP_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.PHP_SDK]: "1.15.1",
         [GeneratorName.RUST_MODEL]: GeneratorWasNotCreatedYet,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixes the reverse migrations to specify IR version used by the generator.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Changes earliest generator version `migrateFromV58ToV57.ts`

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

