### PR TITLE
fix(seed): Fix seed run configuration pulled from generators.yml

### DIFF
--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -39,10 +39,6 @@ export async function runWithCustomFixture({
     const taskContext = taskContextFactory.create(
         `${workspace.workspaceName}:${"custom"} - ${customFixtureConfig?.outputFolder ?? ""}`
     );
-    console.log(
-        `Running custom fixture for ${workspace.workspaceName} with config:`,
-        JSON.stringify(customFixtureConfig)
-    );
 
     let testRunner: TestRunner;
     let scriptRunner: ScriptRunner;
@@ -106,10 +102,17 @@ export async function runWithCustomFixture({
         }
 
         const runFixtureConfig: FixtureConfigurations = {
-            customConfig: generatorGroup.config,
-            outputFolder: "",
-            ...customFixtureConfig
+            ...customFixtureConfig,
+            customConfig: {
+                ...(customFixtureConfig?.customConfig as Record<string, unknown>),
+                ...(generatorGroup.invocation.config as Record<string, unknown>)
+            },
+            outputFolder: ""
         };
+        console.log(
+            `Running custom fixture for ${workspace.workspaceName} with config:`,
+            JSON.stringify(runFixtureConfig)
+        );
 
         await testRunner.build();
 
@@ -147,7 +150,7 @@ function getGeneratorGroup({
     image: string;
     imageAliases?: string[];
     absolutePathToOutput: AbsoluteFilePath;
-}): { group: GeneratorGroup; invocation: GeneratorInvocation; config: object } | undefined {
+}): { group: GeneratorGroup; invocation: GeneratorInvocation } | undefined {
     const groups = apiWorkspace.generatorsConfiguration?.groups;
     for (const group of groups ?? []) {
         for (const generator of group.generators) {
@@ -162,8 +165,7 @@ function getGeneratorGroup({
                         ...group,
                         generators: [invocation]
                     },
-                    invocation,
-                    config: generator.config as object
+                    invocation
                 };
             }
         }

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -141,10 +141,11 @@ export abstract class TestRunner {
             const customConfig =
                 this.generator.workspaceConfig.defaultCustomConfig != null || configuration?.customConfig != null
                     ? {
-                          ...(this.generator.workspaceConfig.defaultCustomConfig ?? {}),
-                          ...((configuration?.customConfig as Record<string, unknown>) ?? {})
+                          ...this.generator.workspaceConfig.defaultCustomConfig,
+                          ...(configuration?.customConfig as Record<string, unknown>)
                       }
                     : undefined;
+            console.log("customConfig", customConfig);
             const publishConfig = configuration?.publishConfig;
             const outputMode = configuration?.outputMode ?? this.generator.workspaceConfig.defaultOutputMode;
             const irVersion = this.generator.workspaceConfig.irVersion;
@@ -224,7 +225,11 @@ export abstract class TestRunner {
             const scriptStopwatch = new Stopwatch();
             scriptStopwatch.start();
 
-            const scriptResponse = await this.scriptRunner.run({ taskContext, outputDir, id });
+            const scriptResponse = await this.scriptRunner.run({
+                taskContext,
+                outputDir,
+                id
+            });
 
             scriptStopwatch.stop();
             metrics.compileTime = scriptStopwatch.duration();

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -29,9 +29,7 @@ generatorType: SDK
 defaultOutputMode: github
 
 customFixtureConfig:
-  customConfig:
-    generateWireTests: true
-    noSerdeLayer: true
+  customConfig: {}
 fixtures:
   imdb:
     - customConfig: null


### PR DESCRIPTION
## Description
The configuration from generators.yml would be ignore because it was being overwritten by the configuration in seed.yml.
Now they are being merged, with generators.yml overwriting matching keys from seed.yml.


## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

