### PR TITLE
fix(java): handle integer overflow in IR preprocessing

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -79,13 +79,10 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         try {
             File irFile = new File(generatorConfig.getIrFilepath());
 
-            // Read the IR JSON as a string first
             String irJson = java.nio.file.Files.readString(irFile.toPath());
 
-            // Preprocess the JSON to handle integer overflow in examples
             String processedJson = preprocessIntegerOverflow(irJson);
 
-            // Now deserialize with the standard ObjectMapper
             return ObjectMappers.JSON_MAPPER.readValue(processedJson, IntermediateRepresentation.class);
         } catch (IOException e) {
             throw new RuntimeException("Failed to read ir", e);

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 2.41.1
+  changelogEntry:
+    - summary: |
+        Fix integer overflow when processing OpenAPI specs with large integer values in examples. Values exceeding Java's Integer range are automatically converted to long type to prevent generation failures.
+      type: fix
+  createdAt: '2025-08-15'
+  irVersion: 58
+
 - version: 2.41.0
   changelogEntry:
     - summary: |

--- a/generators/swift/sdk/src/generators/client/util/__test__/snapshots/formatted-endpoint-paths/exhaustive.swift
+++ b/generators/swift/sdk/src/generators/client/util/__test__/snapshots/formatted-endpoint-paths/exhaustive.swift
@@ -28,6 +28,7 @@
 "/object/get-and-return-nested-with-optional-field"
 "/object/get-and-return-nested-with-required-field/\(string)"
 "/object/get-and-return-nested-with-required-field-list"
+"/object/test-integer-overflow-edge-cases"
 
 // service_endpoints/params
 "/params/path/\(param)"

--- a/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions/exhaustive.json
+++ b/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions/exhaustive.json
@@ -6476,6 +6476,152 @@
             },
             "examples": null
         },
