### PR TITLE
chore(rust): bump generator CLI SDK version for consistency across generators

### DIFF
--- a/generators/base/package.json
+++ b/generators/base/package.json
@@ -39,7 +39,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",
     "tmp-promise": "^3.0.3"

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -49,7 +49,7 @@
     "@fern-api/fern-csharp-model": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@types/lodash-es": "^4.17.12",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -49,7 +49,7 @@
     "@fern-api/go-base": "workspace:*",
     "@fern-api/go-dynamic-snippets": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@types/node": "18.15.3",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -49,7 +49,7 @@
     "@fern-api/java-base": "workspace:*",
     "@fern-api/java-dynamic-snippets": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.30",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@types/lodash-es": "^4.17.12",

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -49,7 +49,7 @@
     "@fern-api/php-codegen": "workspace:*",
     "@fern-api/php-dynamic-snippets": "workspace:*",
     "@fern-api/php-model": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "^58.2.0",
     "@types/lodash-es": "^4.17.12",

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -44,7 +44,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/python-base": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "58.2.0",
     "@types/node": "18.15.3",

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.4
+  createdAt: "2025-08-13"
+  changelogEntry:
+    - type: fix
+      summary: Updated generator CLI SDK version to 0.0.33 for consistency.
+  irVersion: 58
+
 - version: 0.0.3
   createdAt: "2025-08-13"
   changelogEntry:

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -38,7 +38,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
-    "@fern-fern/generator-cli-sdk": "0.0.28",
+    "@fern-fern/generator-cli-sdk": "0.0.33",
     "@fern-fern/generator-exec-sdk": "^0.0.1045",
     "@fern-fern/ir-sdk": "59.0.0",
     "@fern-fern/snippet-sdk": "^0.0.6434",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/logging-execa
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.33
+        version: 0.0.33
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -411,8 +411,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cli/logger
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.33
+        version: 0.0.33
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045
@@ -667,8 +667,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cli/logger
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.33
+        version: 0.0.33
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045
@@ -833,8 +833,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cli/logger
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.30
-        version: 0.0.30
+        specifier: 0.0.33
+        version: 0.0.33
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045
@@ -1113,8 +1113,8 @@ importers:
         specifier: workspace:*
         version: link:../model
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.33
+        version: 0.0.33
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045
@@ -1447,8 +1447,8 @@ importers:
         specifier: workspace:*
         version: link:../base
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.33
+        version: 0.0.33
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045
@@ -3363,8 +3363,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/ast
       '@fern-fern/generator-cli-sdk':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.33
+        version: 0.0.33
       '@fern-fern/generator-exec-sdk':
         specifier: ^0.0.1045
         version: 0.0.1045
@@ -9320,12 +9320,6 @@ packages:
 
   '@fern-fern/fiddle-sdk@0.0.584':
     resolution: {integrity: sha512-92z/Pwo7EDV7PCLwNdxtZiTQpaUpbeXCqKWSLUQwTwFAQEAp+8QKYAA6VJXVQtHLrZg0NqPTXEnE5XF8NbluYA==}
-
-  '@fern-fern/generator-cli-sdk@0.0.28':
-    resolution: {integrity: sha512-KNf9vBkFAV8oEmD/U4ss75d3JIm50fpa+Pq5cVs0fr/e8m1xWVuG189gzfQ9wrkH3Z85B2U/Pxl3cb7KPB4qrw==}
-
-  '@fern-fern/generator-cli-sdk@0.0.30':
-    resolution: {integrity: sha512-H5BFDqMuBRpDSi0qivVStYHCXxRp369Y8Z7xuQsXFu+tmvIFeqXMyLy/viT1pSu0ZN7UR9rbxkdJIQmbRL0T9w==}
 
   '@fern-fern/generator-cli-sdk@0.0.33':
     resolution: {integrity: sha512-p//8tny/ft5r7t3HMm+bxkqa/vW5/DxKKcWXvbBT+nqfDqAw7lHINBl+9Vo4IjwXW7NUHuO12sYN9vMhjSX/FQ==}
@@ -16461,26 +16455,6 @@ snapshots:
       node-fetch: 2.7.0
       qs: 6.11.2
       url-join: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-
-  '@fern-fern/generator-cli-sdk@0.0.28':
-    dependencies:
-      form-data: 4.0.1
-      formdata-node: 6.0.3
-      node-fetch: 2.7.0
-      qs: 6.14.0
-      readable-stream: 4.7.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@fern-fern/generator-cli-sdk@0.0.30':
-    dependencies:
-      form-data: 4.0.1
-      formdata-node: 6.0.3
-      node-fetch: 2.7.0
-      qs: 6.14.0
-      readable-stream: 4.7.0
     transitivePeerDependencies:
       - encoding
 


### PR DESCRIPTION
## Description

This PR fixes version inconsistencies across generator CLI SDK dependencies by updating the Java v2 SDK generator to use the latest version of `@fern-fern/generator-cli-sdk` (0.0.33) for consistency with other generators.

## Changes Made
 
- Updated `@fern-fern/generator-cli-sdk` from version 0.0.28 to 0.0.33 in all SDK generator
- Updated Rust SDK generator versions.yml to document the CLI version consistency fix
- Ensured all generators now use consistent generator CLI SDK version (0.0.33)
  

## Testing

 - [x] Manual testing completed