### PR TITLE
fix(ci): add minimal compile step for root workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ env:
   TURBO_TEAM: "buildwithfern"
 
 jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Compile
+        run: pnpm compile
+
   depcheck:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
Based on this [github community post](https://github.com/orgs/community/discussions/26698#discussioncomment-3252947) for a status check to be required before merge it must **EXIST** and be passing.

So in order to require a `compile` status check to pass for the existing `<language>-generator.yml` workflows we need to add it to the base `ci.yml` workflow as well so that it doesn't hang indefinitely.

## Changes Made
- Add perfunctory `pnpm compile` step


## Testing
- See that the new PR now passes with `compile` enabled in "Require status checks to pass before merging" section