+        "endpoint_endpoints/object.testIntegerOverflowEdgeCases": {
+            "auth": {
+                "type": "bearer",
+                "token": {
+                    "originalName": "token",
+                    "camelCase": {
+                        "unsafeName": "token",
+                        "safeName": "token"
+                    },
+                    "snakeCase": {
+                        "unsafeName": "token",
+                        "safeName": "token"
+                    },
+                    "screamingSnakeCase": {
+                        "unsafeName": "TOKEN",
+                        "safeName": "TOKEN"
+                    },
+                    "pascalCase": {
+                        "unsafeName": "Token",
+                        "safeName": "Token"
+                    }
+                }
+            },
+            "declaration": {
+                "name": {
+                    "originalName": "testIntegerOverflowEdgeCases",
+                    "camelCase": {
+                        "unsafeName": "testIntegerOverflowEdgeCases",
+                        "safeName": "testIntegerOverflowEdgeCases"
+                    },
+                    "snakeCase": {
+                        "unsafeName": "test_integer_overflow_edge_cases",
+                        "safeName": "test_integer_overflow_edge_cases"
+                    },
+                    "screamingSnakeCase": {
+                        "unsafeName": "TEST_INTEGER_OVERFLOW_EDGE_CASES",
+                        "safeName": "TEST_INTEGER_OVERFLOW_EDGE_CASES"
+                    },
+                    "pascalCase": {
+                        "unsafeName": "TestIntegerOverflowEdgeCases",
+                        "safeName": "TestIntegerOverflowEdgeCases"
+                    }
+                },
+                "fernFilepath": {
+                    "allParts": [
+                        {
+                            "originalName": "endpoints",
+                            "camelCase": {
+                                "unsafeName": "endpoints",
+                                "safeName": "endpoints"
+                            },
+                            "snakeCase": {
+                                "unsafeName": "endpoints",
+                                "safeName": "endpoints"
+                            },
+                            "screamingSnakeCase": {
+                                "unsafeName": "ENDPOINTS",
+                                "safeName": "ENDPOINTS"
+                            },
+                            "pascalCase": {
+                                "unsafeName": "Endpoints",
+                                "safeName": "Endpoints"
+                            }
+                        },
+                        {
+                            "originalName": "object",
+                            "camelCase": {
+                                "unsafeName": "object",
+                                "safeName": "object"
+                            },
+                            "snakeCase": {
+                                "unsafeName": "object",
+                                "safeName": "object"
+                            },
+                            "screamingSnakeCase": {
+                                "unsafeName": "OBJECT",
+                                "safeName": "OBJECT"
+                            },
+                            "pascalCase": {
+                                "unsafeName": "Object",
+                                "safeName": "Object"
+                            }
+                        }
+                    ],
+                    "packagePath": [
+                        {
+                            "originalName": "endpoints",
+                            "camelCase": {
+                                "unsafeName": "endpoints",
+                                "safeName": "endpoints"
+                            },
+                            "snakeCase": {
+                                "unsafeName": "endpoints",
+                                "safeName": "endpoints"
+                            },
+                            "screamingSnakeCase": {
+                                "unsafeName": "ENDPOINTS",
+                                "safeName": "ENDPOINTS"
+                            },
+                            "pascalCase": {
+                                "unsafeName": "Endpoints",
+                                "safeName": "Endpoints"
+                            }
+                        }
+                    ],
+                    "file": {
+                        "originalName": "object",
+                        "camelCase": {
+                            "unsafeName": "object",
+                            "safeName": "object"
+                        },
+                        "snakeCase": {
+                            "unsafeName": "object",
+                            "safeName": "object"
+                        },
+                        "screamingSnakeCase": {
+                            "unsafeName": "OBJECT",
+                            "safeName": "OBJECT"
+                        },
+                        "pascalCase": {
+                            "unsafeName": "Object",
+                            "safeName": "Object"
+                        }
+                    }
+                }
+            },
+            "location": {
+                "method": "POST",
+                "path": "/object/test-integer-overflow-edge-cases"
+            },
+            "request": {
+                "type": "body",
+                "pathParameters": [],
+                "body": {
+                    "type": "typeReference",
+                    "value": {
+                        "type": "named",
+                        "value": "type_types/object:ObjectWithOptionalField"
+                    }
+                }
+            },
+            "response": {
+                "type": "json"
+            },
+            "examples": null
+        },
         "endpoint_endpoints/params.getWithPath": {
             "auth": {
                 "type": "bearer",

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/fdr/exhaustive.json
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/fdr/exhaustive.json
@@ -2031,64 +2031,46 @@
           "errorsV2": [],
           "examples": [
             {
+              "name": "WithLargeInteger",
               "path": "/object/get-and-return-with-optional-field",
               "pathParameters": {},
               "queryParameters": {},
               "headers": {},
-              "requestBody": {},
+              "requestBody": {
+                "string": "test",
+                "integer": 21991583578,
+                "long": 9223372036854776000,
+                "double": 3.14,
+                "bool": true
+              },
               "requestBodyV3": {
                 "type": "json",
-                "value": {}
+                "value": {
+                  "string": "test",
+                  "integer": 21991583578,
+                  "long": 9223372036854776000,
+                  "double": 3.14,
+                  "bool": true
+                }
               },
               "responseStatusCode": 200,
               "responseBody": {
-                "string": "string",
-                "integer": 1,
-                "long": 1000000,
-                "double": 1.1,
-                "bool": true,
-                "datetime": "2024-01-15T09:30:00Z",
-                "date": "2023-01-15",
-                "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                "base64": "SGVsbG8gd29ybGQh",
-                "list": [
-                  "list",
-                  "list"
-                ],
-                "set": [
-                  "set"
-                ],
-                "map": {
-                  "1": "map"
-                },
-                "bigint": "1000000"
+                "string": "test",
+                "integer": 21991583578,
+                "long": 9223372036854776000,
+                "double": 3.14,
+                "bool": true
               },
               "responseBodyV3": {
                 "type": "json",
                 "value": {
-                  "string": "string",
-                  "integer": 1,
-                  "long": 1000000,
-                  "double": 1.1,
-                  "bool": true,
-                  "datetime": "2024-01-15T09:30:00Z",
-                  "date": "2023-01-15",
-                  "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                  "base64": "SGVsbG8gd29ybGQh",
-                  "list": [
-                    "list",
-                    "list"
-                  ],
-                  "set": [
-                    "set"
-                  ],
-                  "map": {
-                    "1": "map"
-                  },
-                  "bigint": "1000000"
+                  "string": "test",
+                  "integer": 21991583578,
+                  "long": 9223372036854776000,
+                  "double": 3.14,
+                  "bool": true
                 }
-              },
-              "codeSamples": []
+              }
             }
           ]
         },
@@ -2647,6 +2629,265 @@
                 }
               },
               "codeSamples": []
