### PR TITLE
chore(cli): added support for api keys in query params

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -1,6 +1,6 @@
+import { assertNever } from "@fern-api/core-utils";
 import { EnumSchema, SecurityScheme, Source } from "@fern-api/openapi-ir";
 import { OpenAPIV3 } from "openapi-types";
-
 import { getExtension } from "../../../getExtension";
 import { convertEnum } from "../../../schema/convertEnum";
 import { convertSchemaWithExampleToSchema } from "../../../schema/utils/convertSchemaWithExampleToSchema";
@@ -13,7 +13,6 @@ import {
     HeaderSecuritySchemeNames,
     SecuritySchemeNames
 } from "../extensions/getSecuritySchemeNameAndEnvvars";
-import { assertNever } from "@fern-api/core-utils";
 
 export function convertSecurityScheme(
     securityScheme: OpenAPIV3.SecuritySchemeObject | OpenAPIV3.ReferenceObject,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -28,19 +28,27 @@ function convertSecuritySchemeHelper(
     securityScheme: OpenAPIV3.SecuritySchemeObject,
     source: Source
 ): SecurityScheme | undefined {
-    if (securityScheme.type === "apiKey" && securityScheme.in === "header") {
-        const bearerFormat = getExtension<string>(securityScheme, OpenAPIExtension.BEARER_FORMAT);
-        const headerNames = getExtension<HeaderSecuritySchemeNames>(
-            securityScheme,
-            FernOpenAPIExtension.FERN_HEADER_AUTH
-        );
-        return SecurityScheme.header({
-            headerName: securityScheme.name,
-            prefix: bearerFormat != null ? "Bearer" : headerNames?.prefix,
-            headerVariableName:
-                headerNames?.name ?? getExtension<string>(securityScheme, FernOpenAPIExtension.HEADER_VARIABLE_NAME),
-            headerEnvVar: headerNames?.env
-        });
+    if (securityScheme.type === "apiKey") {
+        if (securityScheme.in === "header") {
+            const bearerFormat = getExtension<string>(securityScheme, OpenAPIExtension.BEARER_FORMAT);
+            const headerNames = getExtension<HeaderSecuritySchemeNames>(
+                securityScheme,
+                FernOpenAPIExtension.FERN_HEADER_AUTH
+            );
+            return SecurityScheme.header({
+                headerName: securityScheme.name,
+                prefix: bearerFormat != null ? "Bearer" : headerNames?.prefix,
+                headerVariableName:
+                    headerNames?.name ?? getExtension<string>(securityScheme, FernOpenAPIExtension.HEADER_VARIABLE_NAME),
+                headerEnvVar: headerNames?.env
+            });
+        } else if (securityScheme.in === "query") {
+            // Handle API key in query parameter
+            // Optionally, you could add support for FernOpenAPIExtension for query param naming/envvar in the future
+            return SecurityScheme.query({
+                queryParameterName: securityScheme.name
+            });
+        }
     } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "bearer") {
         // ^ case insensitivity for securityScheme.scheme required in OAS
         const bearerNames = getExtension<SecuritySchemeNames>(securityScheme, FernOpenAPIExtension.FERN_BEARER_TOKEN);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -80,7 +80,7 @@ function convertSecuritySchemeHelper(
                 passwordEnvVar: basicSecuritySchemeNamingAndEnvvar?.password?.env
             });
         } else {
-            throw new Error(`Unsupported HTTP scheme: ${securityScheme.scheme}`);
+            throw new Error(`Unsupported HTTP scheme - ${key}: ${securityScheme.scheme}`);
         }
     } else if (securityScheme.type === "openIdConnect") {
         return SecurityScheme.bearer({

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -13,21 +13,24 @@ import {
     HeaderSecuritySchemeNames,
     SecuritySchemeNames
 } from "../extensions/getSecuritySchemeNameAndEnvvars";
+import { assertNever } from "@fern-api/core-utils";
 
 export function convertSecurityScheme(
     securityScheme: OpenAPIV3.SecuritySchemeObject | OpenAPIV3.ReferenceObject,
-    source: Source
-): SecurityScheme | undefined {
+    source: Source,
+    key: string
+): SecurityScheme {
     if (isReferenceObject(securityScheme)) {
         throw new Error(`Converting referenced security schemes is unsupported: ${JSON.stringify(securityScheme)}`);
     }
-    return convertSecuritySchemeHelper(securityScheme, source);
+    return convertSecuritySchemeHelper(securityScheme, source, key);
 }
 
 function convertSecuritySchemeHelper(
     securityScheme: OpenAPIV3.SecuritySchemeObject,
-    source: Source
-): SecurityScheme | undefined {
+    source: Source,
+    key: string
+): SecurityScheme {
     if (securityScheme.type === "apiKey") {
         if (securityScheme.in === "header") {
             const bearerFormat = getExtension<string>(securityScheme, OpenAPIExtension.BEARER_FORMAT);
@@ -39,7 +42,8 @@ function convertSecuritySchemeHelper(
                 headerName: securityScheme.name,
                 prefix: bearerFormat != null ? "Bearer" : headerNames?.prefix,
                 headerVariableName:
-                    headerNames?.name ?? getExtension<string>(securityScheme, FernOpenAPIExtension.HEADER_VARIABLE_NAME),
+                    headerNames?.name ??
+                    getExtension<string>(securityScheme, FernOpenAPIExtension.HEADER_VARIABLE_NAME),
                 headerEnvVar: headerNames?.env
             });
         } else if (securityScheme.in === "query") {
@@ -48,28 +52,37 @@ function convertSecuritySchemeHelper(
             return SecurityScheme.query({
                 queryParameterName: securityScheme.name
             });
+        } else {
+            throw new Error(`Unsupported API key location ${key}: ${securityScheme.in}`);
         }
-    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "bearer") {
-        // ^ case insensitivity for securityScheme.scheme required in OAS
-        const bearerNames = getExtension<SecuritySchemeNames>(securityScheme, FernOpenAPIExtension.FERN_BEARER_TOKEN);
-        return SecurityScheme.bearer({
-            tokenVariableName:
-                bearerNames?.name ??
-                getExtension<string>(securityScheme, FernOpenAPIExtension.BEARER_TOKEN_VARIABLE_NAME),
-            tokenEnvVar: bearerNames?.env
-        });
-    } else if (securityScheme.type === "http" && securityScheme.scheme?.toLowerCase() === "basic") {
-        // ^ case insensitivity for securityScheme.scheme required in OAS
-        const basicSecuritySchemeNamingAndEnvvar = getBasicSecuritySchemeNameAndEnvvar(securityScheme);
-        const basicSecuritySchemeNaming = getBasicSecuritySchemeNames(securityScheme);
-        return SecurityScheme.basic({
-            usernameVariableName:
-                basicSecuritySchemeNamingAndEnvvar?.username?.name ?? basicSecuritySchemeNaming.usernameVariable,
-            usernameEnvVar: basicSecuritySchemeNamingAndEnvvar?.username?.env,
-            passwordVariableName:
-                basicSecuritySchemeNamingAndEnvvar?.password?.name ?? basicSecuritySchemeNaming.passwordVariable,
-            passwordEnvVar: basicSecuritySchemeNamingAndEnvvar?.password?.env
-        });
+    } else if (securityScheme.type === "http") {
+        if (securityScheme.scheme?.toLowerCase() === "bearer") {
+            // ^ case insensitivity for securityScheme.scheme required in OAS
+            const bearerNames = getExtension<SecuritySchemeNames>(
+                securityScheme,
+                FernOpenAPIExtension.FERN_BEARER_TOKEN
+            );
+            return SecurityScheme.bearer({
+                tokenVariableName:
+                    bearerNames?.name ??
+                    getExtension<string>(securityScheme, FernOpenAPIExtension.BEARER_TOKEN_VARIABLE_NAME),
+                tokenEnvVar: bearerNames?.env
+            });
+        } else if (securityScheme.scheme?.toLowerCase() === "basic") {
+            // ^ case insensitivity for securityScheme.scheme required in OAS
+            const basicSecuritySchemeNamingAndEnvvar = getBasicSecuritySchemeNameAndEnvvar(securityScheme);
+            const basicSecuritySchemeNaming = getBasicSecuritySchemeNames(securityScheme);
+            return SecurityScheme.basic({
+                usernameVariableName:
+                    basicSecuritySchemeNamingAndEnvvar?.username?.name ?? basicSecuritySchemeNaming.usernameVariable,
+                usernameEnvVar: basicSecuritySchemeNamingAndEnvvar?.username?.env,
+                passwordVariableName:
+                    basicSecuritySchemeNamingAndEnvvar?.password?.name ?? basicSecuritySchemeNaming.passwordVariable,
+                passwordEnvVar: basicSecuritySchemeNamingAndEnvvar?.password?.env
+            });
+        } else {
+            throw new Error(`Unsupported HTTP scheme: ${securityScheme.scheme}`);
+        }
     } else if (securityScheme.type === "openIdConnect") {
         return SecurityScheme.bearer({
             tokenVariableName: undefined,
@@ -79,8 +92,9 @@ function convertSecuritySchemeHelper(
         return SecurityScheme.oauth({
             scopesEnum: getScopes(securityScheme, source)
         });
+    } else {
+        assertNever(securityScheme);
     }
-    return undefined;
 }
 
 function getScopes(oauthSecurityScheme: OpenAPIV3.OAuth2SecurityScheme, source: Source): EnumSchema | undefined {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -68,6 +68,9 @@ export function generateIr({
     const securitySchemes: Record<string, SecurityScheme> = Object.fromEntries(
         Object.entries(openApi.components?.securitySchemes ?? {}).map(([key, securityScheme]) => {
             const convertedSecurityScheme = convertSecurityScheme(securityScheme, source);
+            if (convertedSecurityScheme == undefined) {
+                throw new Error(`Security scheme conversion failed for ${key}: ${JSON.stringify(securityScheme)}`);
+            }
             if (convertedSecurityScheme == null) {
                 return [];
             }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -67,14 +67,7 @@ export function generateIr({
 
     const securitySchemes: Record<string, SecurityScheme> = Object.fromEntries(
         Object.entries(openApi.components?.securitySchemes ?? {}).map(([key, securityScheme]) => {
-            const convertedSecurityScheme = convertSecurityScheme(securityScheme, source);
-            if (convertedSecurityScheme == undefined) {
-                throw new Error(`Security scheme conversion failed for ${key}: ${JSON.stringify(securityScheme)}`);
-            }
-            if (convertedSecurityScheme == null) {
-                return [];
-            }
-            return [key, convertSecurityScheme(securityScheme, source)];
+            return [key, convertSecurityScheme(securityScheme, source, key)];
         })
     );
     const authHeaders = new Set(

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: |
+        - added support for API keys in query params.
+        - improved error message around converting security schemas
+      type: chore
+  irVersion: 59
+  createdAt: "2025-08-20"
+  version: 0.66.20
+
+- changelogEntry:
     - summary: Handle multipart/mixed content types in endpoint responses.
       type: chore
   irVersion: 59


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
A client introduced a new security schema:
```
components:
 securitySchemes:
    APIKeyQueryParam:
      type: apiKey
      name: apiKey
      in: query
```
However, we didn't support this and the error thrown wasn't clear. 
      
## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added support for api keys in query param
- Added an improved error logging for when we fail to convert securitySchemas

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed

