### PR TITLE
fix(go): regression in client generation code for config case that uses GoV1 generator

### DIFF
--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -134,15 +134,15 @@ func (g *Generator) Generate(mode Mode) ([]*File, error) {
 	if err != nil {
 		return nil, err
 	}
-    if g.config.PackagePath == "" {
-        return files, nil
-    }
+	if g.config.PackagePath == "" {
+		return files, nil
+	}
 
 	// Somewhat hacky fix; prefix packagePath to all .go file paths after the fact
 	for i := range files {
-	    if strings.HasSuffix(files[i].Path, ".go") {
-	        files[i].Path = path.Join(g.config.PackagePath, files[i].Path)
-	    }
+		if strings.HasSuffix(files[i].Path, ".go") {
+			files[i].Path = path.Join(g.config.PackagePath, files[i].Path)
+		}
 	}
 
 	return files, nil

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example0/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example0/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example1/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example10/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example10/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example11/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example11/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example12/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example12/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example13/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example13/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example14/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example14/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
+    fern "github.com/examples/fern"
 )
 
 func do() {
@@ -18,9 +18,9 @@ func do() {
     )
     client.Service.CreateMovie(
         context.TODO(),
-        &pleaseinhere.Movie{
+        &fern.Movie{
             Id: "movie-c06a4ad7",
-            Prequel: pleaseinhere.String(
+            Prequel: fern.String(
                 "movie-cv9b914f",
             ),
             Title: "The Boy and the Heron",

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example15/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example15/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
+    fern "github.com/examples/fern"
 )
 
 func do() {
@@ -18,16 +18,16 @@ func do() {
     )
     client.Service.CreateMovie(
         context.TODO(),
-        &pleaseinhere.Movie{
+        &fern.Movie{
             Id: "id",
-            Prequel: pleaseinhere.String(
+            Prequel: fern.String(
                 "prequel",
             ),
             Title: "title",
             From: "from",
             Rating: 1.1,
             Tag: "tag",
-            Book: pleaseinhere.String(
+            Book: fern.String(
                 "book",
             ),
             Metadata: map[string]any{

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example16/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example16/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
+    fern "github.com/examples/fern"
 )
 
 func do() {
@@ -18,12 +18,12 @@ func do() {
     )
     client.Service.GetMetadata(
         context.TODO(),
-        &pleaseinhere.GetMetadataRequest{
-            Shallow: pleaseinhere.Bool(
+        &fern.GetMetadataRequest{
+            Shallow: fern.Bool(
                 false,
             ),
             Tag: []*string{
-                pleaseinhere.String(
+                fern.String(
                     "development",
                 ),
             },

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example17/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example17/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
+    fern "github.com/examples/fern"
 )
 
 func do() {
@@ -18,12 +18,12 @@ func do() {
     )
     client.Service.GetMetadata(
         context.TODO(),
-        &pleaseinhere.GetMetadataRequest{
-            Shallow: pleaseinhere.Bool(
+        &fern.GetMetadataRequest{
+            Shallow: fern.Bool(
                 true,
             ),
             Tag: []*string{
-                pleaseinhere.String(
+                fern.String(
                     "tag",
                 ),
             },

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example18/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example18/snippet.go
@@ -1,11 +1,11 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
-    commons "github.com/examples/fern/pleaseinhere/commons"
+    fern "github.com/examples/fern"
+    commons "github.com/examples/fern/commons"
     uuid "github.com/google/uuid"
 )
 
@@ -20,27 +20,27 @@ func do() {
     )
     client.Service.CreateBigEntity(
         context.TODO(),
-        &pleaseinhere.BigEntity{
-            CastMember: &pleaseinhere.CastMember{
-                Actor: &pleaseinhere.Actor{
+        &fern.BigEntity{
+            CastMember: &fern.CastMember{
+                Actor: &fern.Actor{
                     Name: "name",
                     Id: "id",
                 },
             },
-            ExtendedMovie: &pleaseinhere.ExtendedMovie{
+            ExtendedMovie: &fern.ExtendedMovie{
                 Cast: []string{
                     "cast",
                     "cast",
                 },
                 Id: "id",
-                Prequel: pleaseinhere.String(
+                Prequel: fern.String(
                     "prequel",
                 ),
                 Title: "title",
                 From: "from",
                 Rating: 1.1,
                 Tag: "tag",
-                Book: pleaseinhere.String(
+                Book: fern.String(
                     "book",
                 ),
                 Metadata: map[string]any{
@@ -50,13 +50,13 @@ func do() {
                 },
                 Revenue: 1000000,
             },
-            Entity: &pleaseinhere.Entity{
-                Type: &pleaseinhere.Type{
-                    BasicType: pleaseinhere.BasicTypePrimitive,
+            Entity: &fern.Entity{
+                Type: &fern.Type{
+                    BasicType: fern.BasicTypePrimitive,
                 },
                 Name: "name",
             },
-            Metadata: &pleaseinhere.Metadata{
+            Metadata: &fern.Metadata{
                 Extra: map[string]string{
                     "extra": "extra",
                 },
@@ -69,7 +69,7 @@ func do() {
                 Data: map[string]string{
                     "data": "data",
                 },
-                JsonString: pleaseinhere.String(
+                JsonString: fern.String(
                     "jsonString",
                 ),
             },
@@ -79,178 +79,178 @@ func do() {
                     Data: map[string]string{
                         "data": "data",
                     },
-                    JsonString: pleaseinhere.String(
+                    JsonString: fern.String(
                         "jsonString",
                     ),
                 },
             },
             Data: &commons.Data{},
-            Migration: &pleaseinhere.Migration{
+            Migration: &fern.Migration{
                 Name: "name",
-                Status: pleaseinhere.MigrationStatusRunning,
+                Status: fern.MigrationStatusRunning,
             },
-            Exception: &pleaseinhere.Exception{
-                Generic: &pleaseinhere.ExceptionInfo{
+            Exception: &fern.Exception{
+                Generic: &fern.ExceptionInfo{
                     ExceptionType: "exceptionType",
                     ExceptionMessage: "exceptionMessage",
                     ExceptionStacktrace: "exceptionStacktrace",
                 },
             },
-            Test: &pleaseinhere.Test{},
-            Node: &pleaseinhere.Node{
+            Test: &fern.Test{},
+            Node: &fern.Node{
                 Name: "name",
-                Nodes: []*pleaseinhere.Node{
-                    &pleaseinhere.Node{
+                Nodes: []*fern.Node{
+                    &fern.Node{
                         Name: "name",
-                        Nodes: []*pleaseinhere.Node{
-                            &pleaseinhere.Node{
+                        Nodes: []*fern.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
-                            &pleaseinhere.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
                         },
-                        Trees: []*pleaseinhere.Tree{
-                            &pleaseinhere.Tree{
-                                Nodes: []*pleaseinhere.Node{},
+                        Trees: []*fern.Tree{
+                            &fern.Tree{
+                                Nodes: []*fern.Node{},
                             },
-                            &pleaseinhere.Tree{
-                                Nodes: []*pleaseinhere.Node{},
+                            &fern.Tree{
+                                Nodes: []*fern.Node{},
                             },
                         },
                     },
-                    &pleaseinhere.Node{
+                    &fern.Node{
                         Name: "name",
-                        Nodes: []*pleaseinhere.Node{
-                            &pleaseinhere.Node{
+                        Nodes: []*fern.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
-                            &pleaseinhere.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
                         },
-                        Trees: []*pleaseinhere.Tree{
-                            &pleaseinhere.Tree{
-                                Nodes: []*pleaseinhere.Node{},
+                        Trees: []*fern.Tree{
+                            &fern.Tree{
+                                Nodes: []*fern.Node{},
                             },
-                            &pleaseinhere.Tree{
-                                Nodes: []*pleaseinhere.Node{},
+                            &fern.Tree{
+                                Nodes: []*fern.Node{},
                             },
                         },
                     },
                 },
-                Trees: []*pleaseinhere.Tree{
-                    &pleaseinhere.Tree{
-                        Nodes: []*pleaseinhere.Node{
-                            &pleaseinhere.Node{
+                Trees: []*fern.Tree{
+                    &fern.Tree{
+                        Nodes: []*fern.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
-                            &pleaseinhere.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
                         },
                     },
-                    &pleaseinhere.Tree{
-                        Nodes: []*pleaseinhere.Node{
-                            &pleaseinhere.Node{
+                    &fern.Tree{
+                        Nodes: []*fern.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
-                            &pleaseinhere.Node{
+                            &fern.Node{
                                 Name: "name",
-                                Nodes: []*pleaseinhere.Node{},
-                                Trees: []*pleaseinhere.Tree{},
+                                Nodes: []*fern.Node{},
+                                Trees: []*fern.Tree{},
                             },
                         },
                     },
                 },
             },
-            Directory: &pleaseinhere.Directory{
+            Directory: &fern.Directory{
                 Name: "name",
-                Files: []*pleaseinhere.File{
-                    &pleaseinhere.File{
+                Files: []*fern.File{
+                    &fern.File{
                         Name: "name",
                         Contents: "contents",
                     },
-                    &pleaseinhere.File{
+                    &fern.File{
                         Name: "name",
                         Contents: "contents",
                     },
                 },
-                Directories: []*pleaseinhere.Directory{
-                    &pleaseinhere.Directory{
+                Directories: []*fern.Directory{
+                    &fern.Directory{
                         Name: "name",
-                        Files: []*pleaseinhere.File{
-                            &pleaseinhere.File{
+                        Files: []*fern.File{
+                            &fern.File{
                                 Name: "name",
                                 Contents: "contents",
                             },
-                            &pleaseinhere.File{
+                            &fern.File{
                                 Name: "name",
                                 Contents: "contents",
                             },
                         },
-                        Directories: []*pleaseinhere.Directory{
-                            &pleaseinhere.Directory{
+                        Directories: []*fern.Directory{
+                            &fern.Directory{
                                 Name: "name",
-                                Files: []*pleaseinhere.File{},
-                                Directories: []*pleaseinhere.Directory{},
+                                Files: []*fern.File{},
+                                Directories: []*fern.Directory{},
                             },
-                            &pleaseinhere.Directory{
+                            &fern.Directory{
                                 Name: "name",
-                                Files: []*pleaseinhere.File{},
-                                Directories: []*pleaseinhere.Directory{},
+                                Files: []*fern.File{},
+                                Directories: []*fern.Directory{},
                             },
                         },
                     },
-                    &pleaseinhere.Directory{
+                    &fern.Directory{
                         Name: "name",
-                        Files: []*pleaseinhere.File{
-                            &pleaseinhere.File{
+                        Files: []*fern.File{
+                            &fern.File{
                                 Name: "name",
                                 Contents: "contents",
                             },
-                            &pleaseinhere.File{
+                            &fern.File{
                                 Name: "name",
                                 Contents: "contents",
                             },
                         },
-                        Directories: []*pleaseinhere.Directory{
-                            &pleaseinhere.Directory{
+                        Directories: []*fern.Directory{
+                            &fern.Directory{
                                 Name: "name",
-                                Files: []*pleaseinhere.File{},
-                                Directories: []*pleaseinhere.Directory{},
+                                Files: []*fern.File{},
+                                Directories: []*fern.Directory{},
                             },
-                            &pleaseinhere.Directory{
+                            &fern.Directory{
                                 Name: "name",
-                                Files: []*pleaseinhere.File{},
-                                Directories: []*pleaseinhere.Directory{},
+                                Files: []*fern.File{},
+                                Directories: []*fern.Directory{},
                             },
                         },
                     },
                 },
             },
-            Moment: &pleaseinhere.Moment{
+            Moment: &fern.Moment{
                 Id: uuid.MustParse(
                     "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
                 ),
-                Date: pleaseinhere.MustParseDateTime(
+                Date: fern.MustParseDateTime(
                     "2023-01-15",
                 ),
-                Datetime: pleaseinhere.MustParseDateTime(
+                Datetime: fern.MustParseDateTime(
                     "2024-01-15T09:30:00Z",
                 ),
             },

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example19/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example2/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example2/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example20/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example20/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
+    fern "github.com/examples/fern"
 )
 
 func do() {
@@ -18,7 +18,7 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
-        &pleaseinhere.RefreshTokenRequest{
+        &fern.RefreshTokenRequest{
             Ttl: 420,
         },
     )

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example21/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example21/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    pleaseinhere "github.com/examples/fern/pleaseinhere"
+    fern "github.com/examples/fern"
 )
 
 func do() {
@@ -18,7 +18,7 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
-        &pleaseinhere.RefreshTokenRequest{
+        &fern.RefreshTokenRequest{
             Ttl: 1,
         },
     )

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example3/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example3/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example4/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example4/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example5/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example5/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    file "github.com/examples/fern/pleaseinhere/file"
+    file "github.com/examples/fern/file"
 )
 
 func do() {

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example6/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example6/snippet.go
@@ -1,10 +1,10 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
-    file "github.com/examples/fern/pleaseinhere/file"
+    file "github.com/examples/fern/file"
 )
 
 func do() {

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example7/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example7/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example8/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example8/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example9/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example9/snippet.go
@@ -1,8 +1,8 @@
 package example
 
 import (
-    client "github.com/examples/fern/pleaseinhere/client"
-    option "github.com/examples/fern/pleaseinhere/option"
+    client "github.com/examples/fern/client"
+    option "github.com/examples/fern/option"
     context "context"
 )
 

--- a/seed/go-sdk/imdb/flat-package-layout-with-custom-client-name/imdb.go
+++ b/seed/go-sdk/imdb/flat-package-layout-with-custom-client-name/imdb.go
@@ -15,13 +15,12 @@ import (
 type ImdbClient struct {
 	baseURL string
 	caller  *internal.Caller
-	header  http.Header
+	options *core.RequestOptions
 
 	WithRawResponse *RawImdbClient
 }
 
-func NewImdbClient(opts ...option.RequestOption) *ImdbClient {
-	options := core.NewRequestOptions(opts...)
+func NewImdbClient(options *core.RequestOptions) *ImdbClient {
 	return &ImdbClient{
 		baseURL: options.BaseURL,
 		caller: internal.NewCaller(
@@ -30,7 +29,7 @@ func NewImdbClient(opts ...option.RequestOption) *ImdbClient {
 				MaxAttempts: options.MaxAttempts,
 			},
 		),
-		header:          options.ToHeader(),
+		options:         options,
 		WithRawResponse: NewRawImdbClient(options),
 	}
 }
@@ -49,7 +48,7 @@ func (i *ImdbClient) CreateMovie(
 	)
 	endpointURL := baseURL + "/movies/create-movie"
 	headers := internal.MergeHeaders(
-		i.header.Clone(),
+		i.options.ToHeader(),
 		options.ToHeader(),
 	)
 
@@ -89,7 +88,7 @@ func (i *ImdbClient) GetMovie(
 		movieId,
 	)
 	headers := internal.MergeHeaders(
-		i.header.Clone(),
+		i.options.ToHeader(),
 		options.ToHeader(),
 	)
 	errorCodes := internal.ErrorCodes{

--- a/seed/go-sdk/imdb/flat-package-layout/imdb.go
+++ b/seed/go-sdk/imdb/flat-package-layout/imdb.go
@@ -15,13 +15,12 @@ import (
 type ImdbClient struct {
 	baseURL string
 	caller  *internal.Caller
-	header  http.Header
+	options *core.RequestOptions
 
 	WithRawResponse *RawImdbClient
 }
 
-func NewImdbClient(opts ...option.RequestOption) *ImdbClient {
-	options := core.NewRequestOptions(opts...)
+func NewImdbClient(options *core.RequestOptions) *ImdbClient {
 	return &ImdbClient{
 		baseURL: options.BaseURL,
 		caller: internal.NewCaller(
@@ -30,7 +29,7 @@ func NewImdbClient(opts ...option.RequestOption) *ImdbClient {
 				MaxAttempts: options.MaxAttempts,
 			},
 		),
-		header:          options.ToHeader(),
+		options:         options,
 		WithRawResponse: NewRawImdbClient(options),
 	}
 }
@@ -49,7 +48,7 @@ func (i *ImdbClient) CreateMovie(
 	)
 	endpointURL := baseURL + "/movies/create-movie"
 	headers := internal.MergeHeaders(
-		i.header.Clone(),
+		i.options.ToHeader(),
 		options.ToHeader(),
 	)
 
@@ -89,7 +88,7 @@ func (i *ImdbClient) GetMovie(
 		movieId,
 	)
 	headers := internal.MergeHeaders(
-		i.header.Clone(),
+		i.options.ToHeader(),
 		options.ToHeader(),
 	)
 	errorCodes := internal.ErrorCodes{


### PR DESCRIPTION
## Description
Without fully understanding all of the code paths, there is a particular config option that forces client generation using the go v1 generator (line [here](https://github.com/fern-api/fern/blob/8062163a50342b133d4ac6436a4d63ed02750248/generators/go/internal/generator/generator.go#L205)) therefore we still need to apply the logic changes from https://github.com/fern-api/fern/pull/8956 into the go v1 generator also.

> [!NOTE]  
> Open Question: Should I invest the time now into porting over support for the `PackageLayoutFlat` config option to the v2 generator so we don't have core logic split over both generators?

## Changes Made
- Added the new client/subclient structure to the go v1 generator
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed

