### PR TITLE
fix(internal): allow `pnpm seed run` to read `config` of `generators.yml`

### DIFF
--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -9,6 +9,7 @@ import { convertGeneratorWorkspaceToFernWorkspace } from "../../utils/convertSee
 import { DockerScriptRunner, LocalScriptRunner, ScriptRunner } from "../test";
 import { TaskContextFactory } from "../test/TaskContextFactory";
 import { DockerTestRunner, LocalTestRunner, TestRunner } from "../test/test-runner";
+import { FixtureConfigurations } from "../../config/api";
 
 export async function runWithCustomFixture({
     pathToFixture,
@@ -104,11 +105,17 @@ export async function runWithCustomFixture({
             return;
         }
 
+        const runFixtureConfig: FixtureConfigurations = {
+            customConfig: generatorGroup.config,
+            outputFolder: "",
+            ...customFixtureConfig
+        };
+
         await testRunner.build();
 
         await testRunner.run({
             fixture: "custom",
-            configuration: customFixtureConfig,
+            configuration: runFixtureConfig,
             inspect,
             absolutePathToApiDefinition: pathToFixture,
             outputDir: absolutePathToOutput
@@ -140,7 +147,7 @@ function getGeneratorGroup({
     image: string;
     imageAliases?: string[];
     absolutePathToOutput: AbsoluteFilePath;
-}): { group: GeneratorGroup; invocation: GeneratorInvocation } | undefined {
+}): { group: GeneratorGroup; invocation: GeneratorInvocation; config: object } | undefined {
     const groups = apiWorkspace.generatorsConfiguration?.groups;
     for (const group of groups ?? []) {
         for (const generator of group.generators) {
@@ -155,7 +162,8 @@ function getGeneratorGroup({
                         ...group,
                         generators: [invocation]
                     },
-                    invocation
+                    invocation,
+                    config: generator.config as object
                 };
             }
         }

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -3,13 +3,13 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import tmp from "tmp-promise";
+import { FixtureConfigurations } from "../../config/api";
 import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces";
 import { Semaphore } from "../../Semaphore";
 import { convertGeneratorWorkspaceToFernWorkspace } from "../../utils/convertSeedWorkspaceToFernWorkspace";
 import { DockerScriptRunner, LocalScriptRunner, ScriptRunner } from "../test";
 import { TaskContextFactory } from "../test/TaskContextFactory";
 import { DockerTestRunner, LocalTestRunner, TestRunner } from "../test/test-runner";
-import { FixtureConfigurations } from "../../config/api";
 
 export async function runWithCustomFixture({
     pathToFixture,


### PR DESCRIPTION
## Description
`pnpm seed run` used to ignore the `config` attribute when reading a `generators.yml` file; it shouldn't now.

## Changes Made
Only a relatively small addition to `packages/seed/src/commands/run/runWithCustomFixture.ts` (the function called by `pnpm seed run`) to grab the relevant config from the generator.

## Testing
- [X] Manual testing completed

