### PR TITLE
fix(java): PATCH endpoints with merge-patch now accept both content types

### DIFF
--- a/generators/java/spring/src/main/java/com/fern/java/spring/generators/spring/SpringHttpMethodToAnnotationSpec.java
+++ b/generators/java/spring/src/main/java/com/fern/java/spring/generators/spring/SpringHttpMethodToAnnotationSpec.java
@@ -46,7 +46,6 @@ public final class SpringHttpMethodToAnnotationSpec implements HttpMethod.Visito
     }
 
     private String[] determineConsumesTypes(HttpRequestBody requestBody, HttpMethod method) {
-        // Check if this is a merge-patch request
         boolean isMergePatch = requestBody.visit(new HttpRequestBody.Visitor<Boolean>() {
             @Override
             public Boolean visitInlinedRequestBody(InlinedRequestBody inlinedRequestBody) {
@@ -80,12 +79,10 @@ public final class SpringHttpMethodToAnnotationSpec implements HttpMethod.Visito
             }
         });
 
-        // For PATCH methods with merge-patch content type, accept both standard JSON and merge-patch
         if (isMergePatch && method.visit(new IsPatchMethodVisitor())) {
             return new String[] {"application/json", "application/merge-patch+json"};
         }
 
-        // Default to standard JSON
         return new String[] {"application/json"};
     }
 