+            }
+          ]
+        },
+        {
+          "auth": true,
+          "method": "POST",
+          "id": "testIntegerOverflowEdgeCases",
+          "originalEndpointId": "endpoint_endpoints/object.testIntegerOverflowEdgeCases",
+          "name": "Test Integer Overflow Edge Cases",
+          "path": {
+            "pathParameters": [],
+            "parts": [
+              {
+                "type": "literal",
+                "value": "/object"
+              },
+              {
+                "type": "literal",
+                "value": "/test-integer-overflow-edge-cases"
+              }
+            ]
+          },
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "type": {
+              "type": "json",
+              "contentType": "application/json",
+              "shape": {
+                "type": "reference",
+                "value": {
+                  "type": "id",
+                  "value": "type_types/object:ObjectWithOptionalField"
+                }
+              }
+            }
+          },
+          "requestsV2": {},
+          "response": {
+            "type": {
+              "type": "reference",
+              "value": {
+                "type": "id",
+                "value": "type_types/object:ObjectWithOptionalField"
+              }
+            }
+          },
+          "responsesV2": {},
+          "errorsV2": [],
+          "examples": [
+            {
+              "name": "BoundaryValues",
+              "path": "/object/test-integer-overflow-edge-cases",
+              "pathParameters": {},
+              "queryParameters": {},
+              "headers": {},
+              "requestBody": {
+                "string": "boundary-test",
+                "integer": 2147483647,
+                "long": 9223372036854776000,
+                "double": 1.7976931348623157e+308,
+                "bool": true
+              },
+              "requestBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "boundary-test",
+                  "integer": 2147483647,
+                  "long": 9223372036854776000,
+                  "double": 1.7976931348623157e+308,
+                  "bool": true
+                }
+              },
+              "responseStatusCode": 200,
+              "responseBody": {
+                "string": "boundary-test",
+                "integer": 2147483647,
+                "long": 9223372036854776000,
+                "double": 1.7976931348623157e+308,
+                "bool": true
+              },
+              "responseBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "boundary-test",
+                  "integer": 2147483647,
+                  "long": 9223372036854776000,
+                  "double": 1.7976931348623157e+308,
+                  "bool": true
+                }
+              }
+            },
+            {
+              "name": "JustOverBoundary",
+              "path": "/object/test-integer-overflow-edge-cases",
+              "pathParameters": {},
+              "queryParameters": {},
+              "headers": {},
+              "requestBody": {
+                "string": "just-over-boundary",
+                "integer": 2147483648,
+                "long": 2147483648,
+                "double": 2,
+                "bool": false
+              },
+              "requestBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "just-over-boundary",
+                  "integer": 2147483648,
+                  "long": 2147483648,
+                  "double": 2,
+                  "bool": false
+                }
+              },
+              "responseStatusCode": 200,
+              "responseBody": {
+                "string": "just-over-boundary",
+                "integer": 2147483648,
+                "long": 2147483648,
+                "double": 2,
+                "bool": false
+              },
+              "responseBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "just-over-boundary",
+                  "integer": 2147483648,
+                  "long": 2147483648,
+                  "double": 2,
+                  "bool": false
+                }
+              }
+            },
+            {
+              "name": "JustUnderBoundary",
+              "path": "/object/test-integer-overflow-edge-cases",
+              "pathParameters": {},
+              "queryParameters": {},
+              "headers": {},
+              "requestBody": {
+                "string": "just-under-boundary",
+                "integer": -2147483649,
+                "long": -2147483649,
+                "double": -2,
+                "bool": true
+              },
+              "requestBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "just-under-boundary",
+                  "integer": -2147483649,
+                  "long": -2147483649,
+                  "double": -2,
+                  "bool": true
+                }
+              },
+              "responseStatusCode": 200,
+              "responseBody": {
+                "string": "just-under-boundary",
+                "integer": -2147483649,
+                "long": -2147483649,
+                "double": -2,
+                "bool": true
+              },
+              "responseBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "just-under-boundary",
+                  "integer": -2147483649,
+                  "long": -2147483649,
+                  "double": -2,
+                  "bool": true
+                }
+              }
+            },
+            {
+              "name": "LargePositiveValue",
+              "path": "/object/test-integer-overflow-edge-cases",
+              "pathParameters": {},
+              "queryParameters": {},
+              "headers": {},
+              "requestBody": {
+                "string": "large-positive",
+                "integer": 1000000000000,
+                "long": 1000000000000,
+                "double": 1000000000000,
+                "bool": false
+              },
+              "requestBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "large-positive",
+                  "integer": 1000000000000,
+                  "long": 1000000000000,
+                  "double": 1000000000000,
+                  "bool": false
+                }
+              },
+              "responseStatusCode": 200,
+              "responseBody": {
+                "string": "large-positive",
+                "integer": 1000000000000,
+                "long": 1000000000000,
+                "double": 1000000000000,
+                "bool": false
+              },
+              "responseBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "large-positive",
+                  "integer": 1000000000000,
+                  "long": 1000000000000,
+                  "double": 1000000000000,
+                  "bool": false
+                }
+              }
+            },
+            {
+              "name": "LargeNegativeValue",
+              "path": "/object/test-integer-overflow-edge-cases",
+              "pathParameters": {},
+              "queryParameters": {},
+              "headers": {},
+              "requestBody": {
+                "string": "large-negative",
+                "integer": -1000000000000,
+                "long": -1000000000000,
+                "double": -1000000000000,
+                "bool": true
+              },
+              "requestBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "large-negative",
+                  "integer": -1000000000000,
+                  "long": -1000000000000,
+                  "double": -1000000000000,
+                  "bool": true
+                }
+              },
+              "responseStatusCode": 200,
+              "responseBody": {
+                "string": "large-negative",
+                "integer": -1000000000000,
+                "long": -1000000000000,
+                "double": -1000000000000,
+                "bool": true
+              },
+              "responseBodyV3": {
+                "type": "json",
+                "value": {
+                  "string": "large-negative",
+                  "integer": -1000000000000,
+                  "long": -1000000000000,
+                  "double": -1000000000000,
+                  "bool": true
+                }
+              }
             }
           ]
         }

