### PR TITLE
fix(internal): specify generator metadata for swift

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Specify generator metadata for Swift.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-08-13"
+  version: 0.66.15
+  
+- changelogEntry:
     - summary: Specify the earliest Swift generator version for IR v58.
       type: fix
   irVersion: 59

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
@@ -114,6 +114,12 @@ function getGeneratorMetadataFromName(generatorName: string, context?: TaskConte
         case "fern-rust-model":
             return "rust-model";
 
+        // Swift
+        case "fern-swift-sdk":
+            return "swift-sdk";
+        case "fern-swift-model":
+            return "swift-model";
+
         default: {
             context?.logger.warn(`Unrecognized generator name found, attempting to parse manually: ${generatorName}`);
             if (generatorName.startsWith("fern-")) {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Adjusts the `getGeneratorMetadataFromName` function to specify the metadata for the Swift generator.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `getGeneratorVersions.ts` file

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