@@ -170,7 +167,6 @@ public final class SpringHttpMethodToAnnotationSpec implements HttpMethod.Visito
             if (consumesArray.length == 1) {
                 annotationSpecBuilder.addMember("consumes", "$S", consumesArray[0]);
             } else {
-                // Multiple content types - use array notation
                 annotationSpecBuilder.addMember(
                         "consumes",
                         "{$L}",

--- a/generators/java/spring/src/main/java/com/fern/java/spring/generators/spring/SpringHttpMethodToAnnotationSpec.java
+++ b/generators/java/spring/src/main/java/com/fern/java/spring/generators/spring/SpringHttpMethodToAnnotationSpec.java
@@ -15,8 +15,13 @@
  */
 package com.fern.java.spring.generators.spring;
 
+import com.fern.ir.model.http.BytesRequest;
+import com.fern.ir.model.http.FileUploadRequest;
 import com.fern.ir.model.http.HttpEndpoint;
 import com.fern.ir.model.http.HttpMethod;
+import com.fern.ir.model.http.HttpRequestBody;
+import com.fern.ir.model.http.HttpRequestBodyReference;
+import com.fern.ir.model.http.InlinedRequestBody;
 import com.fern.java.utils.HttpPathUtils;
 import com.squareup.javapoet.AnnotationSpec;
 import java.util.Optional;
@@ -29,13 +34,96 @@ import org.springframework.web.bind.annotation.PutMapping;
 public final class SpringHttpMethodToAnnotationSpec implements HttpMethod.Visitor<AnnotationSpec> {
 
     private final String path;
-    private final Optional<String> consumes;
+    private final Optional<String[]> consumes;
     private final Optional<String> produces;
+    private final HttpMethod httpMethod;
 
     public SpringHttpMethodToAnnotationSpec(HttpEndpoint httpEndpoint) {
         this.path = HttpPathUtils.getPathWithCurlyBracedPathParams(httpEndpoint.getPath());
-        this.consumes = httpEndpoint.getRequestBody().map(_body -> "application/json");
+        this.httpMethod = httpEndpoint.getMethod();
+        this.consumes = httpEndpoint.getRequestBody().map(body -> determineConsumesTypes(body, httpMethod));
         this.produces = httpEndpoint.getResponse().map(_body -> "application/json");
+    }
+
+    private String[] determineConsumesTypes(HttpRequestBody requestBody, HttpMethod method) {
+        // Check if this is a merge-patch request
+        boolean isMergePatch = requestBody.visit(new HttpRequestBody.Visitor<Boolean>() {
+            @Override
+            public Boolean visitInlinedRequestBody(InlinedRequestBody inlinedRequestBody) {
+                return inlinedRequestBody
+                        .getContentType()
+                        .map(ct -> ct.equals("application/merge-patch+json"))
+                        .orElse(false);
+            }
+
+            @Override
+            public Boolean visitReference(HttpRequestBodyReference reference) {
+                return reference
+                        .getContentType()
+                        .map(ct -> ct.equals("application/merge-patch+json"))
+                        .orElse(false);
+            }
+
+            @Override
+            public Boolean visitFileUpload(FileUploadRequest fileUpload) {
+                return false;
+            }
+
+            @Override
+            public Boolean visitBytes(BytesRequest bytes) {
+                return false;
+            }
+
+            @Override
+            public Boolean _visitUnknown(Object unknownType) {
+                return false;
+            }
+        });
+
+        // For PATCH methods with merge-patch content type, accept both standard JSON and merge-patch
+        if (isMergePatch && method.visit(new IsPatchMethodVisitor())) {
+            return new String[] {"application/json", "application/merge-patch+json"};
+        }
+
+        // Default to standard JSON
+        return new String[] {"application/json"};
+    }
+
+    private static class IsPatchMethodVisitor implements HttpMethod.Visitor<Boolean> {
+        @Override
+        public Boolean visitGet() {
+            return false;
+        }
+
+        @Override
+        public Boolean visitPost() {
+            return false;
+        }
+
+        @Override
+        public Boolean visitPut() {
+            return false;
+        }
+
+        @Override
+        public Boolean visitDelete() {
+            return false;
+        }
+
+        @Override
+        public Boolean visitPatch() {
+            return true;
+        }
+
+        @Override
+        public Boolean visitHead() {
+            return false;
+        }
+
+        @Override
+        public Boolean visitUnknown(String unknownType) {
+            return false;
+        }
     }
 
     @Override
@@ -78,7 +166,20 @@ public final class SpringHttpMethodToAnnotationSpec implements HttpMethod.Visito
             annotationSpecBuilder.addMember("produces", "$S", produces.get());
         }
         if (consumes.isPresent()) {
-            annotationSpecBuilder.addMember("consumes", "$S", consumes.get());
+            String[] consumesArray = consumes.get();
+            if (consumesArray.length == 1) {
+                annotationSpecBuilder.addMember("consumes", "$S", consumesArray[0]);
+            } else {
+                // Multiple content types - use array notation
+                annotationSpecBuilder.addMember(
+                        "consumes",
+                        "{$L}",
+                        String.join(
+                                ", ",
+                                java.util.Arrays.stream(consumesArray)
+                                        .map(ct -> "\"" + ct + "\"")
+                                        .toArray(String[]::new)));
+            }
         }
         return annotationSpecBuilder.build();
     }

--- a/generators/java/spring/versions.yml
+++ b/generators/java/spring/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix PATCH endpoints with merge-patch content type to accept both application/json 
+        and application/merge-patch+json for backward compatibility.
+      type: fix
+  createdAt: '2025-08-20'
+  irVersion: 58
+  version: 1.7.5
+- changelogEntry:
+    - summary: |
         Fix NPE in merge-patch requests with optional fields. Optional fields in builders 
         are now initialized to Optional.empty() and JsonSetter annotations include 
         nulls=SKIP to properly handle absent and null values in JSON payloads.

--- a/seed/java-spring/content-type/package-prefix/resources/service/ServiceService.java
+++ b/seed/java-spring/content-type/package-prefix/resources/service/ServiceService.java
@@ -22,28 +22,28 @@ public interface ServiceService {
   @PatchMapping(
       value = "/",
       produces = "application/json",
-      consumes = "application/json"
+      consumes = {"application/json", "application/merge-patch+json"}
   )
   void patch(@RequestBody PatchProxyRequest body);
 
   @PatchMapping(
       value = "/complex/{id}",
       produces = "application/json",
-      consumes = "application/json"
+      consumes = {"application/json", "application/merge-patch+json"}
   )
   void patchComplex(@PathVariable("id") String id, @RequestBody PatchComplexRequest body);
 
   @PatchMapping(
       value = "/named-mixed/{id}",
       produces = "application/json",
-      consumes = "application/json"
+      consumes = {"application/json", "application/merge-patch+json"}
   )
   void namedPatchWithMixed(@PathVariable("id") String id, @RequestBody NamedMixedPatchRequest body);
 
   @PatchMapping(
       value = "/optional-merge-patch-test",
       produces = "application/json",
-      consumes = "application/json"
+      consumes = {"application/json", "application/merge-patch+json"}
   )
   void optionalMergePatchTest(@RequestBody OptionalMergePatchRequest body);
 


### PR DESCRIPTION
## Description:

Fix backward compatibility issue where PATCH endpoints configured with `application/merge-patch+json` content type were rejecting standard `application/json` requests, causing production errors.

PATCH endpoints with merge-patch content type now accept both:
- `application/json` (for backward compatibility)
- `application/merge-patch+json` (for RFC 7396 compliance)

**Regular PATCH endpoints** without merge-patch remain unchanged and continue to accept only `application/json`.

This ensures existing SDK clients using `application/json` continue to work while allowing new clients to use the proper merge-patch content type.