### PR TITLE
fix(csharp): Support literal values in dynamic snippet generation

### DIFF
--- a/generators/csharp/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/csharp/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -66,6 +66,7 @@ await client.Service.CreateBigEntityAsync(
             Title = "Pulp Fiction",
             From = "Quentin Tarantino",
             Rating = 8.5,
+            Type = "movie",
             Tag = "tag-12efs9dv",
             Metadata = new Dictionary<string, object>(){
                 ["academyAward"] = true,
@@ -110,6 +111,7 @@ await client.Service.CreateMovieAsync(
         Title = "The Boy and the Heron",
         From = "Hayao Miyazaki",
         Rating = 8,
+        Type = "movie",
         Tag = "development",
         Metadata = new Dictionary<string, object>(){
             ["actors"] = new List<object>() {

--- a/generators/csharp/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/csharp/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -43,7 +43,7 @@ export class DynamicTypeLiteralMapper {
             case "list":
                 return this.convertList({ list: args.typeReference.value, value: args.value });
             case "literal":
-                return csharp.TypeLiteral.nop();
+                return this.convertLiteral({ literal: args.typeReference.value, value: args.value });
             case "map":
                 return this.convertMap({ map: args.typeReference, value: args.value });
             case "named": {
@@ -87,6 +87,33 @@ export class DynamicTypeLiteralMapper {
                 }
             })
         });
+    }
+
+    private convertLiteral({
+        literal,
+        value
+    }: {
+        literal: FernIr.dynamic.LiteralType;
+        value: unknown;
+    }): csharp.TypeLiteral {
+        switch (literal.type) {
+            case "boolean": {
+                const bool = this.context.getValueAsBoolean({ value });
+                if (bool == null) {
+                    return csharp.TypeLiteral.nop();
+                }
+                return csharp.TypeLiteral.boolean(bool);
+            }
+            case "string": {
+                const str = this.context.getValueAsString({ value });
+                if (str == null) {
+                    return csharp.TypeLiteral.nop();
+                }
+                return csharp.TypeLiteral.string(str);
+            }
+            default:
+                assertNever(literal);
+        }
     }
 
     private convertSet({ set, value }: { set: FernIr.dynamic.TypeReference; value: unknown }): csharp.TypeLiteral {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.15
+  changelogEntry:
+    - type: fix
+      summary: Ensure dynamic snippet method calls can use literal values
+  createdAt: '2025-08-25'
+  irVersion: 58
 - version: 2.1.14
   changelogEntry:
     - type: fix

--- a/seed/csharp-sdk/any-auth/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedApi.DynamicSnippets/Example0.cs
@@ -17,6 +17,8 @@ public class Example0
             new GetTokenRequest{
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedApi.DynamicSnippets/Example2.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedApi.DynamicSnippets/Example2.cs
@@ -19,7 +19,8 @@ public class Example2
                 Line2 = "line2",
                 City = "city",
                 State = "state",
-                Zip = "zip"
+                Zip = "zip",
+                Country = "USA"
             }
         );
     }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedApi.DynamicSnippets/Example3.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedApi.DynamicSnippets/Example3.cs
@@ -21,7 +21,8 @@ public class Example3
                     Line2 = "line2",
                     City = "city",
                     State = "state",
-                    Zip = "zip"
+                    Zip = "zip",
+                    Country = "USA"
                 }
             }
         );

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedApi.DynamicSnippets/Example0.cs
@@ -18,7 +18,8 @@ public class Example0
                 Line2 = "line2",
                 City = "city",
                 State = "state",
-                Zip = "zip"
+                Zip = "zip",
+                Country = "USA"
             }
         );
     }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedApi.DynamicSnippets/Example1.cs
@@ -20,7 +20,8 @@ public class Example1
                     Line2 = "line2",
                     City = "city",
                     State = "state",
-                    Zip = "zip"
+                    Zip = "zip",
+                    Country = "USA"
                 }
             }
         );

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedApi.DynamicSnippets/Example2.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedApi.DynamicSnippets/Example2.cs
@@ -20,7 +20,8 @@ public class Example2
                     Line2 = "line2",
                     City = "city",
                     State = "state",
