### PR TITLE
fix(ruby): Union types should extend the Model class

### DIFF
--- a/generators/ruby-v2/base/src/asIs/multipart/multipart_request.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/multipart/multipart_request.Template.rb
@@ -4,7 +4,7 @@ module <%= gem_namespace %>
   module Internal
     module Multipart
       # @api private
-      class Request <%= gem_namespace %>::Internal::Http::BaseRequest
+      class Request < <%= gem_namespace %>::Internal::Http::BaseRequest
         attr_reader :body
 
         # @param base_url [String] The base URL for the request

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -53,6 +53,13 @@ export abstract class AbstractRubyGeneratorContext<
         });
     }
 
+    public getModelClassReference(): ruby.ClassReference {
+        return ruby.classReference({
+            name: "Model",
+            modules: ["Internal", "Types"]
+        });
+    }
+
     public getTypesModule(): ruby.Module_ {
         return ruby.module({
             name: "Types",

--- a/generators/ruby-v2/model/src/object/ObjectGenerator.ts
+++ b/generators/ruby-v2/model/src/object/ObjectGenerator.ts
@@ -39,10 +39,7 @@ export class ObjectGenerator extends FileGenerator<RubyFile, ModelCustomConfigSc
 
         const classNode = ruby.class_({
             name: this.typeDeclaration.name.name.pascalCase.safeName,
-            superclass: ruby.classReference({
-                name: "Model",
-                modules: ["Internal", "Types"]
-            }),
+            superclass: this.context.getModelClassReference(),
             docstring: this.typeDeclaration.docs ?? undefined,
             statements: statements
         });

--- a/generators/ruby-v2/model/src/union/UnionGenerator.ts
+++ b/generators/ruby-v2/model/src/union/UnionGenerator.ts
@@ -37,6 +37,7 @@ export class UnionGenerator extends FileGenerator<RubyFile, ModelCustomConfigSch
     public doGenerate(): RubyFile {
         const classNode = ruby.class_({
             ...this.classReference,
+            superclass: this.context.getModelClassReference(),
             docstring: this.typeDeclaration.docs ?? undefined
         });
         classNode.addStatement(ruby.codeblock(`extend ${this.context.getRootModule().name}::Internal::Types::Union`));

--- a/generators/ruby-v2/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -32,10 +32,7 @@ export class WrappedRequestGenerator extends FileGenerator<RubyFile, SdkCustomCo
 
         const class_ = ruby.class_({
             name: this.wrapper.wrapperName.pascalCase.safeName,
-            superclass: ruby.classReference({
-                name: "Model",
-                modules: ["Internal", "Types"]
-            })
+            superclass: this.context.getModelClassReference()
         });
 
         for (const pathParameter of this.endpoint.allPathParameters) {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc9
+  createdAt: "2025-08-18"
+  changelogEntry:
+    - type: fix
+      summary: >-
+        Union types extend the Model class.
+  irVersion: 58
+
 - version: 1.0.0-rc8
   createdAt: "2025-08-18"
   changelogEntry:

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/client.rb
@@ -2,10 +2,8 @@
 module Seed
   module Endpoints
     class Client
-      # @option client [Seed::Internal::Http::RawClient]
-      #
       # @return [Seed::Endpoints::Client]
-      def initialize(client)
+      def initialize(client:)
         @client = client
       end
 

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/container/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/container/client.rb
@@ -3,16 +3,14 @@ module Seed
   module Endpoints
     module Container
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Container::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
         # @return [Array[String]]
         def get_and_return_list_of_primitives(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/list-of-primitives",
             body: params[:request],
@@ -27,7 +25,7 @@ module Seed
 
         # @return [Array[Seed::Types::Object_::Types::ObjectWithRequiredField]]
         def get_and_return_list_of_objects(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/list-of-objects",
             body: params[:request],
@@ -42,7 +40,7 @@ module Seed
 
         # @return [Array[String]]
         def get_and_return_set_of_primitives(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/set-of-primitives",
             body: params[:request],
@@ -57,7 +55,7 @@ module Seed
 
         # @return [Array[Seed::Types::Object_::Types::ObjectWithRequiredField]]
         def get_and_return_set_of_objects(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/set-of-objects",
             body: params[:request],
@@ -72,7 +70,7 @@ module Seed
 
         # @return [Hash[String, String]]
         def get_and_return_map_prim_to_prim(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/map-prim-to-prim",
             body: params[:request],
@@ -87,7 +85,7 @@ module Seed
 
         # @return [Hash[String, Seed::Types::Object_::Types::ObjectWithRequiredField]]
         def get_and_return_map_of_prim_to_object(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/map-prim-to-object",
             body: params[:request],
@@ -102,7 +100,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithRequiredField | nil]
         def get_and_return_optional(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/container/opt-objects",
             body: params[:request],

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/content_type/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/content_type/client.rb
@@ -3,16 +3,14 @@ module Seed
   module Endpoints
     module ContentType
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::ContentType::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
         # @return [untyped]
         def post_json_patch_content_type(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/foo/bar",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params[:request]).to_h,
@@ -27,7 +25,7 @@ module Seed
 
         # @return [untyped]
         def post_json_patch_content_with_charset_type(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/foo/baz",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params[:request]).to_h,

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/enum/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/enum/client.rb
@@ -3,16 +3,14 @@ module Seed
   module Endpoints
     module Enum
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Enum::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
         # @return [Seed::Types::Enum::Types::WeatherReport]
         def get_and_return_enum(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/enum",
             body: Seed::Types::Enum::Types::WeatherReport.new(params[:request]).to_h,

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/http_methods/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/http_methods/client.rb
@@ -3,10 +3,8 @@ module Seed
   module Endpoints
     module HttpMethods
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::HttpMethods::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
@@ -23,7 +21,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_post(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/http-methods",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params[:request]).to_h,
@@ -38,7 +36,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_put(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: PUT,
             path: "/http-methods/#{params[:id]}",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params[:request]).to_h,
@@ -53,7 +51,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_patch(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: PATCH,
             path: "/http-methods/#{params[:id]}",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params[:request]).to_h,

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/object/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/object/client.rb
@@ -3,16 +3,14 @@ module Seed
   module Endpoints
     module Object_
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Object_::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def get_and_return_with_optional_field(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/get-and-return-with-optional-field",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params[:request]).to_h,
@@ -27,7 +25,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithRequiredField]
         def get_and_return_with_required_field(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/get-and-return-with-required-field",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params[:request]).to_h,
@@ -42,7 +40,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithMapOfMap]
         def get_and_return_with_map_of_map(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/get-and-return-with-map-of-map",
             body: Seed::Types::Object_::Types::ObjectWithMapOfMap.new(params[:request]).to_h,
@@ -57,7 +55,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::NestedObjectWithOptionalField]
         def get_and_return_nested_with_optional_field(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/get-and-return-nested-with-optional-field",
             body: Seed::Types::Object_::Types::NestedObjectWithOptionalField.new(params[:request]).to_h,
@@ -72,7 +70,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::NestedObjectWithRequiredField]
         def get_and_return_nested_with_required_field(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/get-and-return-nested-with-required-field/#{params[:string]}",
             body: Seed::Types::Object_::Types::NestedObjectWithRequiredField.new(params[:request]).to_h,
@@ -87,7 +85,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::NestedObjectWithRequiredField]
         def get_and_return_nested_with_required_field_as_list(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/get-and-return-nested-with-required-field-list",
             body: params[:request],
@@ -102,7 +100,7 @@ module Seed
 
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_integer_overflow_edge_cases(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/object/test-integer-overflow-edge-cases",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params[:request]).to_h,

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/params/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/params/client.rb
@@ -3,10 +3,8 @@ module Seed
   module Endpoints
     module Params
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Params::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
@@ -92,7 +90,7 @@ module Seed
         #
         # @return [String]
         def modify_with_path(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: PUT,
             path: "/params/path/#{params[:param]}",
             body: params[:request],

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/primitive/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/primitive/client.rb
@@ -3,16 +3,14 @@ module Seed
   module Endpoints
     module Primitive
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Primitive::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
         # @return [String]
         def get_and_return_string(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/string",
             body: params[:request],
@@ -27,7 +25,7 @@ module Seed
 
         # @return [Integer]
         def get_and_return_int(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/integer",
             body: params[:request],
@@ -42,7 +40,7 @@ module Seed
 
         # @return [Integer]
         def get_and_return_long(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/long",
             body: params[:request],
@@ -57,7 +55,7 @@ module Seed
 
         # @return [Integer]
         def get_and_return_double(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/double",
             body: params[:request],
@@ -72,7 +70,7 @@ module Seed
 
         # @return [bool]
         def get_and_return_bool(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/boolean",
             body: params[:request],
@@ -87,7 +85,7 @@ module Seed
 
         # @return [String]
         def get_and_return_datetime(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/datetime",
             body: params[:request],
@@ -102,7 +100,7 @@ module Seed
 
         # @return [String]
         def get_and_return_date(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/date",
             body: params[:request],
@@ -117,7 +115,7 @@ module Seed
 
         # @return [String]
         def get_and_return_uuid(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/uuid",
             body: params[:request],
@@ -132,7 +130,7 @@ module Seed
 
         # @return [String]
         def get_and_return_base_64(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/primitive/base64",
             body: params[:request],

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/put/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/put/client.rb
@@ -3,10 +3,8 @@ module Seed
   module Endpoints
     module Put
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Put::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/union/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/union/client.rb
@@ -3,16 +3,14 @@ module Seed
   module Endpoints
     module Union
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Union::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 
         # @return [Seed::Types::Union::Types::Animal]
         def get_and_return_union(request_options: {}, **params)
-          _request = Seed::Internal::Http::JSONRequest.new(
+          _request = Seed::Internal::JSON::Request.new(
             method: POST,
             path: "/union",
             body: Seed::Types::Union::Types::Animal.new(params[:request]).to_h,

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/urls/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/urls/client.rb
@@ -3,10 +3,8 @@ module Seed
   module Endpoints
     module Urls
       class Client
-        # @option client [Seed::Internal::Http::RawClient]
-        #
         # @return [Seed::Endpoints::Urls::Client]
-        def initialize(client)
+        def initialize(client:)
           @client = client
         end
 

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/inlined_requests/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/inlined_requests/client.rb
@@ -2,10 +2,8 @@
 module Seed
   module InlinedRequests
     class Client
-      # @option client [Seed::Internal::Http::RawClient]
-      #
       # @return [Seed::InlinedRequests::Client]
-      def initialize(client)
+      def initialize(client:)
         @client = client
       end
 

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/internal/types/enum.rb
@@ -5,7 +5,7 @@ module Seed
     module Types
       # Module for defining enums
       module Enum
-        include Type
+        include Seed::Internal::Types::Type
 
         # @api private
         #

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/no_auth/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/no_auth/client.rb
@@ -2,10 +2,8 @@
 module Seed
   module NoAuth
     class Client
-      # @option client [Seed::Internal::Http::RawClient]
-      #
       # @return [Seed::NoAuth::Client]
-      def initialize(client)
+      def initialize(client:)
         @client = client
       end
 
@@ -13,7 +11,7 @@ module Seed
       #
       # @return [bool]
       def post_with_no_auth(request_options: {}, **params)
-        _request = Seed::Internal::Http::JSONRequest.new(
+        _request = Seed::Internal::JSON::Request.new(
           method: POST,
           path: "/no-auth",
           body: params[:request],

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/no_req_body/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/no_req_body/client.rb
@@ -2,10 +2,8 @@
 module Seed
   module NoReqBody
     class Client
-      # @option client [Seed::Internal::Http::RawClient]
-      #
       # @return [Seed::NoReqBody::Client]
-      def initialize(client)
+      def initialize(client:)
         @client = client
       end
 

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/req_with_headers/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/req_with_headers/client.rb
@@ -2,10 +2,8 @@
 module Seed
   module ReqWithHeaders
     class Client
-      # @option client [Seed::Internal::Http::RawClient]
-      #
       # @return [Seed::ReqWithHeaders::Client]
-      def initialize(client)
+      def initialize(client:)
         @client = client
       end
 

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/types/union/types/animal.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/types/union/types/animal.rb
@@ -4,7 +4,7 @@ module Seed
   module Types
     module Union
       module Types
-        class Animal
+        class Animal < Internal::Types::Model
           extend Seed::Internal::Types::Union
 
           discriminant :animal

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/json/request.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/json/request.rb
@@ -2,7 +2,7 @@
 
 module Seed
   module Internal
-    module JSON
+    module Multipart
       # @api private
       class Request < Seed::Internal::Http::BaseRequest
         attr_reader :body

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/enum.rb
@@ -5,7 +5,7 @@ module Seed
     module Types
       # Module for defining enums
       module Enum
-        include Type
+        include Seed::Internal::Types::Type
 
         # @api private
         #

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/model.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/model.rb
@@ -112,7 +112,7 @@ module Seed
             end
           end
 
-          def coerce(value, strict: (respond_to?(:strict?) ? strict? : false))
+          def coerce(value, strict: strict?)
             return value if value.is_a?(self)
 
             return value unless value.is_a?(::Hash)
@@ -169,12 +169,6 @@ module Seed
             value = @data[name]
 
             next if value.nil? && field.optional && !field.nullable
-
-            if value.is_a?(::Array)
-              value = value.map { |item| item.respond_to?(:to_h) ? item.to_h : item }
-            elsif value.respond_to?(:to_h)
-              value = value.to_h
-            end
 
             acc[field.api_name] = value
           end

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/union.rb
@@ -72,6 +72,8 @@ module Seed
             raise Errors::TypeError, "could not resolve to member of union #{self}"
           end
 
+          value = value.except(@discriminant) if type <= Model && value.is_a?(::Hash)
+
           Utils.coerce(type, value, strict: strict)
         end
       end


### PR DESCRIPTION
## Description
Union types should extend the Model class
Centralized class references to the Model class

## Testing
- [x] Manual testing completed

