### PR TITLE
fix(go): dynamic snippets dont exceed call stack for list values

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeMapper.ts
@@ -20,7 +20,7 @@ export class DynamicTypeMapper {
     public convert(args: DynamicTypeMapper.Args): go.Type {
         switch (args.typeReference.type) {
             case "list":
-                return go.Type.slice(this.convert({ typeReference: args.typeReference }));
+                return go.Type.slice(this.convert({ typeReference: args.typeReference.value }));
             case "literal":
                 return this.convertLiteral({ literal: args.typeReference.value });
             case "map":

--- a/generators/go-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorCli.ts
@@ -67,7 +67,11 @@ export class SdkGeneratorCLI extends AbstractGoGeneratorCli<SdkCustomConfigSchem
                     endpointSnippets
                 });
             } catch (e) {
-                context.logger.warn("Failed to generate README.md, this is OK.");
+                context.logger.error("Failed to generate README.md");
+                if (e instanceof Error) {
+                    context.logger.debug(e.message);
+                    context.logger.debug(e.stack ?? "");
+                }
             }
         }
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.6.3
+  changelogEntry:
+    - summary: |
+        Update the dyanmic snippet generator to handle list values in the request body. 
+        Previously, it would throw an error.
+      type: fix
+  createdAt: '2025-08-21'
+  irVersion: 58
+
 - version: 1.6.2
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/go/DynamicSnippetsGoTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/go/DynamicSnippetsGoTestGenerator.ts
@@ -45,6 +45,9 @@ export class DynamicSnippetsGoTestGenerator {
                 this.context.logger.error(
                     `Failed to generate dynamic snippet for endpoint ${JSON.stringify(request.endpoint)}: ${error}`
                 );
+                if (error instanceof Error && error.stack) {
+                    this.context.logger.error(error.stack);
+                }
             }
         }
         this.context.logger.debug("Done generating dynamic snippet tests");


### PR DESCRIPTION
## Description
  Update the dyanmic snippet generator to handle list values in the request body. 
  Previously, it would throw an error.

## Changes Made
- Better error logging
- Updated recursive action for GoTypeMapper

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