--- a/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
@@ -57,3 +57,80 @@ service:
       method: POST
       request: list<objects.NestedObjectWithRequiredField>
       response: objects.NestedObjectWithRequiredField
+
+    testIntegerOverflowEdgeCases:
+      path: /test-integer-overflow-edge-cases
+      method: POST
+      request: objects.ObjectWithOptionalField
+      response: objects.ObjectWithOptionalField
+      examples:
+        - name: BoundaryValues
+          request:
+            string: "boundary-test"
+            integer: 2147483647  # Integer.MAX_VALUE (should NOT convert)
+            long: 9223372036854775807  # Long.MAX_VALUE
+            double: 1.7976931348623157e+308  # Double.MAX_VALUE
+            bool: true
+          response:
+            body:
+              string: "boundary-test"
+              integer: 2147483647  # Should remain integer
+              long: 9223372036854775807
+              double: 1.7976931348623157e+308
+              bool: true
+        - name: JustOverBoundary
+          request:
+            string: "just-over-boundary"
+            integer: 2147483648  # Integer.MAX_VALUE + 1 (should convert)
+            long: 2147483648
+            double: 2.0
+            bool: false
+          response:
+            body:
+              string: "just-over-boundary"  
+              integer: 2147483648  # Should convert to long
+              long: 2147483648
+              double: 2.0
+              bool: false
+        - name: JustUnderBoundary
+          request:
+            string: "just-under-boundary"
+            integer: -2147483649  # Integer.MIN_VALUE - 1 (should convert)
+            long: -2147483649
+            double: -2.0
+            bool: true
+          response:
+            body:
+              string: "just-under-boundary"
+              integer: -2147483649  # Should convert to long
+              long: -2147483649
+              double: -2.0
+              bool: true
+        - name: LargePositiveValue
+          request:
+            string: "large-positive"
+            integer: 1000000000000  # 1 trillion (should convert)
+            long: 1000000000000
+            double: 1e12
+            bool: false
+          response:
+            body:
+              string: "large-positive"
+              integer: 1000000000000  # Should convert to long
+              long: 1000000000000
+              double: 1e12
+              bool: false
+        - name: LargeNegativeValue
+          request:
+            string: "large-negative"
+            integer: -1000000000000  # -1 trillion (should convert)
+            long: -1000000000000
+            double: -1e12
+            bool: true
+          response:
+            body:
+              string: "large-negative"
+              integer: -1000000000000  # Should convert to long
+              long: -1000000000000
+              double: -1e12
+              bool: true

--- a/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
@@ -10,6 +10,21 @@ service:
       method: POST
       request: objects.ObjectWithOptionalField
       response: objects.ObjectWithOptionalField
+      examples:
+        - name: WithLargeInteger
+          request:
+            string: "test"
+            integer: 21991583578  # Large value that exceeds Integer.MAX_VALUE (2147483647)
+            long: 9223372036854775807
+            double: 3.14
+            bool: true
+          response:
+            body:
+              string: "test"
+              integer: 21991583578  # This tests our integer overflow fix
+              long: 9223372036854775807
+              double: 3.14
+              bool: true
 
     getAndReturnWithRequiredField:
       path: /get-and-return-with-required-field


### PR DESCRIPTION
### Description:
Java SDK generator was failing on api specs with large integer values (like ImageKit's 21991583578) because they exceeded Java's Integer.MAX_VALUE, causing Jackson deserialization errors.

This PR adds some JSON preprocessing in that detects integer overflow in IR values and converts `"integer": large_value` to `"long": large_value` to preserve the original data while preventing deserialization failures.

### Changes
  - Jackson JsonNode tree processing to traverse
  - Recursive node processing - Handles nested objects, arrays, and primitive values throughout the entire IR
   structure
  - Overflow detection logic and boundary checking
  - Only processes fields explicitly typed as "integer" to avoid modifying schema definitions
  - Graceful error handling by falling back to original JSON if preprocessing fails

### Testing:
- Added test case coverage - Added boundary values (2147483647, -2147483648), overflow cases (21991583578,
  2147483648, -2147483649), and large scale values (1000000000000, -1000000000000)
- Made sure to test against ImageKit def so we don't get the error anymore. We were getting this before
```
  Caused by: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (21991583578) out of range of
   int (-2147483648 - 2147483647)
```