### PR TITLE
fix(ruby): v2 - Parameterless endpoint methods send valid request types to raw client

### DIFF
--- a/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
@@ -146,6 +146,14 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
         });
     }
 
+    public getDefaultEnvironmentClassReference(): ruby.ClassReference {
+        const defaultEnvironmentName = this.ir.environments?.defaultEnvironment ?? "SANDBOX";
+        return ruby.classReference({
+            name: defaultEnvironmentName,
+            modules: [this.getRootModule().name, "Environment"]
+        });
+    }
+
     public getRootClientClassName(): string {
         return `Client`;
     }

--- a/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
@@ -90,7 +90,21 @@ export class RawClient {
                     writer.write(`)`);
                 });
         }
-        return undefined;
+        return ruby.codeblock((writer) => {
+            writer.writeLine(
+                `${RAW_CLIENT_REQUEST_VARIABLE_NAME} = ${this.context.getReferenceToInternalJSONRequest()}.new(`
+            );
+            writer.indent();
+            writer.writeLine(
+                `base_url: request_options[:base_url] || ${this.context.getEnvironmentsClassReference().toString()}::SANDBOX,`
+            );
+            writer.writeLine(`method: "${endpoint.method.toUpperCase()}",`);
+            writer.write(`path: `);
+            this.writePathString({ writer, endpoint, pathParameterReferences: {} });
+            writer.newLine();
+            writer.dedent();
+            writer.write(`)`);
+        });
     }
 
     private writePathString({

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc14
+  createdAt: "2025-08-20"
+  changelogEntry:
+    - type: fix
+      summary: >-
+        Fix parameterless endpoint methods.
+  irVersion: 58
+
 - version: 1.0.0-rc13
   createdAt: "2025-08-20"
   changelogEntry:


### PR DESCRIPTION
## Description
Parameterless endpoint methods send valid request types to raw client

