### PR TITLE
fix(go): fix ignored default values for `page`

### DIFF
--- a/generators/go-v2/sdk/src/endpoint/utils/getPaginationInfo.ts
+++ b/generators/go-v2/sdk/src/endpoint/utils/getPaginationInfo.ts
@@ -524,23 +524,29 @@ function getPagePropertyInitializer({
                     writer.newLine();
                     writer.write("if ");
                     writer.writeNode(
-                        getPropertyNilCheckCondition({
-                            variableName: "request",
-                            propertyPath: [...(pagination.page.propertyPath ?? []), pagination.page.property.name.name]
+                        hasQueryParameter({
+                            key: pagination.page.property.name.wireValue
                         })
                     );
                     writer.writeLine(" {");
                     writer.indent();
-                    writer.write("next = ");
+                    writer.writeLine("var err error");
+                    writer.write("if next, err = ");
                     writer.writeNode(
-                        getPropertyReference({
-                            variableName: "request",
-                            propertyPath: pagination.page.propertyPath,
-                            name: pagination.page.property.name.name,
-                            dereference: true
+                        go.invokeFunc({
+                            func: go.typeReference({
+                                name: "Atoi",
+                                importPath: "strconv"
+                            }),
+                            arguments_: [getQueryParameter({ key: pagination.page.property.name.wireValue })],
+                            multiline: false
                         })
                     );
-                    writer.newLine();
+                    writer.writeLine("; err != nil {");
+                    writer.indent();
+                    writer.writeLine("return nil, err");
+                    writer.dedent();
+                    writer.writeLine("}");
                     writer.dedent();
                     writer.writeLine("}");
                     return;
@@ -768,6 +774,22 @@ function setQueryParameter({ key, value }: { key: string; value: go.AstNode }): 
         writer.writeNode(go.TypeInstantiation.string(key));
         writer.write(", ");
         writer.writeNode(value);
+        writer.write(")");
+    });
+}
+
+function hasQueryParameter({ key }: { key: string }): go.AstNode {
+    return go.codeblock((writer) => {
+        writer.write("queryParams.Has(");
+        writer.writeNode(go.TypeInstantiation.string(key));
+        writer.write(")");
+    });
+}
+
+function getQueryParameter({ key }: { key: string }): go.AstNode {
+    return go.codeblock((writer) => {
+        writer.write("queryParams.Get(");
+        writer.writeNode(go.TypeInstantiation.string(key));
         writer.write(")");
     });
 }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.6.6-rc0
+  changelogEntry:
+    - summary: |
+        Fixes the ignoring of a default for `page` in pagination requests.
+      type: fix
+  createdAt: "2025-08-26"
+  irVersion: 58
+
 - version: 1.6.5-rc0
   changelogEntry:
     - summary: |
@@ -18,7 +26,7 @@
 - version: 1.6.3
   changelogEntry:
     - summary: |
-        Update the dyanmic snippet generator to handle list values in the request body.
+        Update the dynamic snippet generator to handle list values in the request body.
         Previously, it would throw an error.
       type: fix
   createdAt: "2025-08-21"

--- a/seed/go-sdk/pagination/users/client.go
+++ b/seed/go-sdk/pagination/users/client.go
@@ -11,6 +11,7 @@ import (
 	internal "github.com/pagination/fern/internal"
 	option "github.com/pagination/fern/option"
 	http "net/http"
+	strconv "strconv"
 )
 
 type Client struct {
@@ -205,8 +206,11 @@ func (c *Client) ListWithOffsetPagination(
 		}
 	}
 	next := 1
-	if request.Page != nil {
-		next = *request.Page
+	if queryParams.Has("page") {
+		var err error
+		if next, err = strconv.Atoi(queryParams.Get("page")); err != nil {
+			return nil, err
+		}
 	}
 
 	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*int, *fern.User] {
@@ -265,8 +269,11 @@ func (c *Client) ListWithDoubleOffsetPagination(
 		}
 	}
 	var next float64 = 1
-	if request.Page != nil {
-		next = *request.Page
+	if queryParams.Has("page") {
+		var err error
+		if next, err = strconv.Atoi(queryParams.Get("page")); err != nil {
+			return nil, err
+		}
 	}
 
 	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*float64, *fern.User] {
@@ -341,8 +348,11 @@ func (c *Client) ListWithOffsetStepPagination(
 		}
 	}
 	next := 1
-	if request.Page != nil {
-		next = *request.Page
+	if queryParams.Has("page") {
+		var err error
+		if next, err = strconv.Atoi(queryParams.Get("page")); err != nil {
+			return nil, err
+		}
 	}
 
 	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*int, *fern.User] {
@@ -401,8 +411,11 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 		}
 	}
 	next := 1
-	if request.Page != nil {
-		next = *request.Page
+	if queryParams.Has("page") {
+		var err error
+		if next, err = strconv.Atoi(queryParams.Get("page")); err != nil {
+			return nil, err
+		}
 	}
 
 	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*int, *fern.User] {
@@ -635,8 +648,11 @@ func (c *Client) ListWithGlobalConfig(
 		}
 	}
 	next := 1
-	if request.Offset != nil {
-		next = *request.Offset
+	if queryParams.Has("offset") {
+		var err error
+		if next, err = strconv.Atoi(queryParams.Get("offset")); err != nil {
+			return nil, err
+		}
 	}
 
 	readPageResponse := func(response *fern.UsernameContainer) *internal.PageResponse[*int, string] {


### PR DESCRIPTION
## Description
The addition of default values clashed with the setting of `page` directly from the `request` struct in `client.go` code for pagination endpoints; now the value is pulled from `queryParams`, which should respect all default-setting logic.

## Changes Made
Changes to `generators/go-v2/sdk/src/endpoint/utils/getPaginationInfo.ts`'s `getPagePropertyInitializer()` function.

## Testing
Updated seed snapshots; only changes are to the pagination codeblocks in the correct spaces; manual testing confirms the `page` default is respected.
- [X] Unit tests added/updated
- [X] Manual testing completed