-                    Zip = "zip"
+                    Zip = "zip",
+                    Country = "USA"
                 }
             }
         );

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedApi.DynamicSnippets/Example14.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedApi.DynamicSnippets/Example14.cs
@@ -20,6 +20,7 @@ public class Example14
                 Title = "The Boy and the Heron",
                 From = "Hayao Miyazaki",
                 Rating = 8,
+                Type = "movie",
                 Tag = "tag-wf9as23d",
                 Metadata = new Dictionary<string, object>(){
                     ["actors"] = new List<object>() {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedApi.DynamicSnippets/Example15.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedApi.DynamicSnippets/Example15.cs
@@ -20,6 +20,7 @@ public class Example15
                 Title = "title",
                 From = "from",
                 Rating = 1.1,
+                Type = "movie",
                 Tag = "tag",
                 Book = "book",
                 Metadata = new Dictionary<string, object>(){

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedApi.DynamicSnippets/Example18.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedApi.DynamicSnippets/Example18.cs
@@ -31,6 +31,7 @@ public class Example18
                     Title = "title",
                     From = "from",
                     Rating = 1.1,
+                    Type = "movie",
                     Tag = "tag",
                     Book = "book",
                     Metadata = new Dictionary<string, object>(){

--- a/seed/csharp-sdk/examples/readme-config/src/SeedApi.DynamicSnippets/Example14.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedApi.DynamicSnippets/Example14.cs
@@ -20,6 +20,7 @@ public class Example14
                 Title = "The Boy and the Heron",
                 From = "Hayao Miyazaki",
                 Rating = 8,
+                Type = "movie",
                 Tag = "tag-wf9as23d",
                 Metadata = new Dictionary<string, object>(){
                     ["actors"] = new List<object>() {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedApi.DynamicSnippets/Example15.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedApi.DynamicSnippets/Example15.cs
@@ -20,6 +20,7 @@ public class Example15
                 Title = "title",
                 From = "from",
                 Rating = 1.1,
+                Type = "movie",
                 Tag = "tag",
                 Book = "book",
                 Metadata = new Dictionary<string, object>(){

--- a/seed/csharp-sdk/examples/readme-config/src/SeedApi.DynamicSnippets/Example18.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedApi.DynamicSnippets/Example18.cs
@@ -31,6 +31,7 @@ public class Example18
                     Title = "title",
                     From = "from",
                     Rating = 1.1,
+                    Type = "movie",
                     Tag = "tag",
                     Book = "book",
                     Metadata = new Dictionary<string, object>(){

--- a/seed/csharp-sdk/extra-properties/no-additional-properties/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/extra-properties/no-additional-properties/src/SeedApi.DynamicSnippets/Example0.cs
@@ -14,6 +14,8 @@ public class Example0
 
         await client.User.CreateUserAsync(
             new CreateUserRequest{
+                Type = "CreateUserRequest",
+                Version = "v1",
                 Name = "name"
             }
         );

--- a/seed/csharp-sdk/extra-properties/no-custom-config/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/extra-properties/no-custom-config/src/SeedApi.DynamicSnippets/Example0.cs
@@ -14,6 +14,8 @@ public class Example0
 
         await client.User.CreateUserAsync(
             new CreateUserRequest{
+                Type = "CreateUserRequest",
+                Version = "v1",
                 Name = "name"
             }
         );

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedApi.DynamicSnippets/Example0.cs
@@ -17,6 +17,8 @@ public class Example0
                 XApiKey = "X-Api-Key",
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedApi.DynamicSnippets/Example1.cs
@@ -18,6 +18,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedApi.DynamicSnippets/Example0.cs
@@ -17,6 +17,8 @@ public class Example0
                 XApiKey = "X-Api-Key",
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedApi.DynamicSnippets/Example1.cs
@@ -18,6 +18,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedApi.DynamicSnippets/Example0.cs
@@ -17,6 +17,8 @@ public class Example0
                 XApiKey = "X-Api-Key",
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedApi.DynamicSnippets/Example1.cs
@@ -18,6 +18,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example0.cs
@@ -14,6 +14,8 @@ public class Example0
 
         await client.Headers.SendAsync(
             new SendLiteralsInHeadersRequest{
+                EndpointVersion = "02-12-2024",
+                Async = true,
                 Query = "What is the weather today"
             }
         );

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example1.cs
@@ -14,6 +14,8 @@ public class Example1
 
         await client.Headers.SendAsync(
             new SendLiteralsInHeadersRequest{
+                EndpointVersion = "02-12-2024",
+                Async = true,
                 Query = "query"
             }
         );

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example2.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example2.cs
@@ -15,9 +15,16 @@ public class Example2
         await client.Inlined.SendAsync(
             new SendLiteralsInlinedRequest{
                 Temperature = 10.1,
+                Prompt = "You are a helpful assistant",
+                Context = "You're super wise",
+                AliasedContext = "You're super wise",
+                MaybeContext = "You're super wise",
                 ObjectWithLiteral = new ATopLevelLiteral{
-                    NestedLiteral = new ANestedLiteral()
+                    NestedLiteral = new ANestedLiteral{
+                        MyLiteral = "How super cool"
+                    }
                 },
+                Stream = false,
                 Query = "What is the weather today"
             }
         );

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example3.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example3.cs
@@ -14,10 +14,17 @@ public class Example3
 
         await client.Inlined.SendAsync(
             new SendLiteralsInlinedRequest{
+                Prompt = "You are a helpful assistant",
+                Context = "You're super wise",
                 Query = "query",
                 Temperature = 1.1,
+                Stream = false,
+                AliasedContext = "You're super wise",
+                MaybeContext = "You're super wise",
                 ObjectWithLiteral = new ATopLevelLiteral{
-                    NestedLiteral = new ANestedLiteral()
+                    NestedLiteral = new ANestedLiteral{
+                        MyLiteral = "How super cool"
+                    }
                 }
             }
         );

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example4.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example4.cs
@@ -13,7 +13,7 @@ public class Example4
         );
 
         await client.Path.SendAsync(
-
+            "123"
         );
     }
 

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example5.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example5.cs
@@ -13,7 +13,7 @@ public class Example5
         );
 
         await client.Path.SendAsync(
-
+            "123"
         );
     }
 

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example6.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example6.cs
@@ -14,6 +14,14 @@ public class Example6
 
         await client.Query.SendAsync(
             new SendLiteralsInQueryRequest{
+                Prompt = "You are a helpful assistant",
+                OptionalPrompt = "You are a helpful assistant",
+                AliasPrompt = "You are a helpful assistant",
+                AliasOptionalPrompt = "You are a helpful assistant",
+                Stream = false,
+                OptionalStream = false,
+                AliasStream = false,
+                AliasOptionalStream = false,
                 Query = "What is the weather today"
             }
         );

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example7.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example7.cs
@@ -14,7 +14,15 @@ public class Example7
 
         await client.Query.SendAsync(
             new SendLiteralsInQueryRequest{
-                Query = "query"
+                Prompt = "You are a helpful assistant",
+                OptionalPrompt = "You are a helpful assistant",
+                AliasPrompt = "You are a helpful assistant",
+                AliasOptionalPrompt = "You are a helpful assistant",
+                Query = "query",
+                Stream = false,
+                OptionalStream = false,
+                AliasStream = false,
+                AliasOptionalStream = false
             }
         );
     }

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example8.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example8.cs
@@ -14,10 +14,15 @@ public class Example8
 
         await client.Reference.SendAsync(
             new SendRequest{
+                Prompt = "You are a helpful assistant",
+                Stream = false,
+                Context = "You're super wise",
                 Query = "What is the weather today",
                 ContainerObject = new ContainerObject{
                     NestedObjects = new List<NestedObjectWithLiterals>(){
                         new NestedObjectWithLiterals{
+                            Literal1 = "literal1",
+                            Literal2 = "literal2",
                             StrProp = "strProp"
                         },
                     }

--- a/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example9.cs
+++ b/seed/csharp-sdk/literal/src/SeedApi.DynamicSnippets/Example9.cs
@@ -14,13 +14,22 @@ public class Example9
 
         await client.Reference.SendAsync(
             new SendRequest{
+                Prompt = "You are a helpful assistant",
                 Query = "query",
+                Stream = false,
+                Ending = "$ending",
+                Context = "You're super wise",
+                MaybeContext = "You're super wise",
                 ContainerObject = new ContainerObject{
                     NestedObjects = new List<NestedObjectWithLiterals>(){
                         new NestedObjectWithLiterals{
+                            Literal1 = "literal1",
+                            Literal2 = "literal2",
                             StrProp = "strProp"
                         },
                         new NestedObjectWithLiterals{
+                            Literal1 = "literal1",
+                            Literal2 = "literal2",
                             StrProp = "strProp"
                         },
                     }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedApi.DynamicSnippets/Example0.cs
@@ -20,6 +20,8 @@ public class Example0
                 Csr = "csr",
                 Scp = "scp",
                 EntityId = "entity_id",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedApi.DynamicSnippets/Example1.cs
@@ -19,6 +19,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedApi.DynamicSnippets/Example0.cs
@@ -17,7 +17,8 @@ public class Example0
         await client.Auth.GetTokenAsync(
             new GetTokenRequest{
                 ClientId = "client_id",
-                ClientSecret = "client_secret"
+                ClientSecret = "client_secret",
+                GrantType = "client_credentials"
             }
         );
     }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedApi.DynamicSnippets/Example0.cs
@@ -18,6 +18,8 @@ public class Example0
             new GetTokenRequest{
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedApi.DynamicSnippets/Example1.cs
@@ -19,6 +19,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedApi.DynamicSnippets/Example0.cs
@@ -19,6 +19,8 @@ public class Example0
             new GetTokenRequest{
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedApi.DynamicSnippets/Example0.cs
@@ -18,6 +18,8 @@ public class Example0
             new GetTokenRequest{
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedApi.DynamicSnippets/Example1.cs
@@ -19,6 +19,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedApi.DynamicSnippets/Example0.cs
@@ -18,6 +18,8 @@ public class Example0
             new GetTokenRequest{
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedApi.DynamicSnippets/Example1.cs
@@ -19,6 +19,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedApi.DynamicSnippets/Example0.cs
@@ -18,6 +18,8 @@ public class Example0
             new GetTokenRequest{
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedApi.DynamicSnippets/Example1.cs
@@ -19,6 +19,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/seed.yml
+++ b/seed/csharp-sdk/seed.yml
@@ -177,7 +177,6 @@ fixtures:
       outputFolder: system-client
 allowedFailures:
   - imdb:exported-client-class-name
-  - literal
   - oauth-client-credentials-custom
   - pagination:no-custom-config
   - pagination:custom-pager

--- a/seed/csharp-sdk/streaming/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/streaming/src/SeedApi.DynamicSnippets/Example0.cs
@@ -14,6 +14,7 @@ public class Example0
 
         await foreach (var item in client.Dummy.GenerateStreamAsync(
             new GenerateStreamRequest{
+                Stream = true,
                 NumEvents = 1
             }
         )) {/** consume each item */};

--- a/seed/csharp-sdk/streaming/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/streaming/src/SeedApi.DynamicSnippets/Example1.cs
@@ -14,6 +14,7 @@ public class Example1
 
         await client.Dummy.GenerateAsync(
             new Generateequest{
+                Stream = false,
                 NumEvents = 5
             }
         );

--- a/seed/csharp-sdk/streaming/src/SeedApi.DynamicSnippets/Example2.cs
+++ b/seed/csharp-sdk/streaming/src/SeedApi.DynamicSnippets/Example2.cs
@@ -14,6 +14,7 @@ public class Example2
 
         await client.Dummy.GenerateAsync(
             new Generateequest{
+                Stream = false,
                 NumEvents = 1
             }
         );

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedApi.DynamicSnippets/Example0.cs
@@ -17,6 +17,8 @@ public class Example0
                 XApiKey = "X-Api-Key",
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
+                Audience = "https://api.example.com",
+                GrantType = "client_credentials",
                 Scope = "scope"
             }
         );

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedApi.DynamicSnippets/Example1.cs
@@ -18,6 +18,8 @@ public class Example1
                 ClientId = "client_id",
                 ClientSecret = "client_secret",
                 RefreshToken = "refresh_token",
+                Audience = "https://api.example.com",
+                GrantType = "refresh_token",
                 Scope = "scope"
             }
         );


### PR DESCRIPTION
## Description
Dynamic snippet calls did not support literal values in arguments.

## Changes Made
- Added `convertLiteral` support in `DynamicTypeLiteralMapper` to support string and boolean values

## Testing
<!-- Describe how you tested these changes -->
- [x] regenerated csharp-sdk (contains dynamic snippets)

