### PR TITLE
chore(docs): fix allOf parsing to grab the additionalProperties arg

### DIFF
--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
@@ -85,9 +85,6 @@ export class ObjectSchemaConverter extends AbstractConverter<
 
                 // Check for additionalProperties before this is passed by for not having req. properties
                 if (typeof allOfSchema.additionalProperties === "boolean" && allOfSchema.additionalProperties) {
-                    this.context.logger.debug?.(
-                        `[ObjectSchemaConverter] allOf[${index}] allows additionalProperties. Setting hasAdditionalProperties = true 1.`
-                    );
                     hasAdditionalProperties = true;
                 }
                 

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
@@ -87,11 +87,11 @@ export class ObjectSchemaConverter extends AbstractConverter<
                 if (typeof allOfSchema.additionalProperties === "boolean" && allOfSchema.additionalProperties) {
                     hasAdditionalProperties = true;
                 }
-                
+
                 // if the allOf schema has no properties that are required in the base schema, add the reference to the extends_
                 if (
-                    (!objectHasRequiredProperties) || 
-                    (Object.keys(allOfSchema.properties ?? {}).every((key) => !this.schema.required?.includes(key)))
+                    !objectHasRequiredProperties ||
+                    Object.keys(allOfSchema.properties ?? {}).every((key) => !this.schema.required?.includes(key))
                 ) {
                     this.addTypeReferenceToExtends({
                         reference: allOfSchemaOrReference,

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
@@ -70,7 +70,6 @@ export class ObjectSchemaConverter extends AbstractConverter<
             const breadcrumbs = [...this.breadcrumbs, "allOf", index.toString()];
             let allOfSchema: OpenAPIV3_1.SchemaObject;
             if (this.context.isReferenceObject(allOfSchemaOrReference)) {
-                // Tries to resolve reference
                 const maybeResolvedReference = this.context.resolveMaybeReference<OpenAPIV3_1.SchemaObject>({
                     schemaOrReference: allOfSchemaOrReference,
                     breadcrumbs
@@ -105,7 +104,6 @@ export class ObjectSchemaConverter extends AbstractConverter<
                 allOfSchema = allOfSchemaOrReference;
             }
 
-            // Check for additionalProperties in this allOf schema
             if (typeof allOfSchema.additionalProperties === "boolean" && allOfSchema.additionalProperties) {
                 hasAdditionalProperties = true;
             }

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
@@ -31,7 +31,7 @@ export class ObjectSchemaConverter extends AbstractConverter<
     }
 
     public convert(): ObjectSchemaConverter.Output {
-        const hasAdditionalProperties =
+        let hasAdditionalProperties =
             typeof this.schema.additionalProperties === "boolean" && this.schema.additionalProperties;
 
         if (!this.schema.properties && !this.schema.allOf) {
@@ -98,6 +98,11 @@ export class ObjectSchemaConverter extends AbstractConverter<
                 }
             } else {
                 allOfSchema = allOfSchemaOrReference;
+            }
+
+            // Check for additionalProperties in this allOf schema
+            if (typeof allOfSchema.additionalProperties === "boolean" && allOfSchema.additionalProperties) {
+                hasAdditionalProperties = true;
             }
 
             const {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- changelogEntry:
+    - summary: Updated allOf scheme parsing to grab additionalProperties flag
+      type: chore
+  irVersion: 59
+  createdAt: "2025-08-18"
+  version: 0.66.18
 
 - changelogEntry:
     - summary: Support IR v59 in the Swift SDK generator.


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
In the v3 IR parser, the allOf parsing fails to respect the additionalProperties flag because it would only look for additionalProperties flag at the top level schema and won't parse any of the allOf schemas for them.

E.g. this won't assign `additionalProperties = True` to the `inquiry-fields` schema: 
```
components:
 schemas:
   inquiry-fields:
      unevaluatedProperties: ...
      description: ...
      allOf:
        - $ref: '#/components/schemas/default-fields'
        - type: object
          properties:
            address-country-code:
              description: optional
              examples:
                - US
                - AU
                - GB
              type: string
          additionalProperties: true
```

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- updated the logic to properly grab additional properties if set in any "allOf" schema 

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed

