### PR TITLE
feat(java): add addHeader() convenience method to SDK builders

### DIFF
--- a/generators/java-v2/sdk/features.yml
+++ b/generators/java-v2/sdk/features.yml
@@ -46,3 +46,8 @@ features:
     description: |
       The SDK defaults to a 60 second timeout. You can configure this with a timeout option at the client or request level.
 
+  - id: CUSTOM_HEADERS
+    advanced: true
+    description: |
+      The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -18,6 +18,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private static ENVIRONMENTS_FEATURE_ID: FernGeneratorCli.FeatureId = "ENVIRONMENTS";
     private static EXCEPTION_HANDLING_FEATURE_ID: FernGeneratorCli.FeatureId = "EXCEPTION_HANDLING";
     private static BASE_URL_FEATURE_ID: FernGeneratorCli.FeatureId = "BASE_URL";
+    private static CUSTOM_HEADERS_FEATURE_ID: FernGeneratorCli.FeatureId = "CUSTOM_HEADERS";
     private static SNIPPET_PACKAGE_NAME = "com.example.usage";
     private static ELLIPSES = java.codeblock("...");
 
@@ -80,6 +81,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             },
             [FernGeneratorCli.StructuredFeatureId.Retries]: { renderer: this.renderRetriesSnippet.bind(this) },
             [FernGeneratorCli.StructuredFeatureId.Timeouts]: { renderer: this.renderTimeoutsSnippet.bind(this) },
+            [ReadmeSnippetBuilder.CUSTOM_HEADERS_FEATURE_ID]: { renderer: this.renderCustomHeadersSnippet.bind(this) },
             ...(this.isPaginationEnabled
                 ? {
                       [FernGeneratorCli.StructuredFeatureId.Pagination]: {
@@ -326,6 +328,56 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         const snippet = java.codeblock((writer) => {
             writer.writeLine("// Client level");
             writer.writeNodeStatement(clientWithTimeout);
+            writer.newLine();
+            writer.writeLine("// Request level");
+            writer.writeNodeStatement(endpointMethodInvocation);
+        });
+
+        return this.renderSnippet(snippet);
+    }
+
+    private renderCustomHeadersSnippet(endpoint: EndpointWithFilepath): string {
+        const clientClassReference = this.context.getRootClientClassReference();
+
+        const clientInitialization = java.TypeLiteral.builder({
+            classReference: clientClassReference,
+            parameters: [
+                {
+                    name: "addHeader",
+                    value: java.TypeLiteral.raw(java.codeblock('"X-Custom-Header", "custom-value"'))
+                },
+                {
+                    name: "addHeader",
+                    value: java.TypeLiteral.raw(java.codeblock('"X-Request-Id", "abc-123"'))
+                }
+            ]
+        });
+
+        const clientWithHeaders = java.codeblock((writer) => {
+            writer.writeNode(clientClassReference);
+            writer.write(` ${this.rootPackageClientName} = `);
+            writer.writeNodeStatement(clientInitialization);
+        });
+
+        const requestOptionsClassReference = this.context.getRequestOptionsClassReference();
+        const requestOptionsInitialization = java.TypeLiteral.builder({
+            classReference: requestOptionsClassReference,
+            parameters: [
+                {
+                    name: "addHeader",
+                    value: java.TypeLiteral.raw(java.codeblock('"X-Request-Header", "request-value"'))
+                }
+            ]
+        });
+
+        const endpointMethodInvocation = this.getMethodCall(endpoint, [
+            ReadmeSnippetBuilder.ELLIPSES,
+            requestOptionsInitialization
+        ]);
+
+        const snippet = java.codeblock((writer) => {
+            writer.writeLine("// Client level");
+            writer.writeNodeStatement(clientWithHeaders);
             writer.newLine();
             writer.writeLine("// Request level");
             writer.writeNodeStatement(endpointMethodInvocation);

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -400,7 +400,6 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 .addStatement("setHttpClient(builder)")
                 .addStatement("setTimeouts(builder)")
                 .addStatement("setRetries(builder)")
-                .addComment("Apply user-added headers from addHeader() calls")
                 .beginControlFlow("for ($T.Entry<String, String> header : this.customHeaders.entrySet())", Map.class)
                 .addStatement("builder.addHeader(header.getKey(), header.getValue())")
                 .endControlFlow()

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -192,7 +192,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 .build());
 
         clientBuilder.addField(FieldSpec.builder(
-                        ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), ClassName.get(String.class)),
+                        ParameterizedTypeName.get(
+                                ClassName.get(Map.class), ClassName.get(String.class), ClassName.get(String.class)),
                         "customHeaders")
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                 .initializer("new $T<>()", HashMap.class)

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,12 @@
+- version: 2.41.3
+  changelogEntry:
+    - summary: |
+        Add convenient `addHeader()` method to SDK builders for adding custom headers without requiring
+        OkHttpClient customization or inheritance.
+      type: feat
+  createdAt: '2025-08-19'
+  irVersion: 58
+
 - version: 2.41.2
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/README.md
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.Best;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+Best client = Best
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/AsyncBestBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/AsyncBestBuilder.java
@@ -80,7 +80,6 @@ public class AsyncBestBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/AsyncBestBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/AsyncBestBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncBestBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncBestBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncBestBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncBestBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/BestBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/BestBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class BestBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class BestBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public BestBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class BestBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/BestBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/BestBuilder.java
@@ -80,7 +80,6 @@ public class BestBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/README.md
+++ b/seed/java-sdk/exhaustive/custom-dependency/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/README.md
+++ b/seed/java-sdk/exhaustive/custom-error-names/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/README.md
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/README.md
+++ b/seed/java-sdk/exhaustive/flat-package-layout/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/README.md
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/local-files/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/local-files/AsyncSeedExhaustiveClientBuilder.java
@@ -8,6 +8,8 @@ import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.Environment;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -15,6 +17,8 @@ public class AsyncSeedExhaustiveClientBuilder {
   private Optional<Integer> timeout = Optional.empty();
 
   private Optional<Integer> maxRetries = Optional.empty();
+
+  private final Map<String, String> customHeaders = new HashMap<>();
 
   private String token = null;
 
@@ -59,6 +63,19 @@ public class AsyncSeedExhaustiveClientBuilder {
     return this;
   }
 
+  /**
+   * Add a custom header to be sent with all requests.
+   * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+   *
+   * @param name The header name
+   * @param value The header value
+   * @return This builder for method chaining
+   */
+  public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+    this.customHeaders.put(name, value);
+    return this;
+  }
+
   protected ClientOptions buildClientOptions() {
     ClientOptions.Builder builder = ClientOptions.builder();
     setEnvironment(builder);
@@ -66,6 +83,10 @@ public class AsyncSeedExhaustiveClientBuilder {
     setHttpClient(builder);
     setTimeouts(builder);
     setRetries(builder);
+    // Apply user-added headers from addHeader() calls
+    for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+      builder.addHeader(header.getKey(), header.getValue());
+    }
     setAdditional(builder);
     return builder.build();
   }

--- a/seed/java-sdk/exhaustive/local-files/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/local-files/AsyncSeedExhaustiveClientBuilder.java
@@ -83,7 +83,6 @@ public class AsyncSeedExhaustiveClientBuilder {
     setHttpClient(builder);
     setTimeouts(builder);
     setRetries(builder);
-    // Apply user-added headers from addHeader() calls
     for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
       builder.addHeader(header.getKey(), header.getValue());
     }

--- a/seed/java-sdk/exhaustive/local-files/README.md
+++ b/seed/java-sdk/exhaustive/local-files/README.md
@@ -128,6 +128,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.fern.sdk.SeedExhaustiveClient;
+import com.fern.sdk.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/local-files/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/local-files/SeedExhaustiveClientBuilder.java
@@ -8,6 +8,8 @@ import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.Environment;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -15,6 +17,8 @@ public class SeedExhaustiveClientBuilder {
   private Optional<Integer> timeout = Optional.empty();
 
   private Optional<Integer> maxRetries = Optional.empty();
+
+  private final Map<String, String> customHeaders = new HashMap<>();
 
   private String token = null;
 
@@ -59,6 +63,19 @@ public class SeedExhaustiveClientBuilder {
     return this;
   }
 
+  /**
+   * Add a custom header to be sent with all requests.
+   * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+   *
+   * @param name The header name
+   * @param value The header value
+   * @return This builder for method chaining
+   */
+  public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+    this.customHeaders.put(name, value);
+    return this;
+  }
+
   protected ClientOptions buildClientOptions() {
     ClientOptions.Builder builder = ClientOptions.builder();
     setEnvironment(builder);
@@ -66,6 +83,10 @@ public class SeedExhaustiveClientBuilder {
     setHttpClient(builder);
     setTimeouts(builder);
     setRetries(builder);
+    // Apply user-added headers from addHeader() calls
+    for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+      builder.addHeader(header.getKey(), header.getValue());
+    }
     setAdditional(builder);
     return builder.build();
   }

--- a/seed/java-sdk/exhaustive/local-files/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/local-files/SeedExhaustiveClientBuilder.java
@@ -83,7 +83,6 @@ public class SeedExhaustiveClientBuilder {
     setHttpClient(builder);
     setTimeouts(builder);
     setRetries(builder);
-    // Apply user-added headers from addHeader() calls
     for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
       builder.addHeader(header.getKey(), header.getValue());
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/java-sdk/exhaustive/no-custom-config/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/publish-to/README.md
+++ b/seed/java-sdk/exhaustive/publish-to/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/signed_publish/README.md
+++ b/seed/java-sdk/exhaustive/signed_publish/README.md
@@ -153,6 +153,32 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.RequestOptions;
+
+// Client level
+SeedExhaustiveClient client = SeedExhaustiveClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.endpoints().container().getAndReturnListOfPrimitives(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncSeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class AsyncSeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncSeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/AsyncSeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class AsyncSeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.exhaustive;
 
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class SeedExhaustiveClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -56,6 +60,19 @@ public class SeedExhaustiveClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public SeedExhaustiveClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -63,6 +80,10 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/SeedExhaustiveClientBuilder.java
@@ -80,7 +80,6 @@ public class SeedExhaustiveClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/java-builder-extension/base-client/README.md
+++ b/seed/java-sdk/java-builder-extension/base-client/README.md
@@ -29,6 +29,10 @@ Add the dependency in your `pom.xml` file:
 </dependency>
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/java-sdk/java-builder-extension/base-client/README.md
+++ b/seed/java-sdk/java-builder-extension/base-client/README.md
@@ -161,6 +161,32 @@ client.service().hello(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.builderExtension.BaseClient;
+import com.seed.builderExtension.core.RequestOptions;
+
+// Client level
+BaseClient client = BaseClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.service().hello(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
@@ -85,7 +85,6 @@ public class AsyncBaseClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.builderExtension;
 
 import com.seed.builderExtension.core.ClientOptions;
 import com.seed.builderExtension.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class AsyncBaseClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -61,6 +65,19 @@ public class AsyncBaseClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public AsyncBaseClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -68,6 +85,10 @@ public class AsyncBaseClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
@@ -85,7 +85,6 @@ public class BaseClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.builderExtension;
 
 import com.seed.builderExtension.core.ClientOptions;
 import com.seed.builderExtension.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public class BaseClientBuilder {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -61,6 +65,19 @@ public class BaseClientBuilder {
         return this;
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public BaseClientBuilder addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -68,6 +85,10 @@ public class BaseClientBuilder {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/java-builder-extension/extensible-builders/README.md
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/README.md
@@ -29,6 +29,10 @@ Add the dependency in your `pom.xml` file:
 </dependency>
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/java-sdk/java-builder-extension/extensible-builders/README.md
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/README.md
@@ -161,6 +161,32 @@ client.service().hello(
 );
 ```
 
+### Custom Headers
+
+The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+```java
+import com.seed.builderExtension.BaseClient;
+import com.seed.builderExtension.core.RequestOptions;
+
+// Client level
+BaseClient client = BaseClient
+    .builder()
+    .addHeader("X-Custom-Header", "custom-value")
+    .addHeader("X-Request-Id", "abc-123")
+    .build();
+;
+
+// Request level
+client.service().hello(
+    ...,
+    RequestOptions
+        .builder()
+        .addHeader("X-Request-Header", "request-value")
+        .build()
+);
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
@@ -87,7 +87,6 @@ public abstract class AsyncBaseClientBuilder<T extends AsyncBaseClientBuilder<T>
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/AsyncBaseClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.builderExtension;
 
 import com.seed.builderExtension.core.ClientOptions;
 import com.seed.builderExtension.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public abstract class AsyncBaseClientBuilder<T extends AsyncBaseClientBuilder<T>
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -63,6 +67,19 @@ public abstract class AsyncBaseClientBuilder<T extends AsyncBaseClientBuilder<T>
         return self();
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public T addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return self();
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -70,6 +87,10 @@ public abstract class AsyncBaseClientBuilder<T extends AsyncBaseClientBuilder<T>
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
@@ -5,6 +5,8 @@ package com.seed.builderExtension;
 
 import com.seed.builderExtension.core.ClientOptions;
 import com.seed.builderExtension.core.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 
@@ -12,6 +14,8 @@ public abstract class BaseClientBuilder<T extends BaseClientBuilder<T>> {
     private Optional<Integer> timeout = Optional.empty();
 
     private Optional<Integer> maxRetries = Optional.empty();
+
+    private final Map<String, String> customHeaders = new HashMap<>();
 
     private String token = null;
 
@@ -63,6 +67,19 @@ public abstract class BaseClientBuilder<T extends BaseClientBuilder<T>> {
         return self();
     }
 
+    /**
+     * Add a custom header to be sent with all requests.
+     * For headers that need to be computed dynamically or conditionally, use the setAdditional() method override instead.
+     *
+     * @param name The header name
+     * @param value The header value
+     * @return This builder for method chaining
+     */
+    public T addHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+        return self();
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -70,6 +87,10 @@ public abstract class BaseClientBuilder<T extends BaseClientBuilder<T>> {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
+        // Apply user-added headers from addHeader() calls
+        for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
         setAdditional(builder);
         return builder.build();
     }

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/BaseClientBuilder.java
@@ -87,7 +87,6 @@ public abstract class BaseClientBuilder<T extends BaseClientBuilder<T>> {
         setHttpClient(builder);
         setTimeouts(builder);
         setRetries(builder);
-        // Apply user-added headers from addHeader() calls
         for (Map.Entry<String, String> header : this.customHeaders.entrySet()) {
             builder.addHeader(header.getKey(), header.getValue());
         }


### PR DESCRIPTION
## Description
Adds a convenience method for adding custom headers directly on Java SDK client builders, eliminating theneed for OkHttpClient customization or inheritance for simple header additions. Also added to the readme for java in the section that contains other related fields like timeout, retries, etc. 

## Changes Made
  - Added `customHeaders` field to store user-defined headers in the builder
  - Implemented `addHeader(String name, String value)` public method for easy header addition

  ## Testing
  - [x] Seed tests pass for java-builder-extension and exhaustive fixtures
  - [x] Generated code includes the new addHeader() method
  - [x] Headers are properly applied in buildClientOptions()

  ## Customer Impact
  
  **Before:** Required OkHttpClient customization or builder inheritance
  ```java
  OkHttpClient customClient = new OkHttpClient.Builder()
      .addInterceptor(chain -> {
          Request request = chain.request().newBuilder()
              .addHeader("X-Custom", "value")
              .build();
          return chain.proceed(request);
      })
      .build();
  Client client = Client.builder().httpClient(customClient).build();

  //After: Direct header addition on the builder
  Client client = Client.builder()
      .token("api-token")
      .addHeader("X-Custom", "value")
      .addHeader("X-Tenant-Id", "tenant-123")
      .build();