### PR TITLE
chore(lint): Address linter warnings

### DIFF
--- a/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
+++ b/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
@@ -273,7 +273,6 @@ export abstract class AbstractGoGeneratorContext<
 
     public maybeUnwrapIterable(typeReference: TypeReference): TypeReference | undefined {
         switch (typeReference.type) {
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "container": {
                 const container = typeReference.container;
                 switch (container.type) {
@@ -293,7 +292,6 @@ export abstract class AbstractGoGeneratorContext<
                 }
                 break;
             }
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "named": {
                 const typeDeclaration = this.getTypeDeclarationOrThrow(typeReference.typeId).shape;
                 switch (typeDeclaration.type) {
@@ -319,7 +317,6 @@ export abstract class AbstractGoGeneratorContext<
 
     public maybeUnwrapOptionalOrNullable(typeReference: TypeReference): TypeReference | undefined {
         switch (typeReference.type) {
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "container": {
                 const container = typeReference.container;
                 switch (container.type) {
@@ -355,7 +352,6 @@ export abstract class AbstractGoGeneratorContext<
      */
     public needsOptionalDereference(typeReference: TypeReference): boolean {
         switch (typeReference.type) {
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "named": {
                 const typeDeclaration = this.getTypeDeclarationOrThrow(typeReference.typeId).shape;
                 switch (typeDeclaration.type) {
@@ -372,7 +368,6 @@ export abstract class AbstractGoGeneratorContext<
                 }
                 break;
             }
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "container": {
                 const containerType = typeReference.container;
                 switch (containerType.type) {
@@ -549,7 +544,6 @@ export abstract class AbstractGoGeneratorContext<
 
     public maybeEnum(typeReference: TypeReference): EnumTypeDeclaration | undefined {
         switch (typeReference.type) {
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "named": {
                 const declaration = this.getTypeDeclarationOrThrow(typeReference.typeId);
                 switch (declaration.shape.type) {
@@ -566,7 +560,6 @@ export abstract class AbstractGoGeneratorContext<
                 }
                 break;
             }
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "container": {
                 const container = typeReference.container;
                 switch (container.type) {
@@ -594,7 +587,6 @@ export abstract class AbstractGoGeneratorContext<
 
     public maybePrimitive(typeReference: TypeReference): PrimitiveTypeV1 | undefined {
         switch (typeReference.type) {
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: allow fall through
             case "container": {
                 const container = typeReference.container;
                 switch (container.type) {

--- a/generators/rust/model/src/__test__/util/createSampleGeneratorContext.ts
+++ b/generators/rust/model/src/__test__/util/createSampleGeneratorContext.ts
@@ -20,7 +20,7 @@ export async function createSampleGeneratorContext(testDefinitionName: string): 
         type: "local",
         _visit: (visitor) => visitor.local()
     });
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    // biome-ignore lint/suspicious/noExplicitAny: allow
     return new ModelGeneratorContext(ir as any, generatorConfig, customConfig, notificationService);
 }
 

--- a/generators/rust/model/src/__test__/util/createSampleGeneratorContext.ts
+++ b/generators/rust/model/src/__test__/util/createSampleGeneratorContext.ts
@@ -20,7 +20,7 @@ export async function createSampleGeneratorContext(testDefinitionName: string): 
         type: "local",
         _visit: (visitor) => visitor.local()
     });
-    // biome-ignore lint/suspicious/noExplicitAny: allow
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     return new ModelGeneratorContext(ir as any, generatorConfig, customConfig, notificationService);
 }
 

--- a/generators/swift/model/src/object/__test__/util/createSampleGeneratorContext.ts
+++ b/generators/swift/model/src/object/__test__/util/createSampleGeneratorContext.ts
@@ -16,7 +16,7 @@ export async function createSampleGeneratorContext(testDefinitionName: string): 
         type: "local",
         _visit: (visitor) => visitor.local()
     });
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    // biome-ignore lint/suspicious/noExplicitAny: allow
     return new ModelGeneratorContext(ir as any, generatorConfig, customConfig, notificationService);
 }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:update": "turbo test:update --filter=!@fern-api/ete-tests",
     "test:ete": "pnpm --filter @fern-api/cli dist:cli:dev && pnpm --filter @fern-api/seed-cli dist:cli && pnpm --filter @fern-api/ete-tests test",
     "test:ete:update": "pnpm --filter @fern-api/cli dist:cli:dev && pnpm --filter @fern-api/seed-cli dist:cli && pnpm --filter @fern-api/ete-tests test -- -u",
-    "lint:biome": "biome lint",
+    "lint:biome": "biome lint --error-on-warnings",
     "lint:style": "stylelint 'packages/**/src/**/*.scss' --allow-empty-input --max-warnings 0",
     "lint:style:fix": "pnpm lint:style --fix",
     "lint:spelling": "cspell **",

--- a/packages/cli/ete-tests/src/tests/ir/ir.test.ts
+++ b/packages/cli/ete-tests/src/tests/ir/ir.test.ts
@@ -105,6 +105,7 @@ describe("ir", () => {
 });
 
 describe("ir from proto", () => {
+    // biome-ignore lint/suspicious/noSkippedTests: Allow test skip for now
     it.skip("works with proto-ir", async () => {
         try {
             await runFernCli(["ir", "ir.json", "--from-openapi"], {
@@ -121,7 +122,7 @@ describe("ir from proto", () => {
             throw error;
         }
     }, 10_000);
-
+    // biome-ignore lint/suspicious/noSkippedTests: Allow test skip for now
     it.skip("ir from proto through oas", async () => {
         try {
             await runFernCli(["ir", "ir.json", "--from-openapi"], {


### PR DESCRIPTION
## Description
Linter was returning a number of warnings, these should be addressed.

## Changes Made
- Remove un-needed ignores
- Fix invalid ignore explanation
- Ignore test skipping
- Make CI fail on warning (TODO)

## Testing
Tested locally and in CI.
- Now will fail on warnings: https://github.com/fern-api/fern/actions/runs/16963805940/job/48082663708?pr=8744
- Warnings fully resolved: https://github.com/fern-api/fern/actions/runs/16963847894/job/48082797340?pr=8744
