### PR TITLE
feat(cli): introduce inline-all-of-schema setting in openapi

### DIFF
--- a/fern/apis/generators-yml/definition/generators.yml
+++ b/fern/apis/generators-yml/definition/generators.yml
@@ -301,6 +301,12 @@ types:
           If false, unwrap oneOf structures with a single schema.
           Defaults to false.
         default: false
+      inline-all-of-schemas: 
+        type: optional<boolean>
+        docs: | 
+          Whether to inline allOf schemas. If false, allOf schemas will be 
+          extended in the code generation.
+        default: false
 
   FormParameterEncoding:
     enum:

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -1678,6 +1678,16 @@
               "type": "null"
             }
           ]
+        },
+        "inline-all-of-schemas": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
@@ -38,6 +38,8 @@ export interface ParseOpenAPIOptions {
     useBytesForBinaryResponse: boolean;
     /* Whether or not to respect forward compatible enums in OpenAPI specifications. */
     respectForwardCompatibleEnums: boolean;
+    /* Whether or not to inline allOf schemas. */
+    inlineAllOfSchemas: boolean;
 
     /* The filter to apply to the OpenAPI document. */
     filter: generatorsYml.OpenApiFilterSchema | undefined;
@@ -88,7 +90,8 @@ export const DEFAULT_PARSE_OPENAPI_SETTINGS: ParseOpenAPIOptions = {
     respectForwardCompatibleEnums: false,
     additionalPropertiesDefaultsTo: false,
     typeDatesAsStrings: true,
-    preserveSingleSchemaOneOf: false
+    preserveSingleSchemaOneOf: false,
+    inlineAllOfSchemas: false
 };
 
 export function getParseOptions({
@@ -169,6 +172,10 @@ export function getParseOptions({
         preserveSingleSchemaOneOf:
             overrides?.preserveSingleSchemaOneOf ??
             options?.preserveSingleSchemaOneOf ??
-            DEFAULT_PARSE_OPENAPI_SETTINGS.preserveSingleSchemaOneOf
+            DEFAULT_PARSE_OPENAPI_SETTINGS.preserveSingleSchemaOneOf,
+        inlineAllOfSchemas:
+            overrides?.inlineAllOfSchemas ??
+            options?.inlineAllOfSchemas ??
+            DEFAULT_PARSE_OPENAPI_SETTINGS.inlineAllOfSchemas
     };
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
@@ -73,7 +73,6 @@ export function convertObject({
     let inlinedParentProperties: ObjectPropertyWithExample[] = [];
     const parents: ReferencedAllOfInfo[] = [];
 
-
     for (const allOfElement of allOf) {
         if (!context.options.inlineAllOfSchemas && isReferenceObject(allOfElement)) {
             // if allOf element is a discriminated union, then don't inherit from it

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
@@ -70,10 +70,12 @@ export function convertObject({
 }): SchemaWithExample {
     const allRequired = [...(required ?? [])];
     const propertiesToConvert = { ...properties };
-    const inlinedParentProperties: ObjectPropertyWithExample[] = [];
+    let inlinedParentProperties: ObjectPropertyWithExample[] = [];
     const parents: ReferencedAllOfInfo[] = [];
+
+
     for (const allOfElement of allOf) {
-        if (isReferenceObject(allOfElement)) {
+        if (!context.options.inlineAllOfSchemas && isReferenceObject(allOfElement)) {
             // if allOf element is a discriminated union, then don't inherit from it
             const resolvedReference = context.resolveSchemaReference(allOfElement);
             if (resolvedReference.discriminator != null && resolvedReference.discriminator.mapping != null) {
@@ -141,7 +143,26 @@ export function convertObject({
                 properties: getAllProperties({ schema: allOfElement, context, breadcrumbs, source, namespace })
             });
             context.markSchemaAsReferencedByNonRequest(schemaId);
+        } else if (isReferenceObject(allOfElement)) {
+            const resolvedReference = context.resolveSchemaReference(allOfElement);
+            const convertedSchema = convertSchema(resolvedReference, false, context, breadcrumbs, source, namespace);
+            if (convertedSchema.type === "object") {
+                inlinedParentProperties.push(...convertedSchema.properties);
+            }
         } else {
+            const required = allOfElement.required ?? [];
+            inlinedParentProperties = inlinedParentProperties.map((property) => {
+                if (
+                    (property.schema.type === "optional" || property.schema.type === "nullable") &&
+                    required.includes(property.key)
+                ) {
+                    return {
+                        ...property,
+                        schema: property.schema.value
+                    };
+                }
+                return property;
+            });
             const allOfSchema = convertSchema(allOfElement, false, context, breadcrumbs, source, namespace);
             if (allOfSchema.type === "object") {
                 inlinedParentProperties.push(...allOfSchema.properties);

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/inline-allof-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/inline-allof-schemas.json
@@ -1,0 +1,69 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "Base": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "description": "optional<string>",
+              "id": "string",
+              "name": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ChildMakesDescriptionRequired": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "description": "string",
+              "id": "string",
+              "name": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  Base:
+    properties:
+      id: string
+      name: string
+      description: optional<string>
+    source:
+      openapi: ../openapi.yml
+  ChildMakesDescriptionRequired:
+    properties:
+      id: string
+      name: string
+      description: string
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Inline allOf schemas with required property overrides",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Inline allOf schemas with required property overrides
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/ada.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/ada.json
@@ -1180,6 +1180,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
@@ -94,6 +94,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/apiture.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/apiture.json
@@ -5781,6 +5781,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
@@ -74,6 +74,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/aries.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/aries.json
@@ -19207,6 +19207,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/assembly.json
@@ -3130,6 +3130,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
@@ -309,6 +309,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/axle.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/axle.json
@@ -1196,6 +1196,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/belvo.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/belvo.json
@@ -34057,6 +34057,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/buzzshot.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/buzzshot.json
@@ -1240,6 +1240,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/content-type.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/content-type.json
@@ -168,6 +168,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/corti.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/corti.json
@@ -5600,6 +5600,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
@@ -118,6 +118,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/deel.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/deel.json
@@ -14299,6 +14299,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/deepgram.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/deepgram.json
@@ -5559,6 +5559,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/default-content.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/default-content.json
@@ -74,6 +74,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/defaults.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/defaults.json
@@ -120,6 +120,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/devrev.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/devrev.json
@@ -6953,6 +6953,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/discriminated-union-value-title.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/discriminated-union-value-title.json
@@ -113,6 +113,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/enum-casing.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/enum-casing.json
@@ -85,6 +85,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/enums.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/enums.json
@@ -89,6 +89,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-exhaustive-multi-single-endpoint.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-exhaustive-multi-single-endpoint.json
@@ -69,6 +69,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-exhaustive-multi-single.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-exhaustive-multi-single.json
@@ -63,6 +63,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-no-endpoint-async.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-no-endpoint-async.json
@@ -63,6 +63,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-no-endpoint.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-no-endpoint.json
@@ -63,6 +63,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-with-endpoint-async.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-with-endpoint-async.json
@@ -69,6 +69,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-with-endpoint.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-multiple-with-endpoint.json
@@ -69,6 +69,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-no-endpoint-async.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-no-endpoint-async.json
@@ -59,6 +59,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-no-endpoint.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-no-endpoint.json
@@ -59,6 +59,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-with-endpoint-async.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-with-endpoint-async.json
@@ -65,6 +65,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-with-endpoint.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/env-single-with-endpoint.json
@@ -65,6 +65,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/example-depth.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/example-depth.json
@@ -69,6 +69,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/examples-null-values.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/examples-null-values.json
@@ -163,6 +163,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/file-upload.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/file-upload.json
@@ -147,6 +147,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/flagright.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/flagright.json
@@ -6451,6 +6451,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/flexport.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/flexport.json
@@ -19310,6 +19310,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/float.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/float.json
@@ -82,6 +82,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/hathora.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/hathora.json
@@ -3641,6 +3641,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/hookdeck.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/hookdeck.json
@@ -16852,6 +16852,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/http-head.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/http-head.json
@@ -86,6 +86,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/hume.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/hume.json
@@ -2020,6 +2020,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/idiomatic-request-names.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/idiomatic-request-names.json
@@ -241,6 +241,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-allof-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-allof-schemas.json
@@ -1,0 +1,70 @@
+{
+  "type": "openapi",
+  "value": {
+    "openapi": "3.1.0",
+    "info": {
+      "title": "Inline allOf schemas with required property overrides",
+      "version": "1.0.0"
+    },
+    "components": {
+      "schemas": {
+        "Base": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ]
+        },
+        "ChildMakesDescriptionRequired": {
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Base"
+            },
+            {
+              "type": "object",
+              "required": [
+                "id",
+                "name",
+                "description"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "paths": {}
+  },
+  "settings": {
+    "disableExamples": false,
+    "discriminatedUnionV2": false,
+    "useTitlesAsName": true,
+    "optionalAdditionalProperties": true,
+    "coerceEnumsToLiterals": true,
+    "respectReadonlySchemas": false,
+    "respectNullableSchemas": false,
+    "onlyIncludeReferencedSchemas": false,
+    "inlinePathParameters": false,
+    "preserveSchemaIds": false,
+    "shouldUseUndiscriminatedUnionsWithLiterals": false,
+    "shouldUseIdiomaticRequestNames": false,
+    "objectQueryParameters": false,
+    "asyncApiNaming": "v1",
+    "useBytesForBinaryResponse": false,
+    "respectForwardCompatibleEnums": false,
+    "additionalPropertiesDefaultsTo": false,
+    "typeDatesAsStrings": true,
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
+  }
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-path-parameters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-path-parameters.json
@@ -158,6 +158,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
@@ -106,6 +106,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/intercom.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/intercom.json
@@ -23202,6 +23202,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/json-string.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/json-string.json
@@ -44,6 +44,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/merge.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/merge.json
@@ -10565,6 +10565,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/multi-url-generators-yml.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/multi-url-generators-yml.json
@@ -151,6 +151,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/multiple-request-bodies.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/multiple-request-bodies.json
@@ -134,6 +134,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/non-alphanumeric-characters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/non-alphanumeric-characters.json
@@ -75,6 +75,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/ntropy.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/ntropy.json
@@ -5304,6 +5304,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/nullable.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/nullable.json
@@ -227,6 +227,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/oauth.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/oauth.json
@@ -140,6 +140,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/only-include-referenced-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/only-include-referenced-schemas.json
@@ -23202,6 +23202,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/openapi-filter.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/openapi-filter.json
@@ -23202,6 +23202,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/overrides-resolution.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/overrides-resolution.json
@@ -101,6 +101,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/permit.json
@@ -13492,6 +13492,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
@@ -73,6 +73,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/query-params-no-objects.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/query-params-no-objects.json
@@ -142,6 +142,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/query-params.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/query-params.json
@@ -142,6 +142,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/readonly-writeonly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/readonly-writeonly.json
@@ -170,6 +170,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/readonly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/readonly.json
@@ -164,6 +164,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/request-response-description.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/request-response-description.json
@@ -65,6 +65,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/rightbrain.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/rightbrain.json
@@ -23641,6 +23641,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/rules.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/rules.json
@@ -112,6 +112,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/seam.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/seam.json
@@ -20502,6 +20502,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/speechify.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/speechify.json
@@ -1162,6 +1162,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/squidex.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/squidex.json
@@ -20537,6 +20537,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/streaming.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/streaming.json
@@ -194,6 +194,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/superagent.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/superagent.json
@@ -1415,6 +1415,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/switchboard.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/switchboard.json
@@ -2265,6 +2265,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/top-level-webhooks.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/top-level-webhooks.json
@@ -110,6 +110,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/uint.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/uint.json
@@ -86,6 +86,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/union-extension.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/union-extension.json
@@ -89,6 +89,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/unions-v1.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/unions-v1.json
@@ -85,6 +85,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/uploadcare.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/uploadcare.json
@@ -3736,6 +3736,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-form-encoded.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-form-encoded.json
@@ -82,6 +82,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
@@ -61,6 +61,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/use-bytes-for-binary-response.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/use-bytes-for-binary-response.json
@@ -95,6 +95,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/use-title-false.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/use-title-false.json
@@ -206,6 +206,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/use-title-true.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/use-title-true.json
@@ -206,6 +206,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/valtown.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/valtown.json
@@ -3259,6 +3259,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/vellum.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/vellum.json
@@ -3897,6 +3897,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/webflow.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/webflow.json
@@ -33411,6 +33411,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/webhooks.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/webhooks.json
@@ -78,6 +78,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-audiences.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-audiences.json
@@ -84,6 +84,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-auth-variables.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-auth-variables.json
@@ -105,6 +105,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-base-path.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-base-path.json
@@ -34,6 +34,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-discriminated.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-discriminated.json
@@ -112,6 +112,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-encoding.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-encoding.json
@@ -68,6 +68,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-enum.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-enum.json
@@ -45,6 +45,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-global-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-global-headers.json
@@ -171,6 +171,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-idempotency-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-idempotency-headers.json
@@ -71,6 +71,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-ignore.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-ignore.json
@@ -144,6 +144,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-pagination.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-pagination.json
@@ -144,6 +144,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-parameter-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-parameter-name.json
@@ -74,6 +74,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-property-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-property-name.json
@@ -41,6 +41,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-resolutions.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-resolutions.json
@@ -96,6 +96,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-sdk-group-name-with-streaming.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-sdk-group-name-with-streaming.json
@@ -110,6 +110,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-sdk-group-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-sdk-group-name.json
@@ -96,6 +96,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-sdk-namespace.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-sdk-namespace.json
@@ -111,6 +111,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-audiences.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-audiences.json
@@ -113,6 +113,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-reference.json
@@ -98,6 +98,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-sse.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-sse.json
@@ -92,6 +92,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-stream-condition.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-streaming-with-stream-condition.json
@@ -160,6 +160,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-token-variable-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-token-variable-name.json
@@ -105,6 +105,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-version.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-version.json
@@ -113,6 +113,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-webhook.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-webhook.json
@@ -132,6 +132,7 @@
     "respectForwardCompatibleEnums": false,
     "additionalPropertiesDefaultsTo": false,
     "typeDatesAsStrings": true,
-    "preserveSingleSchemaOneOf": false
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/inline-allof-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/inline-allof-schemas.json
@@ -1,0 +1,140 @@
+{
+  "title": "Inline allOf schemas with required property overrides",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "Base": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "baseId",
+            "key": "id",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "BaseId",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "baseName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "BaseName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "baseDescription",
+            "key": "description",
+            "schema": {
+              "generatedName": "baseDescription",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "BaseDescription",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Base",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ChildMakesDescriptionRequired": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "childMakesDescriptionRequiredId",
+            "key": "id",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ChildMakesDescriptionRequiredId",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "childMakesDescriptionRequiredName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ChildMakesDescriptionRequiredName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "childMakesDescriptionRequiredDescription",
+            "key": "description",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ChildMakesDescriptionRequiredDescription",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ChildMakesDescriptionRequired",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/inline-allof-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/inline-allof-schemas.json
@@ -1,0 +1,69 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "Base": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "description": "optional<string>",
+              "id": "string",
+              "name": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ChildMakesDescriptionRequired": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "description": "string",
+              "id": "string",
+              "name": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  Base:
+    properties:
+      id: string
+      name: string
+      description: optional<string>
+    source:
+      openapi: ../openapi.yml
+  ChildMakesDescriptionRequired:
+    properties:
+      id: string
+      name: string
+      description: string
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Inline allOf schemas with required property overrides",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Inline allOf schemas with required property overrides
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/inline-allof-schemas/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/inline-allof-schemas/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/inline-allof-schemas/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/inline-allof-schemas/fern/generators.yml
@@ -1,0 +1,5 @@
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings: 
+        inline-all-of-schemas: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/inline-allof-schemas/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/inline-allof-schemas/openapi.yml
@@ -1,0 +1,31 @@
+openapi: 3.1.0
+info:
+  title: Inline allOf schemas with required property overrides
+  version: 1.0.0
+
+components:
+  schemas:
+    Base:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+      required:
+        - id
+        - name
+
+    ChildMakesDescriptionRequired:
+      allOf:
+        - $ref: '#/components/schemas/Base'
+        - type: object
+          required:
+            - id
+            - name
+            - description
+          # 'description' is now required, even though it wasn't in Base
+
+paths: {}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,26 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: | 
+        Introduce an OpenAPI setting called `inline-all-of-schemas` which recursively 
+        visits the scheme definitions of allOf schemas and inlines them into the child. 
+
+        The benefit of doing this is that a child schema can modify whether or not a parent 
+        property is required. Without this setting, Fern would ignore the child schema's 
+        declaration of optional and prefer the parent schema's instead. 
+
+        Add the following to your `generators.yml`: 
+
+        ```yml generators.yml 
+        api: 
+          settings: 
+            inline-all-of-schemas: true
+        ```
+      type: feat
+  irVersion: 59
+  createdAt: "2025-08-18"
+  version: 0.66.21
+
+- changelogEntry:
     - summary: Add `kwargs` as a reserved word in python so that generated SDKs continue to compile.
       type: fix
   irVersion: 59

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -27,7 +27,8 @@ const UNDEFINED_API_DEFINITION_SETTINGS: generatorsYml.APIDefinitionSettings = {
     defaultFormParameterEncoding: undefined,
     additionalPropertiesDefaultsTo: undefined,
     typeDatesAsStrings: undefined,
-    preserveSingleSchemaOneOf: undefined
+    preserveSingleSchemaOneOf: undefined,
+    inlineAllOfSchemas: undefined
 };
 
 export async function convertGeneratorsConfiguration({
@@ -105,7 +106,8 @@ function parseOpenApiDefinitionSettingsSchema(
         respectForwardCompatibleEnums: settings?.["respect-forward-compatible-enums"],
         additionalPropertiesDefaultsTo: settings?.["additional-properties-defaults-to"],
         typeDatesAsStrings: settings?.["type-dates-as-strings"],
-        preserveSingleSchemaOneOf: settings?.["preserve-single-schema-oneof"]
+        preserveSingleSchemaOneOf: settings?.["preserve-single-schema-oneof"],
+        inlineAllOfSchemas: settings?.["inline-all-of-schemas"]
     };
 }
 

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -72,6 +72,7 @@ export interface APIDefinitionSettings {
     additionalPropertiesDefaultsTo: boolean | undefined;
     typeDatesAsStrings: boolean | undefined;
     preserveSingleSchemaOneOf: boolean | undefined;
+    inlineAllOfSchemas: boolean | undefined;
 }
 
 export interface APIDefinitionLocation {

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/OpenApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/OpenApiSettingsSchema.ts
@@ -39,4 +39,9 @@ export interface OpenApiSettingsSchema extends FernDefinition.BaseApiSettingsSch
      * Defaults to false.
      */
     "preserve-single-schema-oneof"?: boolean;
+    /**
+     * Whether to inline allOf schemas. If false, allOf schemas will be
+     * extended in the code generation.
+     */
+    "inline-all-of-schemas"?: boolean;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/OpenApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/OpenApiSettingsSchema.ts
@@ -28,6 +28,7 @@ export const OpenApiSettingsSchema: core.serialization.ObjectSchema<
         "additional-properties-defaults-to": core.serialization.boolean().optional(),
         "type-dates-as-strings": core.serialization.boolean().optional(),
         "preserve-single-schema-oneof": core.serialization.boolean().optional(),
+        "inline-all-of-schemas": core.serialization.boolean().optional(),
     })
     .extend(BaseApiSettingsSchema);
 
@@ -46,5 +47,6 @@ export declare namespace OpenApiSettingsSchema {
         "additional-properties-defaults-to"?: boolean | null;
         "type-dates-as-strings"?: boolean | null;
         "preserve-single-schema-oneof"?: boolean | null;
+        "inline-all-of-schemas"?: boolean | null;
     }
 }

--- a/packages/cli/workspace/browser-compatible-fern-workspace/src/OpenAPIWorkspace.ts
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/src/OpenAPIWorkspace.ts
@@ -48,7 +48,8 @@ export class OpenAPIWorkspace extends BaseOpenAPIWorkspaceSync {
             objectQueryParameters: spec.settings?.objectQueryParameters,
             exampleGeneration: spec.settings?.exampleGeneration,
             useBytesForBinaryResponse: spec.settings?.useBytesForBinaryResponse,
-            respectForwardCompatibleEnums: spec.settings?.respectForwardCompatibleEnums
+            respectForwardCompatibleEnums: spec.settings?.respectForwardCompatibleEnums,
+            inlineAllOfSchemas: spec.settings?.inlineAllOfSchemas
         });
         this.spec = spec;
         this.loader = new InMemoryOpenAPILoader();

--- a/packages/cli/workspace/commons/src/openapi/BaseOpenAPIWorkspace.ts
+++ b/packages/cli/workspace/commons/src/openapi/BaseOpenAPIWorkspace.ts
@@ -17,6 +17,7 @@ export declare namespace BaseOpenAPIWorkspace {
         exampleGeneration: generatorsYml.OpenApiExampleGenerationSchema | undefined;
         useBytesForBinaryResponse: boolean | undefined;
         respectForwardCompatibleEnums: boolean | undefined;
+        inlineAllOfSchemas: boolean | undefined;
     }
 
     export type Settings = Partial<OpenAPISettings>;
@@ -31,6 +32,7 @@ export abstract class BaseOpenAPIWorkspace extends AbstractAPIWorkspace<BaseOpen
     public exampleGeneration: generatorsYml.OpenApiExampleGenerationSchema | undefined;
     public useBytesForBinaryResponse: boolean | undefined;
     public respectForwardCompatibleEnums: boolean | undefined;
+    public inlineAllOfSchemas: boolean | undefined;
     private converter: FernDefinitionConverter;
 
     constructor(args: BaseOpenAPIWorkspace.Args) {
@@ -43,6 +45,7 @@ export abstract class BaseOpenAPIWorkspace extends AbstractAPIWorkspace<BaseOpen
         this.exampleGeneration = args.exampleGeneration;
         this.useBytesForBinaryResponse = args.useBytesForBinaryResponse;
         this.respectForwardCompatibleEnums = args.respectForwardCompatibleEnums;
+        this.inlineAllOfSchemas = args.inlineAllOfSchemas;
         this.converter = new FernDefinitionConverter(args);
     }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -66,6 +66,7 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
 
                 // TODO: Update this to '.every' once AsyncAPI sources are correctly recognized.
                 .some((spec) => spec.settings?.respectForwardCompatibleEnums),
+            inlineAllOfSchemas: specs.every((spec) => spec.settings?.inlineAllOfSchemas),
             exampleGeneration: specs[0]?.settings?.exampleGeneration
         });
         this.specs = specs;
@@ -100,7 +101,8 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
                 inlinePathParameters: settings?.inlinePathParameters ?? this.inlinePathParameters,
                 objectQueryParameters: settings?.objectQueryParameters ?? this.objectQueryParameters,
                 exampleGeneration: settings?.exampleGeneration ?? this.exampleGeneration,
-                useBytesForBinaryResponse: settings?.useBytesForBinaryResponse ?? this.useBytesForBinaryResponse
+                useBytesForBinaryResponse: settings?.useBytesForBinaryResponse ?? this.useBytesForBinaryResponse,
+                inlineAllOfSchemas: settings?.inlineAllOfSchemas ?? this.inlineAllOfSchemas
             }
         });
     }

--- a/packages/cli/workspace/loader/src/loadAPIWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadAPIWorkspace.ts
@@ -99,7 +99,8 @@ export async function loadSingleNamespaceAPIWorkspace({
                     respectForwardCompatibleEnums: definition.settings?.respectForwardCompatibleEnums ?? false,
                     additionalPropertiesDefaultsTo: definition.settings?.additionalPropertiesDefaultsTo ?? false,
                     typeDatesAsStrings: definition.settings?.typeDatesAsStrings ?? true,
-                    preserveSingleSchemaOneOf: definition.settings?.preserveSingleSchemaOneOf ?? false
+                    preserveSingleSchemaOneOf: definition.settings?.preserveSingleSchemaOneOf ?? false,
+                    inlineAllOfSchemas: definition.settings?.inlineAllOfSchemas ?? false
                 }
             });
             continue;
@@ -170,7 +171,8 @@ export async function loadSingleNamespaceAPIWorkspace({
                 respectForwardCompatibleEnums: definition.settings?.respectForwardCompatibleEnums ?? false,
                 additionalPropertiesDefaultsTo: definition.settings?.additionalPropertiesDefaultsTo ?? false,
                 typeDatesAsStrings: definition.settings?.typeDatesAsStrings ?? true,
-                preserveSingleSchemaOneOf: definition.settings?.preserveSingleSchemaOneOf ?? false
+                preserveSingleSchemaOneOf: definition.settings?.preserveSingleSchemaOneOf ?? false,
+                inlineAllOfSchemas: definition.settings?.inlineAllOfSchemas ?? false
             },
             source: {
                 type: "openapi",


### PR DESCRIPTION
## Description
Introduce an OpenAPI setting called `inline-all-of-schemas` which recursively 
visits the scheme definitions of allOf schemas and inlines them into the child. 

The benefit of doing this is that a child schema can modify whether or not a parent 
property is required. Without this setting, Fern would ignore the child schema's 
declaration of optional and prefer the parent schema's instead. 

Add the following to your `generators.yml`: 

```yml generators.yml 
api: 
  settings: 
    inline-all-of-schemas: true
```

## Changes Made
- See flies changed.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

