### PR TITLE
feat(swift): add `fileDownload` support

### DIFF
--- a/generators/swift/.vscode/settings.json
+++ b/generators/swift/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - version: 0.5.0
-  createdAt: "2025-08-14"
+  createdAt: "2025-08-15"
   changelogEntry:
     - type: feat
       summary: |

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.5.0
+  createdAt: "2025-08-14"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Added 'fileDownload' response support.
+  irVersion: 58
+
 - version: 0.4.1
   createdAt: "2025-08-14"
   changelogEntry:

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/bytes-upload/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Resources/Service/ServiceClient.swift
@@ -8,10 +8,11 @@ public final class ServiceClient: Sendable {
     }
 
     public func upload(request: Data, requestOptions: RequestOptions? = nil) async throws -> Void {
-        return try await httpClient.performFileUpload(
+        return try await httpClient.performRequest(
             method: .post,
             path: "/upload-content",
-            fileData: request,
+            contentType: .applicationOctetStream,
+            body: request,
             requestOptions: requestOptions
         )
     }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/client-side-params/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/file-download/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Resources/Service/ServiceClient.swift
@@ -15,12 +15,12 @@ public final class ServiceClient: Sendable {
         )
     }
 
-    public func downloadFile(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func downloadFile(requestOptions: RequestOptions? = nil) async throws -> Data {
         return try await httpClient.performRequest(
             method: .post,
             path: "/",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: Data.self
         )
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/multiple-request-bodies/Package.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "Api",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "Api",
+            targets: ["Api"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Api",
+            path: "Sources"
+        )
+    ]
+)

