### PR TITLE
feat(cli): add support for JSON Schema's `const` keyword

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -250,6 +250,13 @@ export function convertSchemaObject(
         );
     }
 
+    // const
+    // NOTE(patrickthornton): This is an attribute of OpenAPIV3_1.SchemaObject;
+    // at some point we should probably migrate to that object altogether.
+    if ('const' in schema) {
+        schema.enum = [schema.const];
+    }
+
     // enums
     if (
         schema.enum != null &&

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -253,7 +253,7 @@ export function convertSchemaObject(
     // const
     // NOTE(patrickthornton): This is an attribute of OpenAPIV3_1.SchemaObject;
     // at some point we should probably migrate to that object altogether.
-    if ('const' in schema) {
+    if ("const" in schema) {
         schema.enum = [schema.const];
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/const.json
@@ -1,0 +1,146 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createANewPet": {
+              "auth": false,
+              "display-name": "Create a new pet",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "name": "Fluffy",
+                    "type": "pet",
+                  },
+                  "response": {
+                    "body": {
+                      "breed": "Golden Retriever",
+                      "id": 123,
+                      "name": "Fluffy",
+                      "status": "active",
+                      "type": "pet",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/pets",
+              "request": {
+                "body": {
+                  "properties": {
+                    "breed": "optional<string>",
+                    "name": "string",
+                    "type": "literal<"pet">",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "CreatePetRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Pet created successfully",
+                "status-code": 201,
+                "type": "Pet",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "Pet": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "breed": "optional<string>",
+              "id": "integer",
+              "name": "string",
+              "status": "literal<"active">",
+              "type": "literal<"pet">",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createANewPet:
+      path: /pets
+      method: POST
+      auth: false
+      source:
+        openapi: ../openapi.yml
+      display-name: Create a new pet
+      request:
+        name: CreatePetRequest
+        body:
+          properties:
+            type: literal<"pet">
+            name: string
+            breed: optional<string>
+        content-type: application/json
+      response:
+        docs: Pet created successfully
+        type: Pet
+        status-code: 201
+      examples:
+        - request:
+            type: pet
+            name: Fluffy
+          response:
+            body:
+              id: 123
+              type: pet
+              name: Fluffy
+              breed: Golden Retriever
+              status: active
+  source:
+    openapi: ../openapi.yml
+types:
+  Pet:
+    properties:
+      id: integer
+      type: literal<"pet">
+      name: string
+      breed: optional<string>
+      status: literal<"active">
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Pet Store API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Pet Store API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
@@ -1,0 +1,114 @@
+{
+  "type": "openapi",
+  "value": {
+    "openapi": "3.1.0",
+    "info": {
+      "title": "Pet Store API",
+      "version": "1.0.0"
+    },
+    "paths": {
+      "/pets": {
+        "post": {
+          "summary": "Create a new pet",
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePetRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Pet created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "CreatePetRequest": {
+          "type": "object",
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "pet"
+            },
+            "name": {
+              "type": "string",
+              "example": "Fluffy"
+            },
+            "breed": {
+              "type": "string",
+              "example": "Golden Retriever"
+            }
+          }
+        },
+        "Pet": {
+          "type": "object",
+          "required": [
+            "id",
+            "type",
+            "name",
+            "status"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "example": 123
+            },
+            "type": {
+              "const": "pet"
+            },
+            "name": {
+              "type": "string",
+              "example": "Fluffy"
+            },
+            "breed": {
+              "type": "string",
+              "example": "Golden Retriever"
+            },
+            "status": {
+              "const": "active"
+            }
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "disableExamples": false,
+    "discriminatedUnionV2": false,
+    "useTitlesAsName": true,
+    "optionalAdditionalProperties": true,
+    "coerceEnumsToLiterals": true,
+    "respectReadonlySchemas": false,
+    "respectNullableSchemas": false,
+    "onlyIncludeReferencedSchemas": false,
+    "inlinePathParameters": false,
+    "preserveSchemaIds": false,
+    "shouldUseUndiscriminatedUnionsWithLiterals": false,
+    "shouldUseIdiomaticRequestNames": false,
+    "objectQueryParameters": false,
+    "asyncApiNaming": "v1",
+    "useBytesForBinaryResponse": false,
+    "respectForwardCompatibleEnums": false,
+    "additionalPropertiesDefaultsTo": false,
+    "typeDatesAsStrings": true,
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false
+  }
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/assembly.json
@@ -14101,8 +14101,8 @@
                 "value": "SessionBegins",
                 "type": "string"
               },
-              "groupName": [],
               "description": "Describes the type of the message.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -14175,8 +14175,8 @@
                 "value": "SessionTerminated",
                 "type": "string"
               },
-              "groupName": [],
               "description": "Describes the type of the message.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -14332,8 +14332,8 @@
                 "value": "PartialTranscript",
                 "type": "string"
               },
-              "groupName": [],
               "description": "Describes the type of message.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -14373,8 +14373,8 @@
                 "value": "FinalTranscript",
                 "type": "string"
               },
-              "groupName": [],
               "description": "Describes the type of message.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/const.json
@@ -1,0 +1,309 @@
+{
+  "title": "Pet Store API",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Create a new pet",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostPetsRequest",
+      "request": {
+        "schema": {
+          "generatedName": "PostPetsRequest",
+          "schema": "CreatePetRequest",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Pet created successfully",
+        "schema": {
+          "generatedName": "PostPetsResponse",
+          "schema": "Pet",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 201,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/pets",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "type": {
+                "value": {
+                  "value": "pet",
+                  "type": "string"
+                },
+                "type": "literal"
+              },
+              "name": {
+                "value": {
+                  "value": "Fluffy",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": 123,
+                    "type": "int"
+                  },
+                  "type": "primitive"
+                },
+                "type": {
+                  "value": {
+                    "value": "pet",
+                    "type": "string"
+                  },
+                  "type": "literal"
+                },
+                "name": {
+                  "value": {
+                    "value": "Fluffy",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "breed": {
+                  "value": {
+                    "value": "Golden Retriever",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "status": {
+                  "value": {
+                    "value": "active",
+                    "type": "string"
+                  },
+                  "type": "literal"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "CreatePetRequest": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "createPetRequestType",
+            "key": "type",
+            "schema": {
+              "value": {
+                "value": "pet",
+                "type": "string"
+              },
+              "generatedName": "CreatePetRequestType",
+              "groupName": [],
+              "type": "literal"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "createPetRequestName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "example": "Fluffy",
+                "type": "string"
+              },
+              "generatedName": "CreatePetRequestName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "createPetRequestBreed",
+            "key": "breed",
+            "schema": {
+              "generatedName": "createPetRequestBreed",
+              "value": {
+                "schema": {
+                  "example": "Golden Retriever",
+                  "type": "string"
+                },
+                "generatedName": "CreatePetRequestBreed",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "CreatePetRequest",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "Pet": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "petId",
+            "key": "id",
+            "schema": {
+              "schema": {
+                "example": 123,
+                "type": "int"
+              },
+              "generatedName": "PetId",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petType",
+            "key": "type",
+            "schema": {
+              "value": {
+                "value": "pet",
+                "type": "string"
+              },
+              "generatedName": "PetType",
+              "groupName": [],
+              "type": "literal"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "example": "Fluffy",
+                "type": "string"
+              },
+              "generatedName": "PetName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petBreed",
+            "key": "breed",
+            "schema": {
+              "generatedName": "petBreed",
+              "value": {
+                "schema": {
+                  "example": "Golden Retriever",
+                  "type": "string"
+                },
+                "generatedName": "PetBreed",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petStatus",
+            "key": "status",
+            "schema": {
+              "value": {
+                "value": "active",
+                "type": "string"
+              },
+              "generatedName": "PetStatus",
+              "groupName": [],
+              "type": "literal"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Pet",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/hume.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/hume.json
@@ -1919,8 +1919,8 @@
                 "value": "error",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; for a Web Socket Error message, this must be `error`.\n\nThis message indicates a disruption in the WebSocket connection, such as an unexpected disconnection, protocol error, or data transmission issue.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -5401,8 +5401,8 @@
                 "value": "assistant_input",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; must be `assistant_input` for our server to correctly identify and process it as an Assistant Input message.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -5548,8 +5548,8 @@
                 "value": "audio_input",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; must be `audio_input` for our server to correctly identify and process it as an Audio Input message.\n\nThis message is used for sending audio input data to EVI for processing and expression measurement. Audio data should be sent as a continuous stream, encoded in Base64.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -5826,8 +5826,8 @@
                   "value": "pause_assistant_message",
                   "type": "string"
                 },
-                "groupName": [],
                 "description": "The type of message sent through the socket; must be `pause_assistant_message` for our server to correctly identify and process it as a Pause Assistant message.\n\nOnce this message is sent, EVI will not respond until a [Resume Assistant message](/reference/empathic-voice-interface-evi/chat/chat#send.Resume%20Assistant%20Message.type) is sent. When paused, EVI won’t respond, but transcriptions of your audio inputs will still be recorded.",
+                "groupName": [],
                 "type": "literal"
               },
               "groupName": [],
@@ -5896,8 +5896,8 @@
                   "value": "resume_assistant_message",
                   "type": "string"
                 },
-                "groupName": [],
                 "description": "The type of message sent through the socket; must be `resume_assistant_message` for our server to correctly identify and process it as a Resume Assistant message.\n\nUpon resuming, if any audio input was sent during the pause, EVI will retain context from all messages sent but only respond to the last user message. (e.g., If you ask EVI two questions while paused and then send a `resume_assistant_message`, EVI will respond to the second question and have added the first question to its conversation context.)",
+                "groupName": [],
                 "type": "literal"
               },
               "groupName": [],
@@ -5962,8 +5962,8 @@
                 "value": "session_settings",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; must be `session_settings` for our server to correctly identify and process it as a Session Settings message.\n\nSession settings are temporary and apply only to the current Chat session. These settings can be adjusted dynamically based on the requirements of each session to ensure optimal performance and user experience.\n\nFor more information, please refer to the [Session Settings section](/docs/empathic-voice-interface-evi/configuration#session-settings) on the EVI Configuration page.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -6407,8 +6407,8 @@
                   "value": "tool_error",
                   "type": "string"
                 },
-                "groupName": [],
                 "description": "The type of message sent through the socket; for a Tool Error message, this must be `tool_error`.\n\nUpon receiving a [Tool Call message](/reference/empathic-voice-interface-evi/chat/chat#receive.Tool%20Call%20Message.type) and failing to invoke the function, this message is sent to notify EVI of the tool's failure.",
+                "groupName": [],
                 "type": "literal"
               },
               "groupName": [],
@@ -6620,8 +6620,8 @@
                   "value": "tool_response",
                   "type": "string"
                 },
-                "groupName": [],
                 "description": "The type of message sent through the socket; for a Tool Response message, this must be `tool_response`.\n\nUpon receiving a [Tool Call message](/reference/empathic-voice-interface-evi/chat/chat#receive.Tool%20Call%20Message.type) and successfully invoking the function, this message is sent to convey the result of the function call back to EVI.",
+                "groupName": [],
                 "type": "literal"
               },
               "groupName": [],
@@ -6795,8 +6795,8 @@
                 "value": "user_input",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; must be `user_input` for our server to correctly identify and process it as a User Input message.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -6875,8 +6875,8 @@
                 "value": "assistant_end",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; for an Assistant End message, this must be `assistant_end`.\n\nThis message indicates the conclusion of the assistant’s response, signaling that the assistant has finished speaking for the current conversational turn.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -6938,8 +6938,8 @@
                 "value": "assistant_message",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; for an Assistant Message, this must be `assistant_message`.\n\nThis message contains both a transcript of the assistant’s response and the expression measurement predictions of the assistant’s audio output.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -7351,8 +7351,8 @@
                 "value": "chat_metadata",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; for a Chat Metadata message, this must be `chat_metadata`.\n\nThe Chat Metadata message is the first message you receive after establishing a connection with EVI and contains important identifiers for the current Chat session.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],
@@ -8463,8 +8463,8 @@
                   "value": "tool_call",
                   "type": "string"
                 },
-                "groupName": [],
                 "description": "The type of message sent through the socket; for a Tool Call message, this must be `tool_call`.\n\nThis message indicates that the supplemental LLM has detected a need to invoke the specified tool.",
+                "groupName": [],
                 "type": "literal"
               },
               "groupName": [],
@@ -8563,8 +8563,8 @@
                 "value": "user_interruption",
                 "type": "string"
               },
-              "groupName": [],
               "description": "The type of message sent through the socket; for a User Interruption message, this must be `user_interruption`.\n\nThis message indicates the user has interrupted the assistant’s response. EVI detects the interruption in real-time and sends this message to signal the interruption event. This message allows the system to stop the current audio playback, clear the audio queue, and prepare to handle new user input.",
+              "groupName": [],
               "type": "literal"
             },
             "audiences": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/const.json
@@ -1,0 +1,146 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createANewPet": {
+              "auth": false,
+              "display-name": "Create a new pet",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "name": "Fluffy",
+                    "type": "pet",
+                  },
+                  "response": {
+                    "body": {
+                      "breed": "Golden Retriever",
+                      "id": 123,
+                      "name": "Fluffy",
+                      "status": "active",
+                      "type": "pet",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/pets",
+              "request": {
+                "body": {
+                  "properties": {
+                    "breed": "optional<string>",
+                    "name": "string",
+                    "type": "literal<"pet">",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "CreatePetRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Pet created successfully",
+                "status-code": 201,
+                "type": "Pet",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "Pet": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "breed": "optional<string>",
+              "id": "integer",
+              "name": "string",
+              "status": "literal<"active">",
+              "type": "literal<"pet">",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createANewPet:
+      path: /pets
+      method: POST
+      auth: false
+      source:
+        openapi: ../openapi.yml
+      display-name: Create a new pet
+      request:
+        name: CreatePetRequest
+        body:
+          properties:
+            type: literal<"pet">
+            name: string
+            breed: optional<string>
+        content-type: application/json
+      response:
+        docs: Pet created successfully
+        type: Pet
+        status-code: 201
+      examples:
+        - request:
+            type: pet
+            name: Fluffy
+          response:
+            body:
+              id: 123
+              type: pet
+              name: Fluffy
+              breed: Golden Retriever
+              status: active
+  source:
+    openapi: ../openapi.yml
+types:
+  Pet:
+    properties:
+      id: integer
+      type: literal<"pet">
+      name: string
+      breed: optional<string>
+      status: literal<"active">
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Pet Store API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Pet Store API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const/fern/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const/openapi.yml
@@ -1,0 +1,61 @@
+openapi: 3.1.0
+info:
+  title: Pet Store API
+  version: 1.0.0
+
+paths:
+  /pets:
+    post:
+      summary: Create a new pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePetRequest'
+      responses:
+        '201':
+          description: Pet created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+
+components:
+  schemas:
+    CreatePetRequest:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          const: "pet"
+        name:
+          type: string
+          example: "Fluffy"
+        breed:
+          type: string
+          example: "Golden Retriever"
+
+    Pet:
+      type: object
+      required:
+        - id
+        - type
+        - name
+        - status
+      properties:
+        id:
+          type: integer
+          example: 123
+        type:
+          const: "pet"
+        name:
+          type: string
+          example: "Fluffy"
+        breed:
+          type: string
+          example: "Golden Retriever"
+        status:
+          const: "active"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,18 +1,25 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
-    - summary: | 
-        Introduce an OpenAPI setting called `inline-all-of-schemas` which recursively 
-        visits the scheme definitions of allOf schemas and inlines them into the child. 
+    - summary: Add support for `const` JSON schema keyword, which parses to a single-valued enum.
+      type: feat
+  irVersion: 59
+  createdAt: "2025-08-22"
+  version: 0.66.22
 
-        The benefit of doing this is that a child schema can modify whether or not a parent 
-        property is required. Without this setting, Fern would ignore the child schema's 
-        declaration of optional and prefer the parent schema's instead. 
+- changelogEntry:
+    - summary: |
+        Introduce an OpenAPI setting called `inline-all-of-schemas` which recursively
+        visits the scheme definitions of allOf schemas and inlines them into the child.
 
-        Add the following to your `generators.yml`: 
+        The benefit of doing this is that a child schema can modify whether or not a parent
+        property is required. Without this setting, Fern would ignore the child schema's
+        declaration of optional and prefer the parent schema's instead.
 
-        ```yml generators.yml 
-        api: 
-          settings: 
+        Add the following to your `generators.yml`:
+
+        ```yml generators.yml
+        api:
+          settings:
             inline-all-of-schemas: true
         ```
       type: feat
@@ -216,7 +223,7 @@
 
 - changelogEntry:
     - summary: |
-        Escape $ signs when converting from OpenAPI -> Fern Definition (for enums), because the Fern Definition treats 
+        Escape $ signs when converting from OpenAPI -> Fern Definition (for enums), because the Fern Definition treats
         $ sign examples as references.
       type: feat
   irVersion: 58
@@ -257,8 +264,8 @@
 
 - changelogEntry:
     - summary: |
-        Fix snippet generation for local file system output mode. Snippets configured with `snippets.path` 
-        in generators.yml were not being generated when using `--local` flag due to missing Docker volume 
+        Fix snippet generation for local file system output mode. Snippets configured with `snippets.path`
+        in generators.yml were not being generated when using `--local` flag due to missing Docker volume
         mounting for the downloadFiles output mode.
       type: fix
   irVersion: 58
@@ -275,13 +282,13 @@
 
 - changelogEntry:
     - summary: |
-        Add support for snippet.json output as part of self hosted SDK generation. The following config in 
-        `generators.yml` will generate a `snippet.json` file in the relevant director: 
+        Add support for snippet.json output as part of self hosted SDK generation. The following config in
+        `generators.yml` will generate a `snippet.json` file in the relevant director:
         ```
-        groups: 
-          ts-sdk: 
+        groups:
+          ts-sdk:
             - name: fernapi/fern-typescript-sdk
-              snippets: 
+              snippets:
                 path: ../snippets.json
         ```
       type: feat
@@ -507,8 +514,8 @@
 
 - changelogEntry:
     - summary: |
-        The extension `x-fern-global-headers` now supports a type field that can point to 
-        arbitrary schemas. For example you can do the following to describe a header 
+        The extension `x-fern-global-headers` now supports a type field that can point to
+        arbitrary schemas. For example you can do the following to describe a header
         that is an enum.
 
         ```yml
@@ -573,7 +580,7 @@
 - changelogEntry:
     - summary: |
         Previously if the OpenAPI parser v3 was enabled where the CLI would skip parsing any additional Fern Definitions
-        along the OpenAPI spec. With the fix, you can use whatever combination of OpenAPI Spec(s) and Fern Definitions that 
+        along the OpenAPI spec. With the fix, you can use whatever combination of OpenAPI Spec(s) and Fern Definitions that
         you would like.
       type: fix
   irVersion: 58
@@ -710,8 +717,8 @@
 
 - changelogEntry:
     - summary: |
-        Added Server-Sent Events (SSE) support to Java stream implementation. The Java SDK generator now 
-        supports SSE streaming alongside existing JSON streaming, enabling real-time incremental responses 
+        Added Server-Sent Events (SSE) support to Java stream implementation. The Java SDK generator now
+        supports SSE streaming alongside existing JSON streaming, enabling real-time incremental responses
         for chat applications and live data feeds.
       type: feat
   irVersion: 58
@@ -728,8 +735,8 @@
 
 - changelogEntry:
     - summary: |
-        Global headers are now used to create endpoint examples. When building endpoint examples, global headers 
-        are automatically included in the headers section of each example. This ensures that all endpoints have consistent 
+        Global headers are now used to create endpoint examples. When building endpoint examples, global headers
+        are automatically included in the headers section of each example. This ensures that all endpoints have consistent
         header examples that match the global header configuration.
       type: fix
   irVersion: 58
@@ -818,7 +825,7 @@
 
 - changelogEntry:
     - summary: |
-        Respect additional properties in docs example generation by preserving them in generated examples instead of 
+        Respect additional properties in docs example generation by preserving them in generated examples instead of
         stripping unknown properties.
       type: fix
   irVersion: 58
@@ -875,8 +882,8 @@
 
 - changelogEntry:
     - summary: |
-        The Readme importer now downloads MDX files from the source documentation. 
-        This allows for better handling of React components and dynamic content in the imported documentation. 
+        The Readme importer now downloads MDX files from the source documentation.
+        This allows for better handling of React components and dynamic content in the imported documentation.
         The importer will preserve the MDX syntax and structure while converting the content to a format compatible with Fern's documentation system.
       type: fix
   irVersion: 58
@@ -901,9 +908,9 @@
 
 - changelogEntry:
     - summary: |
-        The OpenAPI v3 Parser now uniquely stores schemas across endpoint parameters to prevent overwriting. Previously, 
-        schemas with the same name across different parameters would overwrite each other, leading to potential data loss 
-        and incorrect type definitions. This fix ensures that each parameter's schema is properly preserved and referenced 
+        The OpenAPI v3 Parser now uniquely stores schemas across endpoint parameters to prevent overwriting. Previously,
+        schemas with the same name across different parameters would overwrite each other, leading to potential data loss
+        and incorrect type definitions. This fix ensures that each parameter's schema is properly preserved and referenced
         throughout the API specification.
       type: fix
   irVersion: 58
@@ -912,9 +919,9 @@
 
 - changelogEntry:
     - summary: |
-        The AsyncAPI v3 importer now properly detects query parameters by analyzing the channel address specification. 
-        When a channel address contains a parameter reference in the format `={paramName}`, the importer will automatically 
-        identify it as a query parameter. This allows for more accurate parameter type detection and better handling of 
+        The AsyncAPI v3 importer now properly detects query parameters by analyzing the channel address specification.
+        When a channel address contains a parameter reference in the format `={paramName}`, the importer will automatically
+        identify it as a query parameter. This allows for more accurate parameter type detection and better handling of
         WebSocket channel parameters in AsyncAPI v3 specifications.
       type: fix
   irVersion: 58
@@ -923,8 +930,8 @@
 
 - changelogEntry:
     - summary: |
-        The AsyncAPI importer now supports parameter references and computing location of the parameter based on the address. 
-        This allows for more flexible parameter definitions in AsyncAPI specifications, where parameters can be referenced from other 
+        The AsyncAPI importer now supports parameter references and computing location of the parameter based on the address.
+        This allows for more flexible parameter definitions in AsyncAPI specifications, where parameters can be referenced from other
         parts of the specification and their location can be dynamically determined based on the channel address.
       type: fix
   irVersion: 58
@@ -1040,7 +1047,7 @@
 
 - changelogEntry:
     - summary: |
-        The v3 OpenAPI parser now appropriately creates inlined types for references to 
+        The v3 OpenAPI parser now appropriately creates inlined types for references to
         inlined schemas like `$ref: /components/schemas/MySchema/properties/foo`
       type: fix
     - summary: Bump all generators to IR v58.
@@ -1326,7 +1333,7 @@
         ```yaml
         - name: fernapi/fern-typescript-sdk
           version: 0.48.5
-          api: 
+          api:
             auth: bearer
         ```
 
@@ -1354,7 +1361,7 @@
 
 - changelogEntry:
     - summary: |
-        Remove `respect-readonly-schemas` for the legacy OpenAPI parser since it can block docs 
+        Remove `respect-readonly-schemas` for the legacy OpenAPI parser since it can block docs
         generation. Anyone who wants to enable this can turn it on in `generators.yml` or upgrade
         to the latest OpenAPI parser.
       type: fix
@@ -1461,8 +1468,8 @@
 
 - changelogEntry:
     - summary: |
-        Add logging of filepaths when markdown parsing fails to help with debugging. This includes logging the 
-        absolute filepath of the markdown file being parsed and any associated image paths that were 
+        Add logging of filepaths when markdown parsing fails to help with debugging. This includes logging the
+        absolute filepath of the markdown file being parsed and any associated image paths that were
         being processed when the error occurred.
       type: fix
   irVersion: 57
@@ -1478,8 +1485,8 @@
 
 - changelogEntry:
     - summary: |
-        Fix OpenRPC converter to use proper breadcrumbs when generating request and response schemas. 
-        This ensures that schemas with the same name but different contexts (such as parameters and results) 
+        Fix OpenRPC converter to use proper breadcrumbs when generating request and response schemas.
+        This ensures that schemas with the same name but different contexts (such as parameters and results)
         don't overwrite each other during conversion, maintaining the integrity of the API definition.
       type: fix
   irVersion: 57
@@ -1487,8 +1494,8 @@
 
 - changelogEntry:
     - summary: |
-        Add support for preserving `maxLines` and `focus` attributes when using `<Code>` components in docs. 
-        These attributes are now properly carried over to the generated code blocks, allowing you to control 
+        Add support for preserving `maxLines` and `focus` attributes when using `<Code>` components in docs.
+        These attributes are now properly carried over to the generated code blocks, allowing you to control
         the display of referenced code snippets with features like line limits and syntax highlighting focus.
       type: fix
   irVersion: 57
@@ -1496,7 +1503,7 @@
 
 - changelogEntry:
     - summary: |
-        Fix docs preview server by properly killing the Next.js process on exit and setting 
+        Fix docs preview server by properly killing the Next.js process on exit and setting
         a memory limit (--max-old-space-size=2048) to prevent out-of-memory errors during development.
       type: fix
   irVersion: 57
@@ -1555,7 +1562,7 @@
 
 - changelogEntry:
     - summary: |
-        Fix a bug where the broken link checker would incorrectly flag links to llms.txt and llms-full.txt files as broken. 
+        Fix a bug where the broken link checker would incorrectly flag links to llms.txt and llms-full.txt files as broken.
         The checker now properly recognizes these file paths as valid.
       type: fix
   irVersion: 57
@@ -1643,7 +1650,7 @@
 
 - changelogEntry:
     - summary: |
-        Fixed an issue where local generation could produce invalid build files (like pyproject.toml) when 
+        Fixed an issue where local generation could produce invalid build files (like pyproject.toml) when
         GitHub configuration was missing a repository URL. The CLI now ensures a repository URL is always set when possible.
       type: fix
   irVersion: 57
@@ -1651,7 +1658,7 @@
 
 - changelogEntry:
     - summary: |
-        Added support for using Podman as a container runner with `fern generate --runner podman`. 
+        Added support for using Podman as a container runner with `fern generate --runner podman`.
         This allows users to run generators locally using Podman instead of Docker.
       type: fix
   irVersion: 57
@@ -1799,10 +1806,10 @@
 
 - changelogEntry:
     - summary: |
-        Add support for environment and auth overrides from generators.yml in the OpenAPI parser. When importing OpenAPI specifications, 
-        the parser now checks for environment and auth configurations in the generators.yml file and uses these settings to override 
-        the environments and authentication schemes defined in the OpenAPI document. This enhancement provides more flexibility in 
-        customizing imported APIs without modifying the original OpenAPI specification, allowing for environment-specific configurations 
+        Add support for environment and auth overrides from generators.yml in the OpenAPI parser. When importing OpenAPI specifications,
+        the parser now checks for environment and auth configurations in the generators.yml file and uses these settings to override
+        the environments and authentication schemes defined in the OpenAPI document. This enhancement provides more flexibility in
+        customizing imported APIs without modifying the original OpenAPI specification, allowing for environment-specific configurations
         and standardized authentication schemes across different API versions.
       type: feat
   irVersion: 57
@@ -1810,8 +1817,8 @@
 
 - changelogEntry:
     - summary: |
-        Add support for auth descriptions in generated documentation. Auth schemes can now include descriptive text that explains authentication requirements, 
-        which is properly displayed in the generated documentation. This enhancement improves API usability by providing clearer guidance on authentication 
+        Add support for auth descriptions in generated documentation. Auth schemes can now include descriptive text that explains authentication requirements,
+        which is properly displayed in the generated documentation. This enhancement improves API usability by providing clearer guidance on authentication
         methods directly within the documentation.
       type: feat
   irVersion: 57
@@ -1833,9 +1840,9 @@
 
 - changelogEntry:
     - summary: |
-        Add support for custom parameters in OpenRPC through the `x-fern-parameters` extension. This extension allows OpenRPC 
-        definitions to specify path parameters, query parameters, and headers that aren't natively supported in the OpenRPC 
-        specification. Parameters defined with this extension are properly converted to the Fern IR format and included in 
+        Add support for custom parameters in OpenRPC through the `x-fern-parameters` extension. This extension allows OpenRPC
+        definitions to specify path parameters, query parameters, and headers that aren't natively supported in the OpenRPC
+        specification. Parameters defined with this extension are properly converted to the Fern IR format and included in
         endpoint definitions, enabling more complete API representations when importing from OpenRPC sources.
       type: feat
   irVersion: 57
@@ -1851,9 +1858,9 @@
 
 - changelogEntry:
     - summary: |
-        Fix OpenAPI parser to avoid recreating endpoint headers that clash with auth headers. Previously, the parser would 
-        generate duplicate header definitions when an endpoint used the same header that was already defined as an auth header. 
-        This could lead to conflicts in the generated SDKs. The parser now properly checks for existing auth headers and 
+        Fix OpenAPI parser to avoid recreating endpoint headers that clash with auth headers. Previously, the parser would
+        generate duplicate header definitions when an endpoint used the same header that was already defined as an auth header.
+        This could lead to conflicts in the generated SDKs. The parser now properly checks for existing auth headers and
         avoids creating duplicates, resulting in cleaner and more consistent API definitions.
       type: feat
   irVersion: 57
@@ -1882,9 +1889,9 @@
 
 - changelogEntry:
     - summary: |
-        Add support for local SDK generation with a Fern token. When a valid Fern token is provided, 
-        users can now generate complete SDKs locally using Docker, without requiring remote generation. 
-        This enhancement improves the development workflow by allowing for faster iteration and testing 
+        Add support for local SDK generation with a Fern token. When a valid Fern token is provided,
+        users can now generate complete SDKs locally using Docker, without requiring remote generation.
+        This enhancement improves the development workflow by allowing for faster iteration and testing
         of SDK changes in local environments.
       type: fix
   irVersion: 57
@@ -1892,8 +1899,8 @@
 
 - changelogEntry:
     - summary: |
-        Enhance OpenAPI -> IR conversion to properly handle default values in schemas. The converter now correctly extracts 
-        and preserves default values from OpenAPI schemas, ensuring they are properly represented in the generated SDKs. 
+        Enhance OpenAPI -> IR conversion to properly handle default values in schemas. The converter now correctly extracts
+        and preserves default values from OpenAPI schemas, ensuring they are properly represented in the generated SDKs.
         This improvement allows API providers to specify meaningful defaults that will be respected in client implementations.
       type: fix
   irVersion: 57
@@ -1901,8 +1908,8 @@
 
 - changelogEntry:
     - summary: |
-        Improve OpenRPC importer to generate more unique schema IDs for request parameters by combining method name, 
-        "Param" keyword, and parameter name. This prevents naming conflicts when different methods have parameters 
+        Improve OpenRPC importer to generate more unique schema IDs for request parameters by combining method name,
+        "Param" keyword, and parameter name. This prevents naming conflicts when different methods have parameters
         with the same name, resulting in more reliable and consistent type generation in the SDKs.
       type: fix
   irVersion: 57
@@ -1917,7 +1924,7 @@
 
 - changelogEntry:
     - summary: |
-        Enhance OpenAPI -> IR parser to better handle inlined oneOf schemas. The parser now uses the schema ID when 
+        Enhance OpenAPI -> IR parser to better handle inlined oneOf schemas. The parser now uses the schema ID when
         generating names for oneOf variants, resulting in more predictable and consistent type names in the generated SDKs.
       type: feat
   irVersion: 57
@@ -1933,8 +1940,8 @@
 
 - changelogEntry:
     - summary: |
-        Add support for schema conversion in OpenRPC importer. The importer now properly converts schemas defined in the 
-        OpenRPC document's components section into Fern types, enabling full type definitions for request and response 
+        Add support for schema conversion in OpenRPC importer. The importer now properly converts schemas defined in the
+        OpenRPC document's components section into Fern types, enabling full type definitions for request and response
         objects. This enhancement allows for more complete and accurate SDK generation from OpenRPC specifications.
       type: feat
   irVersion: 57
@@ -1957,10 +1964,10 @@
 
 - changelogEntry:
     - summary: |
-        Enhance OpenAPI security scheme handling in the parser to support both global and endpoint-level security requirements. 
-        The parser now properly converts security schemes from OpenAPI's `securitySchemes` component into appropriate authentication 
-        headers, supporting bearer tokens, basic auth, and custom API key headers. Global security requirements defined at the 
-        document level are applied to all endpoints, while endpoint-specific security requirements override or supplement the 
+        Enhance OpenAPI security scheme handling in the parser to support both global and endpoint-level security requirements.
+        The parser now properly converts security schemes from OpenAPI's `securitySchemes` component into appropriate authentication
+        headers, supporting bearer tokens, basic auth, and custom API key headers. Global security requirements defined at the
+        document level are applied to all endpoints, while endpoint-specific security requirements override or supplement the
         global configuration, ensuring accurate authentication representation in generated SDKs.
       type: feat
   irVersion: 57
@@ -1968,9 +1975,9 @@
 
 - changelogEntry:
     - summary: |
-        Enhance example generation to consider default values when generating examples for primitive types. 
-        When a string primitive type has a default value specified, the example generator now uses this 
-        default value instead of a generic example. This produces more realistic and contextually 
+        Enhance example generation to consider default values when generating examples for primitive types.
+        When a string primitive type has a default value specified, the example generator now uses this
+        default value instead of a generic example. This produces more realistic and contextually
         appropriate examples in generated SDKs and documentation.
       type: feat
   irVersion: 57
@@ -2011,8 +2018,8 @@
 
 - changelogEntry:
     - summary: |
-        Improve OpenRPC request example generation by not wrapping request payloads in JSON-RPC 2.0 format. 
-        This ensures generated request examples match the expected format for the API's method parameters 
+        Improve OpenRPC request example generation by not wrapping request payloads in JSON-RPC 2.0 format.
+        This ensures generated request examples match the expected format for the API's method parameters
         without the additional JSON-RPC envelope.
       type: feat
   irVersion: 57
@@ -2020,9 +2027,9 @@
 
 - changelogEntry:
     - summary: |
-        Improve OpenAPI response handling for 204 status codes by respecting schema definitions. 
-        When a 204 (No Content) response includes a schema, the importer now properly processes 
-        and preserves this schema information, ensuring accurate API documentation and SDK generation 
+        Improve OpenAPI response handling for 204 status codes by respecting schema definitions.
+        When a 204 (No Content) response includes a schema, the importer now properly processes
+        and preserves this schema information, ensuring accurate API documentation and SDK generation
         even for endpoints that don't return content in successful responses.
       type: feat
   irVersion: 57
@@ -2040,7 +2047,7 @@
 
 - changelogEntry:
     - summary: |
-        Improve OpenRPC response example generation by wrapping example payloads in JSON-RPC 2.0 format with metadata 
+        Improve OpenRPC response example generation by wrapping example payloads in JSON-RPC 2.0 format with metadata
         (jsonrpc version and request id). This ensures generated examples match the actual JSON-RPC response format.
       type: feat
   irVersion: 57
@@ -2048,8 +2055,8 @@
 
 - changelogEntry:
     - summary: |
-        Improve server handling in OpenAPI imports by exploding servers with enum variables into multiple servers, 
-        one for each enum value. For example, a server with URL "https://{region}.example.com" where region 
+        Improve server handling in OpenAPI imports by exploding servers with enum variables into multiple servers,
+        one for each enum value. For example, a server with URL "https://{region}.example.com" where region
         is an enum ["us", "eu"] will be exploded into two servers: "https://us.example.com" and "https://eu.example.com".
       type: feat
   irVersion: 57
@@ -2120,7 +2127,7 @@
 
 - changelogEntry:
     - summary: |
-        Fix an issue in the OpenAPI importer where discriminated unions with literal discriminant values in the variants would render the discriminant property twice. 
+        Fix an issue in the OpenAPI importer where discriminated unions with literal discriminant values in the variants would render the discriminant property twice.
         The importer now correctly checks if union variants contain the discriminant property as a literal value and handles them appropriately.
       type: fix
   irVersion: 57
@@ -2156,7 +2163,7 @@
 
 - changelogEntry:
     - summary: |
-        Fix an issue in the OpenAPI parser where array references were not being properly resolved. The parser now correctly resolves references 
+        Fix an issue in the OpenAPI parser where array references were not being properly resolved. The parser now correctly resolves references
         within array schemas, ensuring that arrays of referenced types are properly handled throughout the API definition.
       type: fix
   irVersion: 57
@@ -2164,7 +2171,7 @@
 
 - changelogEntry:
     - summary: |
-        Improve the ReadMe migrator to respect the original navigation structure when creating the file hierarchy. Previously, nested navigation groups were 
+        Improve the ReadMe migrator to respect the original navigation structure when creating the file hierarchy. Previously, nested navigation groups were
         flattened, but now the file structure will mirror the navigation hierarchy, preserving the original organization of documentation.
       type: fix
   irVersion: 57


### PR DESCRIPTION
## Description
Adds support for the syntax `const: "something"` notation, which parses into the equivalent `enum: ["something"]`.

## Changes Made
Tiny change to `convertSchemaObject()`.

## Testing
Added the `const` fixture; this change results in some meaningless reorderings in the `assembly` and `hume` fixtures in the IR also, which required a `test:update`.
- [X] Unit tests added/updated
- [X] Manual testing completed

