### PR TITLE
chore(rust): enable git and git config for docker rust sdk generator

### DIFF
--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22.12-alpine3.20
 
+RUN apk --no-cache add bash curl git zip
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
+
 COPY generators/rust/sdk/dist /dist
 COPY generators/rust/sdk/dist/asIs /asIs
 COPY generators/rust/sdk/features.yml /assets/features.yml

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.5
+  createdAt: "2025-08-13"
+  changelogEntry:
+    - type: chore
+      summary: enable git and git config
+  irVersion: 58
+
 - version: 0.0.4
   createdAt: "2025-08-13"
   changelogEntry:


### PR DESCRIPTION
## Description

Enable git and git config for Docker Rust SDK generator

## Changes Made

- command for installing git
- command for config git.



