### PR TITLE
fix(swift): disambiguate designated initializer calls without auth schemes

### DIFF
--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -137,10 +137,7 @@ export class RootClientGenerator {
             swift.functionArgument({
                 label: "baseURL",
                 value: swift.Expression.reference("baseURL")
-            })
-        ];
-
-        designatedInitializerArgs.push(
+            }),
             swift.functionArgument({
                 label: "headerAuth",
                 value: authSchemes.header
@@ -178,10 +175,7 @@ export class RootClientGenerator {
                               multiline: true
                           })
                     : swift.Expression.nil()
-            })
-        );
-
-        designatedInitializerArgs.push(
+            }),
             swift.functionArgument({
                 label: "bearerAuth",
                 value: authSchemes.bearer
@@ -223,10 +217,7 @@ export class RootClientGenerator {
                               ]
                           })
                     : swift.Expression.nil()
-            })
-        );
-
-        designatedInitializerArgs.push(
+            }),
             swift.functionArgument({
                 label: "basicAuth",
                 value: authSchemes.basic
@@ -244,10 +235,7 @@ export class RootClientGenerator {
                           ]
                       })
                     : swift.Expression.nil()
-            })
-        );
-
-        designatedInitializerArgs.push(
+            }),
             swift.functionArgument({
                 label: "headers",
                 value: swift.Expression.reference("headers")
@@ -264,7 +252,7 @@ export class RootClientGenerator {
                 label: "urlSession",
                 value: swift.Expression.reference("urlSession")
             })
-        );
+        ];
 
         const getDocsSummary = () => {
             if (!authSchemes.bearer) {

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -117,7 +117,11 @@ export class RootClientGenerator {
         const authSchemes = this.getAuthSchemeParameters();
         if (authSchemes.bearer) {
             // For `bearer` auth scheme, we have one more convenience initializer for the async token provider
-            initializers.push(this.generateConvenienceInitializer({ bearerTokenParamType: "async-provider" }));
+            initializers.push(
+                this.generateConvenienceInitializer({
+                    bearerTokenParamType: "async-provider"
+                })
+            );
         }
         initializers.push(this.generateDesignatedInitializer());
         return initializers;
@@ -125,7 +129,9 @@ export class RootClientGenerator {
 
     private generateConvenienceInitializer({ bearerTokenParamType }: { bearerTokenParamType: BearerTokenParamType }) {
         const authSchemes = this.getAuthSchemeParameters();
-        const initializerParams = this.getConvenienceInitializerParams({ bearerTokenParamType });
+        const initializerParams = this.getConvenienceInitializerParams({
+            bearerTokenParamType
+        });
 
         const designatedInitializerArgs: swift.FunctionArgument[] = [
             swift.functionArgument({
@@ -134,11 +140,11 @@ export class RootClientGenerator {
             })
         ];
 
-        if (authSchemes.header) {
-            designatedInitializerArgs.push(
-                swift.functionArgument({
-                    label: "headerAuth",
-                    value: authSchemes.header.param.type.isOptional
+        designatedInitializerArgs.push(
+            swift.functionArgument({
+                label: "headerAuth",
+                value: authSchemes.header
+                    ? authSchemes.header.param.type.isOptional
                         ? swift.Expression.methodCallWithTrailingClosure({
                               target: swift.Expression.reference(authSchemes.header.param.unsafeName),
                               methodName: "map",
@@ -171,15 +177,15 @@ export class RootClientGenerator {
                               ],
                               multiline: true
                           })
-                })
-            );
-        }
+                    : swift.Expression.nil()
+            })
+        );
 
-        if (authSchemes.bearer) {
-            designatedInitializerArgs.push(
-                swift.functionArgument({
-                    label: "bearerAuth",
-                    value: authSchemes.bearer.stringParam.type.isOptional
+        designatedInitializerArgs.push(
+            swift.functionArgument({
+                label: "bearerAuth",
+                value: authSchemes.bearer
+                    ? authSchemes.bearer.stringParam.type.isOptional
                         ? swift.Expression.methodCallWithTrailingClosure({
                               target: swift.Expression.reference(authSchemes.bearer.stringParam.unsafeName),
                               methodName: "map",
@@ -216,30 +222,30 @@ export class RootClientGenerator {
                                   })
                               ]
                           })
-                })
-            );
-        }
+                    : swift.Expression.nil()
+            })
+        );
 
-        if (authSchemes.basic) {
-            designatedInitializerArgs.push(
-                swift.functionArgument({
-                    label: "basicAuth",
-                    value: swift.Expression.contextualMethodCall({
-                        methodName: "init",
-                        arguments_: [
-                            swift.functionArgument({
-                                label: "username",
-                                value: swift.Expression.reference(authSchemes.basic.usernameParam.unsafeName)
-                            }),
-                            swift.functionArgument({
-                                label: "password",
-                                value: swift.Expression.reference(authSchemes.basic.passwordParam.unsafeName)
-                            })
-                        ]
-                    })
-                })
-            );
-        }
+        designatedInitializerArgs.push(
+            swift.functionArgument({
+                label: "basicAuth",
+                value: authSchemes.basic
+                    ? swift.Expression.contextualMethodCall({
+                          methodName: "init",
+                          arguments_: [
+                              swift.functionArgument({
+                                  label: "username",
+                                  value: swift.Expression.reference(authSchemes.basic.usernameParam.unsafeName)
+                              }),
+                              swift.functionArgument({
+                                  label: "password",
+                                  value: swift.Expression.reference(authSchemes.basic.passwordParam.unsafeName)
+                              })
+                          ]
+                      })
+                    : swift.Expression.nil()
+            })
+        );
 
         designatedInitializerArgs.push(
             swift.functionArgument({
@@ -403,7 +409,10 @@ export class RootClientGenerator {
                         swift.Expression.classInitialization({
                             unsafeName: clientName,
                             arguments_: [
-                                swift.functionArgument({ label: "config", value: swift.Expression.reference("config") })
+                                swift.functionArgument({
+                                    label: "config",
+                                    value: swift.Expression.reference("config")
+                                })
                             ]
                         })
                     )
@@ -413,7 +422,10 @@ export class RootClientGenerator {
                     swift.Expression.classInitialization({
                         unsafeName: this.clientGeneratorContext.httpClient.clientName,
                         arguments_: [
-                            swift.functionArgument({ label: "config", value: swift.Expression.reference("config") })
+                            swift.functionArgument({
+                                label: "config",
+                                value: swift.Expression.reference("config")
+                            })
                         ]
                     })
                 )

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.4.1
+  createdAt: "2025-08-14"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed an infinite recursion bug in Swift SDKs where convenience initializers without auth schemes could ambiguously call the designated initializer. The generator now always passes arguments explicitly to avoid ambiguity.
+  irVersion: 58
+
 - version: 0.4.0
   createdAt: "2025-08-13"
   changelogEntry:

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -23,7 +23,9 @@ public final class AcceptClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class AcceptClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
@@ -20,6 +20,9 @@ public final class AliasExtendsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/alias/Sources/AliasClient.swift
+++ b/seed/swift-sdk/alias/Sources/AliasClient.swift
@@ -20,6 +20,9 @@ public final class AliasClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -32,6 +32,7 @@ public final class AnyAuthClient: Sendable {
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -65,6 +66,7 @@ public final class AnyAuthClient: Sendable {
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
@@ -21,6 +21,9 @@ public final class ApiWideBasePathClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
+++ b/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
@@ -26,6 +26,9 @@ public final class AudiencesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -26,6 +26,8 @@ public final class AuthEnvironmentVariablesClient: Sendable {
             headerAuth: apiKey.map {
                 .init(key: $0, header: "X-FERN-API-KEY")
             },
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
@@ -26,6 +26,8 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
             basicAuth: .init(username: username, password: accessToken),
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
@@ -26,6 +26,8 @@ public final class BasicAuthClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
             basicAuth: .init(username: username, password: password),
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -23,7 +23,9 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: apiKey),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: apiKey),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
@@ -21,6 +21,9 @@ public final class BytesDownloadClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
@@ -21,6 +21,9 @@ public final class BytesUploadClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
@@ -22,6 +22,9 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/circular-references/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/ApiClient.swift
@@ -22,6 +22,9 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/client-side-params/Sources/ClientSideParamsClient.swift
+++ b/seed/swift-sdk/client-side-params/Sources/ClientSideParamsClient.swift
@@ -6,15 +6,17 @@ public final class ClientSideParamsClient: Sendable {
     public let types: TypesClient
     private let httpClient: HTTPClient
 
-    /// Initialize the client with the specified configuration.
+    /// Initialize the client with the specified configuration and a static bearer token.
     ///
     /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
     /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public convenience init(
         baseURL: String,
+        token: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -22,6 +24,41 @@ public final class ClientSideParamsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: token.map {
+                .init(token: .staticToken($0))
+            },
+            basicAuth: nil,
+            headers: headers,
+            timeout: timeout,
+            maxRetries: maxRetries,
+            urlSession: urlSession
+        )
+    }
+
+    /// Initialize the client with the specified configuration and an async bearer token provider.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter token: An async function that returns the bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
+    public convenience init(
+        baseURL: String,
+        token: ClientConfig.CredentialProvider? = nil,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        self.init(
+            baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: token.map {
+                .init(token: .provider($0))
+            },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/client-side-params/Sources/Requests/SearchResourcesRequest.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Requests/SearchResourcesRequest.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 public struct SearchResourcesRequest: Codable, Hashable, Sendable {
-    public let query: String
+    /// Search query text
+    public let query: String?
     public let filters: [String: JSONValue]?
     /// Additional properties that are not explicitly defined in the schema
     public let additionalProperties: [String: JSONValue]
 
     public init(
-        query: String,
+        query: String? = nil,
         filters: [String: JSONValue]? = nil,
         additionalProperties: [String: JSONValue] = .init()
     ) {
@@ -18,7 +19,7 @@ public struct SearchResourcesRequest: Codable, Hashable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.query = try container.decode(String.self, forKey: .query)
+        self.query = try container.decodeIfPresent(String.self, forKey: .query)
         self.filters = try container.decodeIfPresent([String: JSONValue].self, forKey: .filters)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
@@ -26,7 +27,7 @@ public struct SearchResourcesRequest: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try encoder.encodeAdditionalProperties(self.additionalProperties)
-        try container.encode(self.query, forKey: .query)
+        try container.encodeIfPresent(self.query, forKey: .query)
         try container.encodeIfPresent(self.filters, forKey: .filters)
     }
 

--- a/seed/swift-sdk/client-side-params/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Resources/Service/ServiceClient.swift
@@ -71,4 +71,173 @@ public final class ServiceClient: Sendable {
             responseType: SearchResponse.self
         )
     }
+
+    /// List or search for users
+    ///
+    /// - Parameter page: Page index of the results to return. First page is 0.
+    /// - Parameter perPage: Number of results per page.
+    /// - Parameter includeTotals: Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
+    /// - Parameter sort: Field to sort by. Use field:order where order is 1 for ascending and -1 for descending.
+    /// - Parameter connection: Connection filter
+    /// - Parameter q: Query string following Lucene query string syntax
+    /// - Parameter searchEngine: Search engine version (v1, v2, or v3)
+    /// - Parameter fields: Comma-separated list of fields to include or exclude
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func listUsers(page: Int? = nil, perPage: Int? = nil, includeTotals: Bool? = nil, sort: String? = nil, connection: String? = nil, q: String? = nil, searchEngine: String? = nil, fields: String? = nil, requestOptions: RequestOptions? = nil) async throws -> PaginatedUserResponse {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users",
+            queryParams: [
+                "page": page.map { .int($0) }, 
+                "per_page": perPage.map { .int($0) }, 
+                "include_totals": includeTotals.map { .bool($0) }, 
+                "sort": sort.map { .string($0) }, 
+                "connection": connection.map { .string($0) }, 
+                "q": q.map { .string($0) }, 
+                "search_engine": searchEngine.map { .string($0) }, 
+                "fields": fields.map { .string($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: PaginatedUserResponse.self
+        )
+    }
+
+    /// Get a user by ID
+    ///
+    /// - Parameter fields: Comma-separated list of fields to include or exclude
+    /// - Parameter includeFields: true to include the fields specified, false to exclude them
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getUserById(userId: String, fields: String? = nil, includeFields: Bool? = nil, requestOptions: RequestOptions? = nil) async throws -> User {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users/\(userId)",
+            queryParams: [
+                "fields": fields.map { .string($0) }, 
+                "include_fields": includeFields.map { .bool($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: User.self
+        )
+    }
+
+    /// Create a new user
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func createUser(request: CreateUserRequest, requestOptions: RequestOptions? = nil) async throws -> User {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/api/users",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: User.self
+        )
+    }
+
+    /// Update a user
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func updateUser(userId: String, request: UpdateUserRequest, requestOptions: RequestOptions? = nil) async throws -> User {
+        return try await httpClient.performRequest(
+            method: .patch,
+            path: "/api/users/\(userId)",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: User.self
+        )
+    }
+
+    /// Delete a user
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func deleteUser(userId: String, requestOptions: RequestOptions? = nil) async throws -> Void {
+        return try await httpClient.performRequest(
+            method: .delete,
+            path: "/api/users/\(userId)",
+            requestOptions: requestOptions
+        )
+    }
+
+    /// List all connections
+    ///
+    /// - Parameter strategy: Filter by strategy type (e.g., auth0, google-oauth2, samlp)
+    /// - Parameter name: Filter by connection name
+    /// - Parameter fields: Comma-separated list of fields to include
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func listConnections(strategy: String? = nil, name: String? = nil, fields: String? = nil, requestOptions: RequestOptions? = nil) async throws -> [Connection] {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/connections",
+            queryParams: [
+                "strategy": strategy.map { .string($0) }, 
+                "name": name.map { .string($0) }, 
+                "fields": fields.map { .string($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: [Connection].self
+        )
+    }
+
+    /// Get a connection by ID
+    ///
+    /// - Parameter fields: Comma-separated list of fields to include
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getConnection(connectionId: String, fields: String? = nil, requestOptions: RequestOptions? = nil) async throws -> Connection {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/connections/\(connectionId)",
+            queryParams: [
+                "fields": fields.map { .string($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: Connection.self
+        )
+    }
+
+    /// List all clients/applications
+    ///
+    /// - Parameter fields: Comma-separated list of fields to include
+    /// - Parameter includeFields: Whether specified fields are included or excluded
+    /// - Parameter page: Page number (zero-based)
+    /// - Parameter perPage: Number of results per page
+    /// - Parameter includeTotals: Include total count in response
+    /// - Parameter isGlobal: Filter by global clients
+    /// - Parameter isFirstParty: Filter by first party clients
+    /// - Parameter appType: Filter by application type (spa, native, regular_web, non_interactive)
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func listClients(fields: String? = nil, includeFields: Bool? = nil, page: Int? = nil, perPage: Int? = nil, includeTotals: Bool? = nil, isGlobal: Bool? = nil, isFirstParty: Bool? = nil, appType: [String]? = nil, requestOptions: RequestOptions? = nil) async throws -> PaginatedClientResponse {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/clients",
+            queryParams: [
+                "fields": fields.map { .string($0) }, 
+                "include_fields": includeFields.map { .bool($0) }, 
+                "page": page.map { .int($0) }, 
+                "per_page": perPage.map { .int($0) }, 
+                "include_totals": includeTotals.map { .bool($0) }, 
+                "is_global": isGlobal.map { .bool($0) }, 
+                "is_first_party": isFirstParty.map { .bool($0) }, 
+                "app_type": appType.map { .stringArray($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: PaginatedClientResponse.self
+        )
+    }
+
+    /// Get a client by ID
+    ///
+    /// - Parameter fields: Comma-separated list of fields to include
+    /// - Parameter includeFields: Whether specified fields are included or excluded
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getClient(clientId: String, fields: String? = nil, includeFields: Bool? = nil, requestOptions: RequestOptions? = nil) async throws -> Client {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/clients/\(clientId)",
+            queryParams: [
+                "fields": fields.map { .string($0) }, 
+                "include_fields": includeFields.map { .bool($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: Client.self
+        )
+    }
 }

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/Client.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/Client.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// Represents a client application
+public struct Client: Codable, Hashable, Sendable {
+    /// The unique client identifier
+    public let clientId: String
+    /// The tenant name
+    public let tenant: String?
+    /// Name of the client
+    public let name: String
+    /// Free text description of the client
+    public let description: String?
+    /// Whether this is a global client
+    public let global: Bool?
+    /// The client secret (only for non-public clients)
+    public let clientSecret: String?
+    /// The type of application (spa, native, regular_web, non_interactive)
+    public let appType: String?
+    /// URL of the client logo
+    public let logoUri: String?
+    /// Whether this client is a first party client
+    public let isFirstParty: Bool?
+    /// Whether this client conforms to OIDC specifications
+    public let oidcConformant: Bool?
+    /// Allowed callback URLs
+    public let callbacks: [String]?
+    /// Allowed origins for CORS
+    public let allowedOrigins: [String]?
+    /// Allowed web origins for CORS
+    public let webOrigins: [String]?
+    /// Allowed grant types
+    public let grantTypes: [String]?
+    /// JWT configuration for the client
+    public let jwtConfiguration: [String: JSONValue]?
+    /// Client signing keys
+    public let signingKeys: [[String: JSONValue]]?
+    /// Encryption key
+    public let encryptionKey: [String: JSONValue]?
+    /// Whether SSO is enabled
+    public let sso: Bool?
+    /// Whether SSO is disabled
+    public let ssoDisabled: Bool?
+    /// Whether to use cross-origin authentication
+    public let crossOriginAuth: Bool?
+    /// URL for cross-origin authentication
+    public let crossOriginLoc: String?
+    /// Whether a custom login page is enabled
+    public let customLoginPageOn: Bool?
+    /// Custom login page URL
+    public let customLoginPage: String?
+    /// Custom login page preview URL
+    public let customLoginPagePreview: String?
+    /// Form template for WS-Federation
+    public let formTemplate: String?
+    /// Whether this is a Heroku application
+    public let isHerokuApp: Bool?
+    /// Addons enabled for this client
+    public let addons: [String: JSONValue]?
+    /// Requested authentication method for the token endpoint
+    public let tokenEndpointAuthMethod: String?
+    /// Metadata associated with the client
+    public let clientMetadata: [String: JSONValue]?
+    /// Mobile app settings
+    public let mobile: [String: JSONValue]?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        clientId: String,
+        tenant: String? = nil,
+        name: String,
+        description: String? = nil,
+        global: Bool? = nil,
+        clientSecret: String? = nil,
+        appType: String? = nil,
+        logoUri: String? = nil,
+        isFirstParty: Bool? = nil,
+        oidcConformant: Bool? = nil,
+        callbacks: [String]? = nil,
+        allowedOrigins: [String]? = nil,
+        webOrigins: [String]? = nil,
+        grantTypes: [String]? = nil,
+        jwtConfiguration: [String: JSONValue]? = nil,
+        signingKeys: [[String: JSONValue]]? = nil,
+        encryptionKey: [String: JSONValue]? = nil,
+        sso: Bool? = nil,
+        ssoDisabled: Bool? = nil,
+        crossOriginAuth: Bool? = nil,
+        crossOriginLoc: String? = nil,
+        customLoginPageOn: Bool? = nil,
+        customLoginPage: String? = nil,
+        customLoginPagePreview: String? = nil,
+        formTemplate: String? = nil,
+        isHerokuApp: Bool? = nil,
+        addons: [String: JSONValue]? = nil,
+        tokenEndpointAuthMethod: String? = nil,
+        clientMetadata: [String: JSONValue]? = nil,
+        mobile: [String: JSONValue]? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.clientId = clientId
+        self.tenant = tenant
+        self.name = name
+        self.description = description
+        self.global = global
+        self.clientSecret = clientSecret
+        self.appType = appType
+        self.logoUri = logoUri
+        self.isFirstParty = isFirstParty
+        self.oidcConformant = oidcConformant
+        self.callbacks = callbacks
+        self.allowedOrigins = allowedOrigins
+        self.webOrigins = webOrigins
+        self.grantTypes = grantTypes
+        self.jwtConfiguration = jwtConfiguration
+        self.signingKeys = signingKeys
+        self.encryptionKey = encryptionKey
+        self.sso = sso
+        self.ssoDisabled = ssoDisabled
+        self.crossOriginAuth = crossOriginAuth
+        self.crossOriginLoc = crossOriginLoc
+        self.customLoginPageOn = customLoginPageOn
+        self.customLoginPage = customLoginPage
+        self.customLoginPagePreview = customLoginPagePreview
+        self.formTemplate = formTemplate
+        self.isHerokuApp = isHerokuApp
+        self.addons = addons
+        self.tokenEndpointAuthMethod = tokenEndpointAuthMethod
+        self.clientMetadata = clientMetadata
+        self.mobile = mobile
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.tenant = try container.decodeIfPresent(String.self, forKey: .tenant)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.global = try container.decodeIfPresent(Bool.self, forKey: .global)
+        self.clientSecret = try container.decodeIfPresent(String.self, forKey: .clientSecret)
+        self.appType = try container.decodeIfPresent(String.self, forKey: .appType)
+        self.logoUri = try container.decodeIfPresent(String.self, forKey: .logoUri)
+        self.isFirstParty = try container.decodeIfPresent(Bool.self, forKey: .isFirstParty)
+        self.oidcConformant = try container.decodeIfPresent(Bool.self, forKey: .oidcConformant)
+        self.callbacks = try container.decodeIfPresent([String].self, forKey: .callbacks)
+        self.allowedOrigins = try container.decodeIfPresent([String].self, forKey: .allowedOrigins)
+        self.webOrigins = try container.decodeIfPresent([String].self, forKey: .webOrigins)
+        self.grantTypes = try container.decodeIfPresent([String].self, forKey: .grantTypes)
+        self.jwtConfiguration = try container.decodeIfPresent([String: JSONValue].self, forKey: .jwtConfiguration)
+        self.signingKeys = try container.decodeIfPresent([[String: JSONValue]].self, forKey: .signingKeys)
+        self.encryptionKey = try container.decodeIfPresent([String: JSONValue].self, forKey: .encryptionKey)
+        self.sso = try container.decodeIfPresent(Bool.self, forKey: .sso)
+        self.ssoDisabled = try container.decodeIfPresent(Bool.self, forKey: .ssoDisabled)
+        self.crossOriginAuth = try container.decodeIfPresent(Bool.self, forKey: .crossOriginAuth)
+        self.crossOriginLoc = try container.decodeIfPresent(String.self, forKey: .crossOriginLoc)
+        self.customLoginPageOn = try container.decodeIfPresent(Bool.self, forKey: .customLoginPageOn)
+        self.customLoginPage = try container.decodeIfPresent(String.self, forKey: .customLoginPage)
+        self.customLoginPagePreview = try container.decodeIfPresent(String.self, forKey: .customLoginPagePreview)
+        self.formTemplate = try container.decodeIfPresent(String.self, forKey: .formTemplate)
+        self.isHerokuApp = try container.decodeIfPresent(Bool.self, forKey: .isHerokuApp)
+        self.addons = try container.decodeIfPresent([String: JSONValue].self, forKey: .addons)
+        self.tokenEndpointAuthMethod = try container.decodeIfPresent(String.self, forKey: .tokenEndpointAuthMethod)
+        self.clientMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .clientMetadata)
+        self.mobile = try container.decodeIfPresent([String: JSONValue].self, forKey: .mobile)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.clientId, forKey: .clientId)
+        try container.encodeIfPresent(self.tenant, forKey: .tenant)
+        try container.encode(self.name, forKey: .name)
+        try container.encodeIfPresent(self.description, forKey: .description)
+        try container.encodeIfPresent(self.global, forKey: .global)
+        try container.encodeIfPresent(self.clientSecret, forKey: .clientSecret)
+        try container.encodeIfPresent(self.appType, forKey: .appType)
+        try container.encodeIfPresent(self.logoUri, forKey: .logoUri)
+        try container.encodeIfPresent(self.isFirstParty, forKey: .isFirstParty)
+        try container.encodeIfPresent(self.oidcConformant, forKey: .oidcConformant)
+        try container.encodeIfPresent(self.callbacks, forKey: .callbacks)
+        try container.encodeIfPresent(self.allowedOrigins, forKey: .allowedOrigins)
+        try container.encodeIfPresent(self.webOrigins, forKey: .webOrigins)
+        try container.encodeIfPresent(self.grantTypes, forKey: .grantTypes)
+        try container.encodeIfPresent(self.jwtConfiguration, forKey: .jwtConfiguration)
+        try container.encodeIfPresent(self.signingKeys, forKey: .signingKeys)
+        try container.encodeIfPresent(self.encryptionKey, forKey: .encryptionKey)
+        try container.encodeIfPresent(self.sso, forKey: .sso)
+        try container.encodeIfPresent(self.ssoDisabled, forKey: .ssoDisabled)
+        try container.encodeIfPresent(self.crossOriginAuth, forKey: .crossOriginAuth)
+        try container.encodeIfPresent(self.crossOriginLoc, forKey: .crossOriginLoc)
+        try container.encodeIfPresent(self.customLoginPageOn, forKey: .customLoginPageOn)
+        try container.encodeIfPresent(self.customLoginPage, forKey: .customLoginPage)
+        try container.encodeIfPresent(self.customLoginPagePreview, forKey: .customLoginPagePreview)
+        try container.encodeIfPresent(self.formTemplate, forKey: .formTemplate)
+        try container.encodeIfPresent(self.isHerokuApp, forKey: .isHerokuApp)
+        try container.encodeIfPresent(self.addons, forKey: .addons)
+        try container.encodeIfPresent(self.tokenEndpointAuthMethod, forKey: .tokenEndpointAuthMethod)
+        try container.encodeIfPresent(self.clientMetadata, forKey: .clientMetadata)
+        try container.encodeIfPresent(self.mobile, forKey: .mobile)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case clientId = "client_id"
+        case tenant
+        case name
+        case description
+        case global
+        case clientSecret = "client_secret"
+        case appType = "app_type"
+        case logoUri = "logo_uri"
+        case isFirstParty = "is_first_party"
+        case oidcConformant = "oidc_conformant"
+        case callbacks
+        case allowedOrigins = "allowed_origins"
+        case webOrigins = "web_origins"
+        case grantTypes = "grant_types"
+        case jwtConfiguration = "jwt_configuration"
+        case signingKeys = "signing_keys"
+        case encryptionKey = "encryption_key"
+        case sso
+        case ssoDisabled = "sso_disabled"
+        case crossOriginAuth = "cross_origin_auth"
+        case crossOriginLoc = "cross_origin_loc"
+        case customLoginPageOn = "custom_login_page_on"
+        case customLoginPage = "custom_login_page"
+        case customLoginPagePreview = "custom_login_page_preview"
+        case formTemplate = "form_template"
+        case isHerokuApp = "is_heroku_app"
+        case addons
+        case tokenEndpointAuthMethod = "token_endpoint_auth_method"
+        case clientMetadata = "client_metadata"
+        case mobile
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/Connection.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/Connection.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Represents an identity provider connection
+public struct Connection: Codable, Hashable, Sendable {
+    /// Connection identifier
+    public let id: String
+    /// Connection name
+    public let name: String
+    /// Display name for the connection
+    public let displayName: String?
+    /// The identity provider identifier (auth0, google-oauth2, facebook, etc.)
+    public let strategy: String
+    /// Connection-specific configuration options
+    public let options: [String: JSONValue]?
+    /// List of client IDs that can use this connection
+    public let enabledClients: [String]?
+    /// Applicable realms for enterprise connections
+    public let realms: [String]?
+    /// Whether this is a domain connection
+    public let isDomainConnection: Bool?
+    /// Additional metadata
+    public let metadata: [String: JSONValue]?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        id: String,
+        name: String,
+        displayName: String? = nil,
+        strategy: String,
+        options: [String: JSONValue]? = nil,
+        enabledClients: [String]? = nil,
+        realms: [String]? = nil,
+        isDomainConnection: Bool? = nil,
+        metadata: [String: JSONValue]? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.id = id
+        self.name = name
+        self.displayName = displayName
+        self.strategy = strategy
+        self.options = options
+        self.enabledClients = enabledClients
+        self.realms = realms
+        self.isDomainConnection = isDomainConnection
+        self.metadata = metadata
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
+        self.strategy = try container.decode(String.self, forKey: .strategy)
+        self.options = try container.decodeIfPresent([String: JSONValue].self, forKey: .options)
+        self.enabledClients = try container.decodeIfPresent([String].self, forKey: .enabledClients)
+        self.realms = try container.decodeIfPresent([String].self, forKey: .realms)
+        self.isDomainConnection = try container.decodeIfPresent(Bool.self, forKey: .isDomainConnection)
+        self.metadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .metadata)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.name, forKey: .name)
+        try container.encodeIfPresent(self.displayName, forKey: .displayName)
+        try container.encode(self.strategy, forKey: .strategy)
+        try container.encodeIfPresent(self.options, forKey: .options)
+        try container.encodeIfPresent(self.enabledClients, forKey: .enabledClients)
+        try container.encodeIfPresent(self.realms, forKey: .realms)
+        try container.encodeIfPresent(self.isDomainConnection, forKey: .isDomainConnection)
+        try container.encodeIfPresent(self.metadata, forKey: .metadata)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+        case displayName = "display_name"
+        case strategy
+        case options
+        case enabledClients = "enabled_clients"
+        case realms
+        case isDomainConnection = "is_domain_connection"
+        case metadata
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/CreateUserRequest.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/CreateUserRequest.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+public struct CreateUserRequest: Codable, Hashable, Sendable {
+    public let email: String
+    public let emailVerified: Bool?
+    public let username: String?
+    public let password: String?
+    public let phoneNumber: String?
+    public let phoneVerified: Bool?
+    public let userMetadata: [String: JSONValue]?
+    public let appMetadata: [String: JSONValue]?
+    public let connection: String
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        email: String,
+        emailVerified: Bool? = nil,
+        username: String? = nil,
+        password: String? = nil,
+        phoneNumber: String? = nil,
+        phoneVerified: Bool? = nil,
+        userMetadata: [String: JSONValue]? = nil,
+        appMetadata: [String: JSONValue]? = nil,
+        connection: String,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.email = email
+        self.emailVerified = emailVerified
+        self.username = username
+        self.password = password
+        self.phoneNumber = phoneNumber
+        self.phoneVerified = phoneVerified
+        self.userMetadata = userMetadata
+        self.appMetadata = appMetadata
+        self.connection = connection
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.email = try container.decode(String.self, forKey: .email)
+        self.emailVerified = try container.decodeIfPresent(Bool.self, forKey: .emailVerified)
+        self.username = try container.decodeIfPresent(String.self, forKey: .username)
+        self.password = try container.decodeIfPresent(String.self, forKey: .password)
+        self.phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
+        self.phoneVerified = try container.decodeIfPresent(Bool.self, forKey: .phoneVerified)
+        self.userMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .userMetadata)
+        self.appMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .appMetadata)
+        self.connection = try container.decode(String.self, forKey: .connection)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.email, forKey: .email)
+        try container.encodeIfPresent(self.emailVerified, forKey: .emailVerified)
+        try container.encodeIfPresent(self.username, forKey: .username)
+        try container.encodeIfPresent(self.password, forKey: .password)
+        try container.encodeIfPresent(self.phoneNumber, forKey: .phoneNumber)
+        try container.encodeIfPresent(self.phoneVerified, forKey: .phoneVerified)
+        try container.encodeIfPresent(self.userMetadata, forKey: .userMetadata)
+        try container.encodeIfPresent(self.appMetadata, forKey: .appMetadata)
+        try container.encode(self.connection, forKey: .connection)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case email
+        case emailVerified = "email_verified"
+        case username
+        case password
+        case phoneNumber = "phone_number"
+        case phoneVerified = "phone_verified"
+        case userMetadata = "user_metadata"
+        case appMetadata = "app_metadata"
+        case connection
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/Identity.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/Identity.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public struct Identity: Codable, Hashable, Sendable {
+    public let connection: String
+    public let userId: String
+    public let provider: String
+    public let isSocial: Bool
+    public let accessToken: String?
+    public let expiresIn: Int?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        connection: String,
+        userId: String,
+        provider: String,
+        isSocial: Bool,
+        accessToken: String? = nil,
+        expiresIn: Int? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.connection = connection
+        self.userId = userId
+        self.provider = provider
+        self.isSocial = isSocial
+        self.accessToken = accessToken
+        self.expiresIn = expiresIn
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.connection = try container.decode(String.self, forKey: .connection)
+        self.userId = try container.decode(String.self, forKey: .userId)
+        self.provider = try container.decode(String.self, forKey: .provider)
+        self.isSocial = try container.decode(Bool.self, forKey: .isSocial)
+        self.accessToken = try container.decodeIfPresent(String.self, forKey: .accessToken)
+        self.expiresIn = try container.decodeIfPresent(Int.self, forKey: .expiresIn)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.connection, forKey: .connection)
+        try container.encode(self.userId, forKey: .userId)
+        try container.encode(self.provider, forKey: .provider)
+        try container.encode(self.isSocial, forKey: .isSocial)
+        try container.encodeIfPresent(self.accessToken, forKey: .accessToken)
+        try container.encodeIfPresent(self.expiresIn, forKey: .expiresIn)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case connection
+        case userId = "user_id"
+        case provider
+        case isSocial = "is_social"
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/PaginatedClientResponse.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/PaginatedClientResponse.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Paginated response for clients listing
+public struct PaginatedClientResponse: Codable, Hashable, Sendable {
+    /// Starting index (zero-based)
+    public let start: Int
+    /// Number of items requested
+    public let limit: Int
+    /// Number of items returned
+    public let length: Int
+    /// Total number of items (when include_totals=true)
+    public let total: Int?
+    /// List of clients
+    public let clients: [Client]
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        start: Int,
+        limit: Int,
+        length: Int,
+        total: Int? = nil,
+        clients: [Client],
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.start = start
+        self.limit = limit
+        self.length = length
+        self.total = total
+        self.clients = clients
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.start = try container.decode(Int.self, forKey: .start)
+        self.limit = try container.decode(Int.self, forKey: .limit)
+        self.length = try container.decode(Int.self, forKey: .length)
+        self.total = try container.decodeIfPresent(Int.self, forKey: .total)
+        self.clients = try container.decode([Client].self, forKey: .clients)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.start, forKey: .start)
+        try container.encode(self.limit, forKey: .limit)
+        try container.encode(self.length, forKey: .length)
+        try container.encodeIfPresent(self.total, forKey: .total)
+        try container.encode(self.clients, forKey: .clients)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case start
+        case limit
+        case length
+        case total
+        case clients
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/PaginatedUserResponse.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/PaginatedUserResponse.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Response with pagination info like Auth0
+public struct PaginatedUserResponse: Codable, Hashable, Sendable {
+    public let users: [User]
+    public let start: Int
+    public let limit: Int
+    public let length: Int
+    public let total: Int?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        users: [User],
+        start: Int,
+        limit: Int,
+        length: Int,
+        total: Int? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.users = users
+        self.start = start
+        self.limit = limit
+        self.length = length
+        self.total = total
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.users = try container.decode([User].self, forKey: .users)
+        self.start = try container.decode(Int.self, forKey: .start)
+        self.limit = try container.decode(Int.self, forKey: .limit)
+        self.length = try container.decode(Int.self, forKey: .length)
+        self.total = try container.decodeIfPresent(Int.self, forKey: .total)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.users, forKey: .users)
+        try container.encode(self.start, forKey: .start)
+        try container.encode(self.limit, forKey: .limit)
+        try container.encode(self.length, forKey: .length)
+        try container.encodeIfPresent(self.total, forKey: .total)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case users
+        case start
+        case limit
+        case length
+        case total
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/UpdateUserRequest.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/UpdateUserRequest.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+public struct UpdateUserRequest: Codable, Hashable, Sendable {
+    public let email: String?
+    public let emailVerified: Bool?
+    public let username: String?
+    public let phoneNumber: String?
+    public let phoneVerified: Bool?
+    public let userMetadata: [String: JSONValue]?
+    public let appMetadata: [String: JSONValue]?
+    public let password: String?
+    public let blocked: Bool?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        email: String? = nil,
+        emailVerified: Bool? = nil,
+        username: String? = nil,
+        phoneNumber: String? = nil,
+        phoneVerified: Bool? = nil,
+        userMetadata: [String: JSONValue]? = nil,
+        appMetadata: [String: JSONValue]? = nil,
+        password: String? = nil,
+        blocked: Bool? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.email = email
+        self.emailVerified = emailVerified
+        self.username = username
+        self.phoneNumber = phoneNumber
+        self.phoneVerified = phoneVerified
+        self.userMetadata = userMetadata
+        self.appMetadata = appMetadata
+        self.password = password
+        self.blocked = blocked
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.email = try container.decodeIfPresent(String.self, forKey: .email)
+        self.emailVerified = try container.decodeIfPresent(Bool.self, forKey: .emailVerified)
+        self.username = try container.decodeIfPresent(String.self, forKey: .username)
+        self.phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
+        self.phoneVerified = try container.decodeIfPresent(Bool.self, forKey: .phoneVerified)
+        self.userMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .userMetadata)
+        self.appMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .appMetadata)
+        self.password = try container.decodeIfPresent(String.self, forKey: .password)
+        self.blocked = try container.decodeIfPresent(Bool.self, forKey: .blocked)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.email, forKey: .email)
+        try container.encodeIfPresent(self.emailVerified, forKey: .emailVerified)
+        try container.encodeIfPresent(self.username, forKey: .username)
+        try container.encodeIfPresent(self.phoneNumber, forKey: .phoneNumber)
+        try container.encodeIfPresent(self.phoneVerified, forKey: .phoneVerified)
+        try container.encodeIfPresent(self.userMetadata, forKey: .userMetadata)
+        try container.encodeIfPresent(self.appMetadata, forKey: .appMetadata)
+        try container.encodeIfPresent(self.password, forKey: .password)
+        try container.encodeIfPresent(self.blocked, forKey: .blocked)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case email
+        case emailVerified = "email_verified"
+        case username
+        case phoneNumber = "phone_number"
+        case phoneVerified = "phone_verified"
+        case userMetadata = "user_metadata"
+        case appMetadata = "app_metadata"
+        case password
+        case blocked
+    }
+}

--- a/seed/swift-sdk/client-side-params/Sources/Schemas/User.swift
+++ b/seed/swift-sdk/client-side-params/Sources/Schemas/User.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// User object similar to Auth0 users
+public struct User: Codable, Hashable, Sendable {
+    public let userId: String
+    public let email: String
+    public let emailVerified: Bool
+    public let username: String?
+    public let phoneNumber: String?
+    public let phoneVerified: Bool?
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let identities: [Identity]?
+    public let appMetadata: [String: JSONValue]?
+    public let userMetadata: [String: JSONValue]?
+    public let picture: String?
+    public let name: String?
+    public let nickname: String?
+    public let multifactor: [String]?
+    public let lastIp: String?
+    public let lastLogin: Date?
+    public let loginsCount: Int?
+    public let blocked: Bool?
+    public let givenName: String?
+    public let familyName: String?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        userId: String,
+        email: String,
+        emailVerified: Bool,
+        username: String? = nil,
+        phoneNumber: String? = nil,
+        phoneVerified: Bool? = nil,
+        createdAt: Date,
+        updatedAt: Date,
+        identities: [Identity]? = nil,
+        appMetadata: [String: JSONValue]? = nil,
+        userMetadata: [String: JSONValue]? = nil,
+        picture: String? = nil,
+        name: String? = nil,
+        nickname: String? = nil,
+        multifactor: [String]? = nil,
+        lastIp: String? = nil,
+        lastLogin: Date? = nil,
+        loginsCount: Int? = nil,
+        blocked: Bool? = nil,
+        givenName: String? = nil,
+        familyName: String? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.userId = userId
+        self.email = email
+        self.emailVerified = emailVerified
+        self.username = username
+        self.phoneNumber = phoneNumber
+        self.phoneVerified = phoneVerified
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.identities = identities
+        self.appMetadata = appMetadata
+        self.userMetadata = userMetadata
+        self.picture = picture
+        self.name = name
+        self.nickname = nickname
+        self.multifactor = multifactor
+        self.lastIp = lastIp
+        self.lastLogin = lastLogin
+        self.loginsCount = loginsCount
+        self.blocked = blocked
+        self.givenName = givenName
+        self.familyName = familyName
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.userId = try container.decode(String.self, forKey: .userId)
+        self.email = try container.decode(String.self, forKey: .email)
+        self.emailVerified = try container.decode(Bool.self, forKey: .emailVerified)
+        self.username = try container.decodeIfPresent(String.self, forKey: .username)
+        self.phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
+        self.phoneVerified = try container.decodeIfPresent(Bool.self, forKey: .phoneVerified)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        self.identities = try container.decodeIfPresent([Identity].self, forKey: .identities)
+        self.appMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .appMetadata)
+        self.userMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .userMetadata)
+        self.picture = try container.decodeIfPresent(String.self, forKey: .picture)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.nickname = try container.decodeIfPresent(String.self, forKey: .nickname)
+        self.multifactor = try container.decodeIfPresent([String].self, forKey: .multifactor)
+        self.lastIp = try container.decodeIfPresent(String.self, forKey: .lastIp)
+        self.lastLogin = try container.decodeIfPresent(Date.self, forKey: .lastLogin)
+        self.loginsCount = try container.decodeIfPresent(Int.self, forKey: .loginsCount)
+        self.blocked = try container.decodeIfPresent(Bool.self, forKey: .blocked)
+        self.givenName = try container.decodeIfPresent(String.self, forKey: .givenName)
+        self.familyName = try container.decodeIfPresent(String.self, forKey: .familyName)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.userId, forKey: .userId)
+        try container.encode(self.email, forKey: .email)
+        try container.encode(self.emailVerified, forKey: .emailVerified)
+        try container.encodeIfPresent(self.username, forKey: .username)
+        try container.encodeIfPresent(self.phoneNumber, forKey: .phoneNumber)
+        try container.encodeIfPresent(self.phoneVerified, forKey: .phoneVerified)
+        try container.encode(self.createdAt, forKey: .createdAt)
+        try container.encode(self.updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(self.identities, forKey: .identities)
+        try container.encodeIfPresent(self.appMetadata, forKey: .appMetadata)
+        try container.encodeIfPresent(self.userMetadata, forKey: .userMetadata)
+        try container.encodeIfPresent(self.picture, forKey: .picture)
+        try container.encodeIfPresent(self.name, forKey: .name)
+        try container.encodeIfPresent(self.nickname, forKey: .nickname)
+        try container.encodeIfPresent(self.multifactor, forKey: .multifactor)
+        try container.encodeIfPresent(self.lastIp, forKey: .lastIp)
+        try container.encodeIfPresent(self.lastLogin, forKey: .lastLogin)
+        try container.encodeIfPresent(self.loginsCount, forKey: .loginsCount)
+        try container.encodeIfPresent(self.blocked, forKey: .blocked)
+        try container.encodeIfPresent(self.givenName, forKey: .givenName)
+        try container.encodeIfPresent(self.familyName, forKey: .familyName)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case userId = "user_id"
+        case email
+        case emailVerified = "email_verified"
+        case username
+        case phoneNumber = "phone_number"
+        case phoneVerified = "phone_verified"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case identities
+        case appMetadata = "app_metadata"
+        case userMetadata = "user_metadata"
+        case picture
+        case name
+        case nickname
+        case multifactor
+        case lastIp = "last_ip"
+        case lastLogin = "last_login"
+        case loginsCount = "logins_count"
+        case blocked
+        case givenName = "given_name"
+        case familyName = "family_name"
+    }
+}

--- a/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
+++ b/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
@@ -21,6 +21,9 @@ public final class ContentTypesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
@@ -26,6 +26,9 @@ public final class CrossPackageTypeNamesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
@@ -28,6 +28,8 @@ public final class CustomAuthClient: Sendable {
                 key: customAuthScheme,
                 header: "X-API-KEY"
             ),
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
@@ -21,6 +21,9 @@ public final class EmptyClientsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/enum/Sources/EnumClient.swift
+++ b/seed/swift-sdk/enum/Sources/EnumClient.swift
@@ -25,6 +25,9 @@ public final class EnumClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
+++ b/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
@@ -22,6 +22,9 @@ public final class ErrorPropertyClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/examples/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/Sources/ExamplesClient.swift
@@ -27,9 +27,11 @@ public final class ExamplesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -55,9 +57,11 @@ public final class ExamplesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -29,9 +29,11 @@ public final class ExhaustiveClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -57,9 +59,11 @@ public final class ExhaustiveClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/extends/Sources/ExtendsClient.swift
+++ b/seed/swift-sdk/extends/Sources/ExtendsClient.swift
@@ -20,6 +20,9 @@ public final class ExtendsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
@@ -21,6 +21,9 @@ public final class ExtraPropertiesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
+++ b/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
@@ -21,6 +21,9 @@ public final class FileDownloadClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
@@ -21,6 +21,9 @@ public final class FileUploadClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/folders/Sources/ApiClient.swift
+++ b/seed/swift-sdk/folders/Sources/ApiClient.swift
@@ -22,6 +22,9 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
+++ b/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
@@ -21,6 +21,9 @@ public final class HttpHeadClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -23,7 +23,9 @@ public final class IdempotencyHeadersClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class IdempotencyHeadersClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -23,9 +23,11 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -51,9 +53,11 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/InferredAuthExplicitClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/InferredAuthExplicitClient.swift
@@ -24,6 +24,9 @@ public final class InferredAuthExplicitClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/InferredAuthImplicitClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/InferredAuthImplicitClient.swift
@@ -24,6 +24,9 @@ public final class InferredAuthImplicitClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/license/Sources/LicenseClient.swift
+++ b/seed/swift-sdk/license/Sources/LicenseClient.swift
@@ -20,6 +20,9 @@ public final class LicenseClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/literal/Sources/LiteralClient.swift
+++ b/seed/swift-sdk/literal/Sources/LiteralClient.swift
@@ -25,6 +25,9 @@ public final class LiteralClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
@@ -21,6 +21,9 @@ public final class MixedCaseClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
@@ -22,6 +22,9 @@ public final class MixedFileDirectoryClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
@@ -21,6 +21,9 @@ public final class MultiLineDocsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -24,7 +24,9 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -50,7 +52,9 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -24,7 +24,9 @@ public final class MultiUrlEnvironmentClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -50,7 +52,9 @@ public final class MultiUrlEnvironmentClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -23,7 +23,9 @@ public final class NoEnvironmentClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class NoEnvironmentClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/nullable/Sources/NullableClient.swift
+++ b/seed/swift-sdk/nullable/Sources/NullableClient.swift
@@ -21,6 +21,9 @@ public final class NullableClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
@@ -24,6 +24,9 @@ public final class OauthClientCredentialsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
@@ -24,6 +24,9 @@ public final class OauthClientCredentialsDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
@@ -24,6 +24,9 @@ public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
@@ -24,6 +24,9 @@ public final class OauthClientCredentialsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
@@ -25,6 +25,9 @@ public final class OauthClientCredentialsWithVariablesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
@@ -24,6 +24,9 @@ public final class OauthClientCredentialsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/object/Sources/ObjectClient.swift
+++ b/seed/swift-sdk/object/Sources/ObjectClient.swift
@@ -20,6 +20,9 @@ public final class ObjectClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
@@ -22,6 +22,9 @@ public final class ObjectsWithImportsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
@@ -21,6 +21,9 @@ public final class ObjectsWithImportsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
@@ -21,6 +21,9 @@ public final class PackageYmlClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -23,9 +23,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -51,9 +53,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -24,9 +24,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -52,9 +54,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -24,9 +24,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -52,9 +54,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -24,9 +24,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -52,9 +54,11 @@ public final class PaginationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
@@ -22,6 +22,9 @@ public final class PathParametersClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
@@ -21,6 +21,9 @@ public final class PlainTextClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
+++ b/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
@@ -21,6 +21,9 @@ public final class PublicObjectClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
@@ -20,6 +20,9 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
@@ -20,6 +20,9 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
@@ -21,6 +21,9 @@ public final class QueryParametersClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
@@ -21,6 +21,9 @@ public final class RequestParametersClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
@@ -21,6 +21,9 @@ public final class NurseryApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
+++ b/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
@@ -21,6 +21,9 @@ public final class ResponsePropertyClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
@@ -21,6 +21,9 @@ public final class ServerSentEventsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
@@ -21,6 +21,9 @@ public final class ServerSentEventsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -23,7 +23,9 @@ public final class SimpleApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class SimpleApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
@@ -20,6 +20,9 @@ public final class ApiClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -23,7 +23,9 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -23,7 +23,9 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -49,7 +51,9 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: .init(token: token),
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
@@ -21,6 +21,9 @@ public final class StreamingClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/streaming/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming/Sources/StreamingClient.swift
@@ -21,6 +21,9 @@ public final class StreamingClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -32,9 +32,11 @@ public final class TraceClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .staticToken($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,
@@ -60,9 +62,11 @@ public final class TraceClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
             bearerAuth: token.map {
                 .init(token: .provider($0))
             },
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
@@ -21,6 +21,9 @@ public final class UndiscriminatedUnionsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/unions/Sources/UnionsClient.swift
+++ b/seed/swift-sdk/unions/Sources/UnionsClient.swift
@@ -23,6 +23,9 @@ public final class UnionsClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
+++ b/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
@@ -21,6 +21,9 @@ public final class UnknownAsAnyClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/validation/Sources/ValidationClient.swift
+++ b/seed/swift-sdk/validation/Sources/ValidationClient.swift
@@ -20,6 +20,9 @@ public final class ValidationClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/variables/Sources/VariablesClient.swift
+++ b/seed/swift-sdk/variables/Sources/VariablesClient.swift
@@ -21,6 +21,9 @@ public final class VariablesClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
@@ -21,6 +21,9 @@ public final class VersionClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/version/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version/Sources/VersionClient.swift
@@ -21,6 +21,9 @@ public final class VersionClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,

--- a/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
+++ b/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
@@ -21,6 +21,9 @@ public final class WebsocketClient: Sendable {
     ) {
         self.init(
             baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
             headers: headers,
             timeout: timeout,
             maxRetries: maxRetries,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixes an infinite recursion bug caused by ambiguity when a convenience initializer calls the designated initializer for definitions without auth schemes. We now explicitly pass arguments from the convenience initializer even when no auth schemes are present, ensuring the call is unambiguous.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `RootClientGenerator` to always specify designated initializer arguments
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

