### PR TITLE
fix(go): certain values being `Sprintf`ed incorrectly into pointers

### DIFF
--- a/generators/go-v2/base/src/context/GoValueFormatter.ts
+++ b/generators/go-v2/base/src/context/GoValueFormatter.ts
@@ -122,28 +122,26 @@ export class GoValueFormatter {
             isPrimitive = true;
         }
 
-        // merge the two
-        if (unwrapPrefix) {
-            const origPrefix = prefix;
-            prefix = origPrefix
+        // merge prefix and suffix with unwrap logic
+        const mergedPrefix = unwrapPrefix != undefined
+            ? (prefix != undefined
                 ? go.codeblock((writer) => {
-                      writer.writeNode(origPrefix);
-                      writer.writeNode(unwrapPrefix);
-                  })
-                : unwrapPrefix;
-        }
-        if (unwrapSuffix) {
-            const origSuffix = suffix;
-            suffix = origSuffix
+                    writer.writeNode(prefix);
+                    writer.writeNode(unwrapPrefix);
+                })
+                : unwrapPrefix)
+            : prefix;
+        const mergedSuffix = unwrapSuffix != undefined
+            ? (suffix != undefined
                 ? go.codeblock((writer) => {
-                      writer.writeNode(unwrapSuffix);
-                      writer.writeNode(origSuffix);
-                  })
-                : unwrapSuffix;
-        }
+                    writer.writeNode(unwrapSuffix);
+                    writer.writeNode(suffix);
+                })
+                : unwrapSuffix)
+            : suffix;
 
         return {
-            formatted: this.format({ prefix, suffix, value }),
+            formatted: this.format({ prefix: mergedPrefix, suffix: mergedSuffix, value }),
             zeroValue: this.context.goZeroValueMapper.convert({ reference }),
             isIterable: false,
             isOptional,

--- a/generators/go-v2/base/src/context/GoValueFormatter.ts
+++ b/generators/go-v2/base/src/context/GoValueFormatter.ts
@@ -124,7 +124,7 @@ export class GoValueFormatter {
         // merge the two
         if (unwrapPrefix) {
             if (prefix) {
-                const origPrefix = prefix
+                const origPrefix = prefix;
                 prefix = go.codeblock((writer) => {
                     writer.writeNode(origPrefix);
                     writer.writeNode(unwrapPrefix);

--- a/generators/go-v2/base/src/context/GoValueFormatter.ts
+++ b/generators/go-v2/base/src/context/GoValueFormatter.ts
@@ -123,22 +123,24 @@ export class GoValueFormatter {
         }
 
         // merge prefix and suffix with unwrap logic
-        const mergedPrefix = unwrapPrefix != undefined
-            ? (prefix != undefined
-                ? go.codeblock((writer) => {
-                    writer.writeNode(prefix);
-                    writer.writeNode(unwrapPrefix);
-                })
-                : unwrapPrefix)
-            : prefix;
-        const mergedSuffix = unwrapSuffix != undefined
-            ? (suffix != undefined
-                ? go.codeblock((writer) => {
-                    writer.writeNode(unwrapSuffix);
-                    writer.writeNode(suffix);
-                })
-                : unwrapSuffix)
-            : suffix;
+        const mergedPrefix =
+            unwrapPrefix != undefined
+                ? prefix != undefined
+                    ? go.codeblock((writer) => {
+                          writer.writeNode(prefix);
+                          writer.writeNode(unwrapPrefix);
+                      })
+                    : unwrapPrefix
+                : prefix;
+        const mergedSuffix =
+            unwrapSuffix != undefined
+                ? suffix != undefined
+                    ? go.codeblock((writer) => {
+                          writer.writeNode(unwrapSuffix);
+                          writer.writeNode(suffix);
+                      })
+                    : unwrapSuffix
+                : suffix;
 
         return {
             formatted: this.format({ prefix: mergedPrefix, suffix: mergedSuffix, value }),

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.6.5-rc0
+  changelogEntry:
+    - summary: |
+        Fix certain instances of fmt.Sprintf'd values failing to be dereferenced.
+      type: fix
+  createdAt: '2025-08-25'
+  irVersion: 58
+
 - version: 1.6.4-rc0
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/file-upload/no-custom-config/service/raw_client.go
+++ b/seed/go-sdk/file-upload/no-custom-config/service/raw_client.go
@@ -73,7 +73,7 @@ func (r *RawClient) Post(
 		}
 	}
 	if request.MaybeInteger != nil {
-		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", *request.MaybeInteger)); err != nil {
 			return nil, err
 		}
 	}
@@ -401,7 +401,7 @@ func (r *RawClient) WithFormEncodedContainers(
 		}
 	}
 	if request.MaybeInteger != nil {
-		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", *request.MaybeInteger)); err != nil {
 			return nil, err
 		}
 	}

--- a/seed/go-sdk/file-upload/package-name/service/raw_client.go
+++ b/seed/go-sdk/file-upload/package-name/service/raw_client.go
@@ -73,7 +73,7 @@ func (r *RawClient) Post(
 		}
 	}
 	if request.MaybeInteger != nil {
-		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", *request.MaybeInteger)); err != nil {
 			return nil, err
 		}
 	}
@@ -401,7 +401,7 @@ func (r *RawClient) WithFormEncodedContainers(
 		}
 	}
 	if request.MaybeInteger != nil {
-		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", *request.MaybeInteger)); err != nil {
 			return nil, err
 		}
 	}

