### PR TITLE
chore(internal): Disable format on save in .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,7 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
     "source.fixAll.biome": "explicit"


### PR DESCRIPTION
## Description
Now that biome check is included in CI checks, we probably don't need this.
Plus it was causing issues where editing config files would result in large whitespace changes, which weren't relevant to the intended change.