--- a/seed/swift-sdk/multiple-request-bodies/Sources/ApiClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/ApiClient.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
+public final class ApiClient: Sendable {
+    private let httpClient: HTTPClient
+
+    /// Initialize the client with the specified configuration and a static bearer token.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
+    public convenience init(
+        baseURL: String = ApiEnvironment.default.rawValue,
+        token: String,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        self.init(
+            baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: .init(token: token),
+            basicAuth: nil,
+            headers: headers,
+            timeout: timeout,
+            maxRetries: maxRetries,
+            urlSession: urlSession
+        )
+    }
+
+    /// Initialize the client with the specified configuration and an async bearer token provider.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter token: An async function that returns the bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
+    public convenience init(
+        baseURL: String = ApiEnvironment.default.rawValue,
+        token: ClientConfig.CredentialProvider,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        self.init(
+            baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: .init(token: token),
+            basicAuth: nil,
+            headers: headers,
+            timeout: timeout,
+            maxRetries: maxRetries,
+            urlSession: urlSession
+        )
+    }
+
+    init(
+        baseURL: String,
+        headerAuth: ClientConfig.HeaderAuth? = nil,
+        bearerAuth: ClientConfig.BearerAuth? = nil,
+        basicAuth: ClientConfig.BasicAuth? = nil,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        let config = ClientConfig(
+            baseURL: baseURL,
+            headerAuth: headerAuth,
+            bearerAuth: bearerAuth,
+            basicAuth: basicAuth,
+            headers: headers,
+            timeout: timeout,
+            maxRetries: maxRetries,
+            urlSession: urlSession
+        )
+        self.httpClient = HTTPClient(config: config)
+    }
+
+    public func uploadJsonDocument(request: UploadDocumentRequest, requestOptions: RequestOptions? = nil) async throws -> UploadDocumentResponse {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/documents/upload",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: UploadDocumentResponse.self
+        )
+    }
+
+    public func uploadPdfDocument(request: Data, requestOptions: RequestOptions? = nil) async throws -> UploadDocumentResponse {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/documents/upload",
+            contentType: .applicationOctetStream,
+            body: request,
+            requestOptions: requestOptions,
+            responseType: UploadDocumentResponse.self
+        )
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/ApiEnvironment.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/ApiEnvironment.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum ApiEnvironment: String, CaseIterable {
+    case `default` = "https://api.example.com/v1"
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTP.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct HTTP {
+    enum Method: String, CaseIterable {
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case delete = "DELETE"
+        case patch = "PATCH"
+        case head = "HEAD"
+    }
+
+    enum ContentType: String, CaseIterable {
+        case applicationJson = "application/json"
+        case applicationOctetStream = "application/octet-stream"
+    }
+
+    enum RequestBody {
+        case jsonEncodable(any Encodable)
+        case data(Data)
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+final class HTTPClient: Sendable {
+    private let clientConfig: ClientConfig
+    private let jsonEncoder = Serde.jsonEncoder
+    private let jsonDecoder = Serde.jsonDecoder
+
+    init(config: ClientConfig) {
+        self.clientConfig = config
+    }
+
+    /// Performs a request with no response.
+    func performRequest(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil
+    ) async throws {
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
+
+        let request = try await buildRequest(
+            method: method,
+            path: path,
+            requestContentType: requestContentType,
+            requestHeaders: requestHeaders,
+            requestQueryParams: requestQueryParams,
+            requestBody: requestBody,
+            requestOptions: requestOptions
+        )
+
+        let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+
+        do {
+            return try jsonDecoder.decode(responseType, from: data)
+        } catch {
+            throw ClientError.decodingError(error)
+        }
+    }
+
+    private func buildRequest(
+        method: HTTP.Method,
+        path: String,
+        requestContentType: HTTP.ContentType,
+        requestHeaders: [String: String],
+        requestQueryParams: [String: QueryParameter?],
+        requestBody: HTTP.RequestBody? = nil,
+        requestOptions: RequestOptions? = nil
+    ) async throws -> URLRequest {
+        // Init with URL
+        let url = buildRequestURL(
+            path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
+        )
+        var request = URLRequest(url: url)
+
+        // Set timeout
+        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
+        if let timeout = requestOptions?.timeout {
+            request.timeoutInterval = TimeInterval(timeout)
+        }
+
+        // Set method
+        request.httpMethod = method.rawValue
+
+        // Set headers
+        let headers = try await buildRequestHeaders(
+            requestContentType: requestContentType,
+            requestHeaders: requestHeaders,
+            requestOptions: requestOptions
+        )
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        // Set body
+        if let requestBody = requestBody {
+            request.httpBody = buildRequestBody(
+                requestBody: requestBody,
+                requestOptions: requestOptions
+            )
+        }
+
+        return request
+    }
+
+    private func buildRequestURL(
+        path: String,
+        requestQueryParams: [String: QueryParameter?],
+        requestOptions: RequestOptions? = nil
+    ) -> URL {
+        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
+        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+            precondition(
+                false,
+                "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
+            )
+        }
+        if !requestQueryParams.isEmpty {
+            components.queryItems = requestQueryParams.map { key, value in
+                URLQueryItem(name: key, value: value?.toString())
+            }
+        }
+        if let additionalQueryParams = requestOptions?.additionalQueryParameters {
+            components.queryItems?.append(
+                contentsOf: additionalQueryParams.map { key, value in
+                    URLQueryItem(name: key, value: value)
+                })
+        }
+        guard let url = components.url else {
+            precondition(
+                false,
+                "Failed to construct URL from components - this indicates an unexpected error in the SDK."
+            )
+        }
+        return url
+    }
+
+    private func buildRequestHeaders(
+        requestContentType: HTTP.ContentType,
+        requestHeaders: [String: String],
+        requestOptions: RequestOptions? = nil
+    ) async throws -> [String: String] {
+        var headers = clientConfig.headers ?? [:]
+        headers["Content-Type"] = requestContentType.rawValue
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
+        }
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
+        }
+        if let bearerAuthToken = try await getBearerAuthToken(requestOptions) {
+            headers["Authorization"] = "Bearer \(bearerAuthToken)"
+        }
+        for (key, value) in requestHeaders {
+            headers[key] = value
+        }
+        for (key, value) in requestOptions?.additionalHeaders ?? [:] {
+            headers[key] = value
+        }
+        return headers
+    }
+
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+        if let tokenString = requestOptions?.token {
+            return tokenString
+        }
+        if let bearerAuth = clientConfig.bearerAuth {
+            return try await bearerAuth.token.retrieve()
+        }
+        return nil
+    }
+
+    private func buildRequestBody(
+        requestBody: HTTP.RequestBody,
+        requestOptions: RequestOptions? = nil
+    ) -> Data {
+        switch requestBody {
+        case .jsonEncodable(let encodableBody):
+            do {
+                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
+                return try jsonEncoder.encode(encodableBody)
+            } catch {
+                precondition(
+                    false,
+                    "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
+                )
+            }
+        case .data(let dataBody):
+            return dataBody
+        }
+    }
+
+    private func executeRequestWithURLSession(
+        _ request: URLRequest
+    ) async throws -> (Data, String?) {
+        do {
+            // TODO(kafkas): Handle retries
+            let (data, response) = try await clientConfig.urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw ClientError.invalidResponse
+            }
+
+            // Handle successful responses
+            if 200...299 ~= httpResponse.statusCode {
+                let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+                return (data, contentType)
+            }
+
+            // Handle error responses
+            try handleErrorResponse(
+                statusCode: httpResponse.statusCode,
+                data: data
+            )
+
+            // This should never be reached, but satisfy the compiler
+            let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+            return (data, contentType)
+
+        } catch {
+            if error is ClientError {
+                throw error
+            } else {
+                throw ClientError.networkError(error)
+            }
+        }
+    }
+
+    private func handleErrorResponse(statusCode: Int, data: Data) throws {
+        let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
+
+        switch statusCode {
+        case 400:
+            throw ClientError.badRequest(errorResponse)
+        case 401:
+            throw ClientError.unauthorized(errorResponse)
+        case 403:
+            throw ClientError.forbidden(errorResponse)
+        case 404:
+            throw ClientError.notFound(errorResponse)
+        case 422:
+            throw ClientError.validationError(errorResponse)
+        case 500...599:
+            throw ClientError.serverError(errorResponse)
+        default:
+            throw ClientError.httpError(statusCode: statusCode, response: errorResponse)
+        }
+    }
+
+    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+        // Try to parse as JSON error response first
+        if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
+            return errorResponse
+        }
+
+        // Try to parse as simple JSON with message field
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let message = json["message"] as? String
+        {
+            return APIErrorResponse(code: statusCode, message: message)
+        }
+
+        // Try to parse as plain text
+        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+            return APIErrorResponse(code: statusCode, message: errorMessage)
+        }
+
+        return nil
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/QueryParameter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum QueryParameter {
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case uint(UInt)
+    case uint64(UInt64)
+    case int64(Int64)
+    case float(Float)
+    case double(Double)
+    case date(Date)
+    case stringArray([String])
+    case uuid(UUID)
+    case unknown(Any)
+
+    func toString() -> String {
+        switch self {
+        case .string(let value):
+            return value
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .int(let value):
+            return String(value)
+        case .uint(let value):
+            return String(value)
+        case .uint64(let value):
+            return String(value)
+        case .int64(let value):
+            return String(value)
+        case .float(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        case .date(let value):
+            return value.ISO8601Format()
+        case .stringArray(let values):
+            return values.joined(separator: ",")
+        case .uuid(let value):
+            return value.uuidString
+        case .unknown:
+            return ""
+        }
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension Decoder {
+    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+        using codingKeysType: C.Type
+    ) throws
+        -> [String: T] where C.RawValue == String
+    {
+        return try decodeAdditionalProperties(
+            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+    }
+
+    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
+        T]
+    {
+        let container = try container(keyedBy: StringKey.self)
+        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        guard !unknownKeys.isEmpty else { return .init() }
+        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+            (key.stringValue, try container.decode(T.self, forKey: key))
+        }
+        return .init(uniqueKeysWithValues: keyValuePairs)
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Encoder {
+    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+        guard !additionalProperties.isEmpty else { return }
+        var container = self.container(keyedBy: StringKey.self)
+        for (key, value) in additionalProperties {
+            try container.encode(value, forKey: .init(key))
+        }
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Serde.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class Serde {
+    static var jsonEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static var jsonDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+            if let date = formatter.date(from: dateString) {
+                return date
+            }
+
+            // Fallback for dates without fractional seconds
+            formatter.formatOptions = [.withInternetDateTime]
+            if let date = formatter.date(from: dateString) {
+                return date
+            }
+
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "Invalid date format: \(dateString)")
+        }
+        return decoder
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/StringKey.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct StringKey: CodingKey, Hashable {
+    var stringValue: String
+    var intValue: Int? { Int(stringValue) }
+
+    init(_ string: String) {
+        self.stringValue = string
+    }
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = String(intValue)
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/String+URLEncoding.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    func urlPathEncoded() -> String {
+        return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
+    }
+
+    func urlQueryEncoded() -> String {
+        return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/APIErrorResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct APIErrorResponse: Codable, Sendable {
+    public let code: Int
+    public let type: String?
+    public let message: String?
+
+    public init(code: Int, type: String? = nil, message: String? = nil) {
+        self.code = code
+        self.type = type
+        self.message = message
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientConfig.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+public final class ClientConfig: Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> String
+
+    struct Defaults {
+        static let timeout: Int = 60
+        static let maxRetries: Int = 2
+    }
+
+    struct HeaderAuth {
+        let key: String
+        let header: String
+    }
+
+    struct BearerAuth {
+        let token: Token
+
+        enum Token: Sendable {
+            case staticToken(String)
+            case provider(CredentialProvider)
+
+            func retrieve() async throws -> String {
+                switch self {
+                case .staticToken(let token):
+                    return token
+                case .provider(let provider):
+                    return try await provider()
+                }
+            }
+        }
+    }
+
+    struct BasicAuth {
+        let username: String?
+        let password: String?
+
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
+        }
+    }
+
+    let baseURL: String
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
+    let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
+    let urlSession: URLSession
+
+    init(
+        baseURL: String,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        self.baseURL = baseURL
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
+        self.headers = headers
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
+    }
+}
+
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
+    return .init(configuration: configuration)
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientError.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum ClientError: Error {
+    // Network & Client Errors
+    case invalidURL
+    case encodingError(Error)
+    case decodingError(Error)
+    case invalidResponse
+    case networkError(Error)
+
+    // Generic HTTP Errors (status code based)
+    case badRequest(APIErrorResponse?)  // 400
+    case unauthorized(APIErrorResponse?)  // 401
+    case forbidden(APIErrorResponse?)  // 403
+    case notFound(APIErrorResponse?)  // 404
+    case validationError(APIErrorResponse?)  // 422
+    case serverError(APIErrorResponse?)  // 5xx
+    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .encodingError(let error):
+            return "Failed to encode request: \(error.localizedDescription)"
+        case .decodingError(let error):
+            return "Failed to decode response: \(error.localizedDescription)"
+        case .invalidResponse:
+            return "Invalid response received"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+
+        case .badRequest(let response):
+            return formatErrorMessage("Bad request", response)
+        case .unauthorized(let response):
+            return formatErrorMessage("Unauthorized", response)
+        case .forbidden(let response):
+            return formatErrorMessage("Forbidden", response)
+        case .notFound(let response):
+            return formatErrorMessage("Not found", response)
+        case .validationError(let response):
+            return formatErrorMessage("Validation error", response)
+        case .serverError(let response):
+            return formatErrorMessage("Server error", response)
+        case .httpError(let statusCode, let response):
+            return formatErrorMessage("HTTP error (\(statusCode))", response)
+        }
+    }
+
+    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
+        -> String
+    {
+        guard let response = response else {
+            return defaultMessage
+        }
+
+        var message = defaultMessage
+
+        // Use server message if available and meaningful
+        if let serverMessage = response.message, !serverMessage.isEmpty {
+            message = serverMessage
+        }
+
+        // Always include the status code
+        message += " (Code: \(response.code))"
+
+        // Include type if available
+        if let type = response.type, !type.isEmpty {
+            message += " [Type: \(type)]"
+        }
+
+        return message
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/JSONValue.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// A type that can represent any JSON value.
+public enum JSONValue: Codable, Hashable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .number(Double(int))
+        } else if let double = try? container.decode(Double.self) {
+            self = .number(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([JSONValue].self) {
+            self = .array(array)
+        } else if let object = try? container.decode([String: JSONValue].self) {
+            self = .object(object)
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unable to decode JSONValue"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .string(let string):
+            try container.encode(string)
+        case .number(let number):
+            try container.encode(number)
+        case .bool(let bool):
+            try container.encode(bool)
+        case .null:
+            try container.encodeNil()
+        case .array(let array):
+            try container.encode(array)
+        case .object(let object):
+            try container.encode(object)
+        }
+    }
+}
+
+// MARK: - Convenience initializers
+extension JSONValue {
+    public init(_ value: String) {
+        self = .string(value)
+    }
+
+    public init(_ value: Int) {
+        self = .number(Double(value))
+    }
+
+    public init(_ value: Double) {
+        self = .number(value)
+    }
+
+    public init(_ value: Bool) {
+        self = .bool(value)
+    }
+
+    public init(_ value: [JSONValue]) {
+        self = .array(value)
+    }
+
+    public init(_ value: [String: JSONValue]) {
+        self = .object(value)
+    }
+}
+
+// MARK: - Value extraction
+extension JSONValue {
+    public var stringValue: String? {
+        if case .string(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var numberValue: Double? {
+        if case .number(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var intValue: Int? {
+        if case .number(let value) = self {
+            return Int(value)
+        }
+        return nil
+    }
+
+    public var boolValue: Bool? {
+        if case .bool(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var arrayValue: [JSONValue]? {
+        if case .array(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var objectValue: [String: JSONValue]? {
+        if case .object(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var isNull: Bool {
+        if case .null = self {
+            return true
+        }
+        return false
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/RequestOptions.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Options for customizing an individual API request.
+///
+/// Use this struct to override or supplement client-wide configuration for a single request.
+public struct RequestOptions {
+    /// The API key to use for this request, overriding the client-wide API key if provided.
+    let apiKey: String?
+
+    /// The token to use for this request, overriding the client-wide token if provided.
+    let token: String?
+
+    /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
+    let timeout: Int?
+
+    /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
+    let maxRetries: Int?
+
+    /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
+    let additionalHeaders: [String: String]?
+
+    /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
+    let additionalQueryParameters: [String: String]?
+
+    // TODO(kafkas): Omit for file uploads
+    /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
+    let additionalBodyParameters: [String: String]?
+
+    public init(
+        apiKey: String? = nil,
+        token: String? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        additionalHeaders: [String: String]? = nil,
+        additionalQueryParameters: [String: String]? = nil,
+        additionalBodyParameters: [String: String]? = nil
+    ) {
+        self.apiKey = apiKey
+        self.token = token
+        self.timeout = timeout
+        self.maxRetries = maxRetries
+        self.additionalHeaders = additionalHeaders
+        self.additionalQueryParameters = additionalQueryParameters
+        self.additionalBodyParameters = additionalBodyParameters
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Requests/UploadDocumentRequest.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Requests/UploadDocumentRequest.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct UploadDocumentRequest: Codable, Hashable, Sendable {
+    public let author: String?
+    public let tags: [String]?
+    public let title: String?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        author: String? = nil,
+        tags: [String]? = nil,
+        title: String? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.author = author
+        self.tags = tags
+        self.title = title
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.author = try container.decodeIfPresent(String.self, forKey: .author)
+        self.tags = try container.decodeIfPresent([String].self, forKey: .tags)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.author, forKey: .author)
+        try container.encodeIfPresent(self.tags, forKey: .tags)
+        try container.encodeIfPresent(self.title, forKey: .title)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case author
+        case tags
+        case title
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Schemas/DocumentMetadata.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Schemas/DocumentMetadata.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct DocumentMetadata: Codable, Hashable, Sendable {
+    public let author: String?
+    public let id: Int?
+    public let tags: [JSONValue]?
+    public let title: String?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        author: String? = nil,
+        id: Int? = nil,
+        tags: [JSONValue]? = nil,
+        title: String? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.author = author
+        self.id = id
+        self.tags = tags
+        self.title = title
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.author = try container.decodeIfPresent(String.self, forKey: .author)
+        self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+        self.tags = try container.decodeIfPresent([JSONValue].self, forKey: .tags)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.author, forKey: .author)
+        try container.encodeIfPresent(self.id, forKey: .id)
+        try container.encodeIfPresent(self.tags, forKey: .tags)
+        try container.encodeIfPresent(self.title, forKey: .title)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case author
+        case id
+        case tags
+        case title
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Schemas/DocumentUploadResult.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Schemas/DocumentUploadResult.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public struct DocumentUploadResult: Codable, Hashable, Sendable {
+    public let fileId: String?
+    public let status: String?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        fileId: String? = nil,
+        status: String? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.fileId = fileId
+        self.status = status
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.fileId = try container.decodeIfPresent(String.self, forKey: .fileId)
+        self.status = try container.decodeIfPresent(String.self, forKey: .status)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.fileId, forKey: .fileId)
+        try container.encodeIfPresent(self.status, forKey: .status)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case fileId
+        case status
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Schemas/UploadDocumentResponse.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Schemas/UploadDocumentResponse.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum UploadDocumentResponse: Codable, Hashable, Sendable {
+    case documentMetadata(DocumentMetadata)
+    case documentUploadResult(DocumentUploadResult)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(DocumentMetadata.self) {
+            self = .documentMetadata(value)
+        } else if let value = try? container.decode(DocumentUploadResult.self) {
+            self = .documentUploadResult(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unexpected value."
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .documentMetadata(let value):
+            try container.encode(value)
+        case .documentUploadResult(let value):
+            try container.encode(value)
+        }
+    }
+}

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/public-object/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Resources/Service/ServiceClient.swift
@@ -7,12 +7,12 @@ public final class ServiceClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func get(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func get(requestOptions: RequestOptions? = nil) async throws -> Data {
         return try await httpClient.performRequest(
             method: .get,
             path: "/helloworld.txt",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: Data.self
         )
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -9,90 +9,74 @@ final class HTTPClient: Sendable {
         self.clientConfig = config
     }
 
-    func performRequest<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        body requestBody: (any Encodable)? = nil,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
-
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationJson,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: requestBody,
-            requestOptions: requestOptions
-        )
-
-        let (data, contentType) = try await executeRequestWithURLSession(request)
-
-        if T.self == String.self {
-            do {
-                return try jsonDecoder.decode(responseType, from: data)
-            } catch {
-                if contentType?.lowercased().contains("text") == true,
-                    let string = String(data: data, encoding: .utf8) as? T
-                {
-                    return string
-                }
-                throw ClientError.decodingError(error)
-            }
-        }
-
-        do {
-            return try jsonDecoder.decode(responseType, from: data)
-        } catch {
-            throw ClientError.decodingError(error)
-        }
-    }
-
+    /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
         path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
         headers requestHeaders: [String: String] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
-        let requestBody: HTTP.RequestBody? = requestBody.map { .jsonEncodable($0) }
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
 
         let request = try await buildRequest(
             method: method,
             path: path,
-            requestContentType: .applicationJson,
+            requestContentType: requestContentType,
             requestHeaders: requestHeaders,
             requestQueryParams: requestQueryParams,
             requestBody: requestBody,
             requestOptions: requestOptions
         )
-        _ = try await executeRequestWithURLSession(request)
-    }
 
-    func performFileUpload<T: Decodable>(
-        method: HTTP.Method,
-        path: String,
-        headers requestHeaders: [String: String] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
-        fileData: Data,
-        requestOptions: RequestOptions? = nil,
-        responseType: T.Type
-    ) async throws -> T {
-        let request = try await buildRequest(
-            method: method,
-            path: path,
-            requestContentType: .applicationOctetStream,
-            requestHeaders: requestHeaders,
-            requestQueryParams: requestQueryParams,
-            requestBody: .data(fileData),
-            requestOptions: requestOptions
-        )
         let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
 
         do {
             return try jsonDecoder.decode(responseType, from: data)


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
This PR adds support for `fileDownload` responses and simplifies request handling in HTTPClient.swift. The `performFileUpload` method has been removed. All request types are now handled by the unified `performRequest` method. The previous implementation contained some redundant logic that was not generator-friendly.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated the `HTTPClient` "as is" file to implement the new `performRequest` method
- Updated `EndpointMethodGenerator` to align with the new `HTTPClient` interface
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