--- a/seed/go-sdk/file-upload/v0/service/raw_client.go
+++ b/seed/go-sdk/file-upload/v0/service/raw_client.go
@@ -78,7 +78,7 @@ func (r *RawClient) Post(
 		}
 	}
 	if request.MaybeInteger != nil {
-		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", *request.MaybeInteger)); err != nil {
 			return nil, err
 		}
 	}
@@ -412,7 +412,7 @@ func (r *RawClient) WithFormEncodedContainers(
 		}
 	}
 	if request.MaybeInteger != nil {
-		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", request.MaybeInteger)); err != nil {
+		if err := writer.WriteField("maybe_integer", fmt.Sprintf("%v", *request.MaybeInteger)); err != nil {
 			return nil, err
 		}
 	}

--- a/seed/go-sdk/pagination/users/client.go
+++ b/seed/go-sdk/pagination/users/client.go
@@ -187,7 +187,7 @@ func (c *Client) ListWithOffsetPagination(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("page", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {
@@ -247,7 +247,7 @@ func (c *Client) ListWithDoubleOffsetPagination(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*float64]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("page", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {
@@ -323,7 +323,7 @@ func (c *Client) ListWithOffsetStepPagination(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("page", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {
@@ -383,7 +383,7 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("page", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {
@@ -443,7 +443,7 @@ func (c *Client) ListWithExtendedResults(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*uuid.UUID]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("cursor", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("cursor", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {
@@ -500,7 +500,7 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*uuid.UUID]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("cursor", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("cursor", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {
@@ -617,7 +617,7 @@ func (c *Client) ListWithGlobalConfig(
 	)
 	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
-			queryParams.Set("offset", fmt.Sprintf("%v", pageRequest.Cursor))
+			queryParams.Set("offset", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
 		nextURL := endpointURL
 		if len(queryParams) > 0 {


### PR DESCRIPTION
## Description
Certain values would appear in a code chunk like the following in a `client.go` or `raw_client.go` file:
```go
if pageRequest.Cursor != nil {
	queryParams.Set("page", fmt.Sprintf("%v", pageRequest.Cursor))
}
```
But `pageRequest.Cursor` is a `*int`, not an `int`; this needs an extra `*`, which hopefully this PR provides.

## Changes Made
In `base/src/context/GoValueFormatter.ts`, there were several assignments to `prefix`, each of which would overwrite the last; this PR makes it so that the prefix is prepended to over these assignments rather than continually replaced.

## Testing
Updated the Go snapshots to reflect the change; you can see the only changes are in the places where a dereference would be correct.
- [X] Unit tests added/updated
- [X] Manual testing completed

