### PR TITLE
feat(swift): allow customizing module name

### DIFF
--- a/generators/swift/codegen/src/custom-config/BaseSwiftCustomConfigSchema.ts
+++ b/generators/swift/codegen/src/custom-config/BaseSwiftCustomConfigSchema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const BaseSwiftCustomConfigSchema = z.object({
+    moduleName: z.string().optional(),
     clientClassName: z.string().optional(),
     environmentEnumName: z.string().optional()
 });

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.11.0
+  createdAt: "2025-08-26"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Added `moduleName` generator config option to allow customizing the module name.
+  irVersion: 59
+
 - version: 0.10.0
   createdAt: "2025-08-24"
   changelogEntry:

--- a/seed/swift-sdk/client-side-params/with-custom-config/Package.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "ClientSideParams",
+    name: "MyCustomModule",
     platforms: [
         .iOS(.v15),
         .macOS(.v12),
@@ -12,14 +12,14 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "ClientSideParams",
-            targets: ["ClientSideParams"]
+            name: "MyCustomModule",
+            targets: ["MyCustomModule"]
         )
     ],
     dependencies: [],
     targets: [
         .target(
-            name: "ClientSideParams",
+            name: "MyCustomModule",
             path: "Sources"
         )
     ]

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Object/ObjectClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Object/ObjectClient.swift
@@ -66,14 +66,4 @@ public final class ObjectClient: Sendable {
             responseType: NestedObjectWithRequiredField.self
         )
     }
-
-    public func testIntegerOverflowEdgeCases(request: ObjectWithOptionalField, requestOptions: RequestOptions? = nil) async throws -> ObjectWithOptionalField {
-        return try await httpClient.performRequest(
-            method: .post,
-            path: "/object/test-integer-overflow-edge-cases",
-            body: request,
-            requestOptions: requestOptions,
-            responseType: ObjectWithOptionalField.self
-        )
-    }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Schemas/Operand.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Schemas/Operand.swift
@@ -6,6 +6,6 @@ public enum Operand: String, Codable, Hashable, CaseIterable, Sendable {
     case greaterThan = ">"
     case equalTo = "="
     /// The name and value should be similar
-    /// are similar for less than. 
+    /// are similar for less than.
     case lessThan = "less_than"
 }

--- a/seed/swift-sdk/nullable-optional/Package.swift
+++ b/seed/swift-sdk/nullable-optional/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "NullableOptional",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "NullableOptional",
+            targets: ["NullableOptional"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "NullableOptional",
+            path: "Sources"
+        )
+    ]
+)

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTP.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct HTTP {
+    enum Method: String, CaseIterable {
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case delete = "DELETE"
+        case patch = "PATCH"
+        case head = "HEAD"
+    }
+
+    enum ContentType: String, CaseIterable {
+        case applicationJson = "application/json"
+        case applicationOctetStream = "application/octet-stream"
+    }
+
+    enum RequestBody {
+        case jsonEncodable(any Encodable)
+        case data(Data)
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+final class HTTPClient: Sendable {
+    private let clientConfig: ClientConfig
+    private let jsonEncoder = Serde.jsonEncoder
+    private let jsonDecoder = Serde.jsonDecoder
+
+    init(config: ClientConfig) {
+        self.clientConfig = config
+    }
+
+    /// Performs a request with no response.
+    func performRequest(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil
+    ) async throws {
+        _ = try await performRequest(
+            method: method,
+            path: path,
+            contentType: requestContentType,
+            headers: requestHeaders,
+            queryParams: requestQueryParams,
+            body: requestBody,
+            requestOptions: requestOptions,
+            responseType: Data.self
+        )
+    }
+
+    /// Performs a request with the specified response type.
+    func performRequest<T: Decodable>(
+        method: HTTP.Method,
+        path: String,
+        contentType requestContentType: HTTP.ContentType = .applicationJson,
+        headers requestHeaders: [String: String] = [:],
+        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        body requestBody: (any Encodable)? = nil,
+        requestOptions: RequestOptions? = nil,
+        responseType: T.Type
+    ) async throws -> T {
+        let requestBody: HTTP.RequestBody? = requestBody.map { body in
+            if let data = body as? Data {
+                return .data(data)
+            } else {
+                return .jsonEncodable(body)
+            }
+        }
+
+        let request = try await buildRequest(
+            method: method,
+            path: path,
+            requestContentType: requestContentType,
+            requestHeaders: requestHeaders,
+            requestQueryParams: requestQueryParams,
+            requestBody: requestBody,
+            requestOptions: requestOptions
+        )
+
+        let (data, _) = try await executeRequestWithURLSession(request)
+
+        if responseType == Data.self {
+            if let data = data as? T {
+                return data
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+        
+        if responseType == String.self {
+            if let string = String(data: data, encoding: .utf8) as? T {
+                return string
+            } else {
+                throw ClientError.invalidResponse
+            }
+        }
+
+        do {
+            return try jsonDecoder.decode(responseType, from: data)
+        } catch {
+            throw ClientError.decodingError(error)
+        }
+    }
+
+    private func buildRequest(
+        method: HTTP.Method,
+        path: String,
+        requestContentType: HTTP.ContentType,
+        requestHeaders: [String: String],
+        requestQueryParams: [String: QueryParameter?],
+        requestBody: HTTP.RequestBody? = nil,
+        requestOptions: RequestOptions? = nil
+    ) async throws -> URLRequest {
+        // Init with URL
+        let url = buildRequestURL(
+            path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
+        )
+        var request = URLRequest(url: url)
+
+        // Set timeout
+        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
+        if let timeout = requestOptions?.timeout {
+            request.timeoutInterval = TimeInterval(timeout)
+        }
+
+        // Set method
+        request.httpMethod = method.rawValue
+
+        // Set headers
+        let headers = try await buildRequestHeaders(
+            requestContentType: requestContentType,
+            requestHeaders: requestHeaders,
+            requestOptions: requestOptions
+        )
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        // Set body
+        if let requestBody = requestBody {
+            request.httpBody = buildRequestBody(
+                requestBody: requestBody,
+                requestOptions: requestOptions
+            )
+        }
+
+        return request
+    }
+
+    private func buildRequestURL(
+        path: String,
+        requestQueryParams: [String: QueryParameter?],
+        requestOptions: RequestOptions? = nil
+    ) -> URL {
+        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
+        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+            precondition(
+                false,
+                "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
+            )
+        }
+        if !requestQueryParams.isEmpty {
+            components.queryItems = requestQueryParams.map { key, value in
+                URLQueryItem(name: key, value: value?.toString())
+            }
+        }
+        if let additionalQueryParams = requestOptions?.additionalQueryParameters {
+            components.queryItems?.append(
+                contentsOf: additionalQueryParams.map { key, value in
+                    URLQueryItem(name: key, value: value)
+                })
+        }
+        guard let url = components.url else {
+            precondition(
+                false,
+                "Failed to construct URL from components - this indicates an unexpected error in the SDK."
+            )
+        }
+        return url
+    }
+
+    private func buildRequestHeaders(
+        requestContentType: HTTP.ContentType,
+        requestHeaders: [String: String],
+        requestOptions: RequestOptions? = nil
+    ) async throws -> [String: String] {
+        var headers = clientConfig.headers ?? [:]
+        headers["Content-Type"] = requestContentType.rawValue
+        if let headerAuth = clientConfig.headerAuth {
+            headers[headerAuth.header] = requestOptions?.apiKey ?? headerAuth.key
+        }
+        if let basicAuthToken = clientConfig.basicAuth?.token {
+            headers["Authorization"] = "Basic \(basicAuthToken)"
+        }
+        if let bearerAuthToken = try await getBearerAuthToken(requestOptions) {
+            headers["Authorization"] = "Bearer \(bearerAuthToken)"
+        }
+        for (key, value) in requestHeaders {
+            headers[key] = value
+        }
+        for (key, value) in requestOptions?.additionalHeaders ?? [:] {
+            headers[key] = value
+        }
+        return headers
+    }
+
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+        if let tokenString = requestOptions?.token {
+            return tokenString
+        }
+        if let bearerAuth = clientConfig.bearerAuth {
+            return try await bearerAuth.token.retrieve()
+        }
+        return nil
+    }
+
+    private func buildRequestBody(
+        requestBody: HTTP.RequestBody,
+        requestOptions: RequestOptions? = nil
+    ) -> Data {
+        switch requestBody {
+        case .jsonEncodable(let encodableBody):
+            do {
+                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
+                return try jsonEncoder.encode(encodableBody)
+            } catch {
+                precondition(
+                    false,
+                    "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
+                )
+            }
+        case .data(let dataBody):
+            return dataBody
+        }
+    }
+
+    private func executeRequestWithURLSession(
+        _ request: URLRequest
+    ) async throws -> (Data, String?) {
+        do {
+            // TODO(kafkas): Handle retries
+            let (data, response) = try await clientConfig.urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw ClientError.invalidResponse
+            }
+
+            // Handle successful responses
+            if 200...299 ~= httpResponse.statusCode {
+                let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+                return (data, contentType)
+            }
+
+            // Handle error responses
+            try handleErrorResponse(
+                statusCode: httpResponse.statusCode,
+                data: data
+            )
+
+            // This should never be reached, but satisfy the compiler
+            let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+            return (data, contentType)
+
+        } catch {
+            if error is ClientError {
+                throw error
+            } else {
+                throw ClientError.networkError(error)
+            }
+        }
+    }
+
+    private func handleErrorResponse(statusCode: Int, data: Data) throws {
+        let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
+
+        switch statusCode {
+        case 400:
+            throw ClientError.badRequest(errorResponse)
+        case 401:
+            throw ClientError.unauthorized(errorResponse)
+        case 403:
+            throw ClientError.forbidden(errorResponse)
+        case 404:
+            throw ClientError.notFound(errorResponse)
+        case 422:
+            throw ClientError.validationError(errorResponse)
+        case 500...599:
+            throw ClientError.serverError(errorResponse)
+        default:
+            throw ClientError.httpError(statusCode: statusCode, response: errorResponse)
+        }
+    }
+
+    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+        // Try to parse as JSON error response first
+        if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
+            return errorResponse
+        }
+
+        // Try to parse as simple JSON with message field
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let message = json["message"] as? String
+        {
+            return APIErrorResponse(code: statusCode, message: message)
+        }
+
+        // Try to parse as plain text
+        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+            return APIErrorResponse(code: statusCode, message: errorMessage)
+        }
+
+        return nil
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/QueryParameter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum QueryParameter {
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case uint(UInt)
+    case uint64(UInt64)
+    case int64(Int64)
+    case float(Float)
+    case double(Double)
+    case date(Date)
+    case stringArray([String])
+    case uuid(UUID)
+    case unknown(Any)
+
+    func toString() -> String {
+        switch self {
+        case .string(let value):
+            return value
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .int(let value):
+            return String(value)
+        case .uint(let value):
+            return String(value)
+        case .uint64(let value):
+            return String(value)
+        case .int64(let value):
+            return String(value)
+        case .float(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        case .date(let value):
+            return value.ISO8601Format()
+        case .stringArray(let values):
+            return values.joined(separator: ",")
+        case .uuid(let value):
+            return value.uuidString
+        case .unknown:
+            return ""
+        }
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension Decoder {
+    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+        using codingKeysType: C.Type
+    ) throws
+        -> [String: T] where C.RawValue == String
+    {
+        return try decodeAdditionalProperties(
+            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+    }
+
+    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
+        T]
+    {
+        let container = try container(keyedBy: StringKey.self)
+        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        guard !unknownKeys.isEmpty else { return .init() }
+        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+            (key.stringValue, try container.decode(T.self, forKey: key))
+        }
+        return .init(uniqueKeysWithValues: keyValuePairs)
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Encoder {
+    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+        guard !additionalProperties.isEmpty else { return }
+        var container = self.container(keyedBy: StringKey.self)
+        for (key, value) in additionalProperties {
+            try container.encode(value, forKey: .init(key))
+        }
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Serde/Serde.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class Serde {
+    static var jsonEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static var jsonDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+            if let date = formatter.date(from: dateString) {
+                return date
+            }
+
+            // Fallback for dates without fractional seconds
+            formatter.formatOptions = [.withInternetDateTime]
+            if let date = formatter.date(from: dateString) {
+                return date
+            }
+
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "Invalid date format: \(dateString)")
+        }
+        return decoder
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Serde/StringKey.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct StringKey: CodingKey, Hashable {
+    var stringValue: String
+    var intValue: Int? { Int(stringValue) }
+
+    init(_ string: String) {
+        self.stringValue = string
+    }
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = String(intValue)
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/String+URLEncoding.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    func urlPathEncoded() -> String {
+        return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
+    }
+
+    func urlQueryEncoded() -> String {
+        return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/NullableOptionalClient.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/NullableOptionalClient.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
+public final class NullableOptionalClient: Sendable {
+    public let nullableOptional: NullableOptionalClient_
+    private let httpClient: HTTPClient
+
+    /// Initialize the client with the specified configuration.
+    ///
+    /// - Parameter baseURL: The base URL to use for requests from the client. If not provided, the default base URL will be used.
+    /// - Parameter headers: Additional headers to send with each request.
+    /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
+    public convenience init(
+        baseURL: String,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        self.init(
+            baseURL: baseURL,
+            headerAuth: nil,
+            bearerAuth: nil,
+            basicAuth: nil,
+            headers: headers,
+            timeout: timeout,
+            maxRetries: maxRetries,
+            urlSession: urlSession
+        )
+    }
+
+    init(
+        baseURL: String,
+        headerAuth: ClientConfig.HeaderAuth? = nil,
+        bearerAuth: ClientConfig.BearerAuth? = nil,
+        basicAuth: ClientConfig.BasicAuth? = nil,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        let config = ClientConfig(
+            baseURL: baseURL,
+            headerAuth: headerAuth,
+            bearerAuth: bearerAuth,
+            basicAuth: basicAuth,
+            headers: headers,
+            timeout: timeout,
+            maxRetries: maxRetries,
+            urlSession: urlSession
+        )
+        self.nullableOptional = NullableOptionalClient_(config: config)
+        self.httpClient = HTTPClient(config: config)
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Public/APIErrorResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct APIErrorResponse: Codable, Sendable {
+    public let code: Int
+    public let type: String?
+    public let message: String?
+
+    public init(code: Int, type: String? = nil, message: String? = nil) {
+        self.code = code
+        self.type = type
+        self.message = message
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Public/ClientConfig.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+public final class ClientConfig: Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> String
+
+    struct Defaults {
+        static let timeout: Int = 60
+        static let maxRetries: Int = 2
+    }
+
+    struct HeaderAuth {
+        let key: String
+        let header: String
+    }
+
+    struct BearerAuth {
+        let token: Token
+
+        enum Token: Sendable {
+            case staticToken(String)
+            case provider(CredentialProvider)
+
+            func retrieve() async throws -> String {
+                switch self {
+                case .staticToken(let token):
+                    return token
+                case .provider(let provider):
+                    return try await provider()
+                }
+            }
+        }
+    }
+
+    struct BasicAuth {
+        let username: String?
+        let password: String?
+
+        var token: String? {
+            if let username, let password {
+                let credentials: String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Data()
+                return data.base64EncodedString()
+            }
+            return nil
+        }
+    }
+
+    let baseURL: String
+    let headerAuth: HeaderAuth?
+    let bearerAuth: BearerAuth?
+    let basicAuth: BasicAuth?
+    let headers: [String: String]?
+    let timeout: Int
+    let maxRetries: Int
+    let urlSession: URLSession
+
+    init(
+        baseURL: String,
+        headerAuth: HeaderAuth? = nil,
+        bearerAuth: BearerAuth? = nil,
+        basicAuth: BasicAuth? = nil,
+        headers: [String: String]? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        urlSession: URLSession? = nil
+    ) {
+        self.baseURL = baseURL
+        self.headerAuth = headerAuth
+        self.bearerAuth = bearerAuth
+        self.basicAuth = basicAuth
+        self.headers = headers
+        self.timeout = timeout ?? Defaults.timeout
+        self.maxRetries = maxRetries ?? Defaults.maxRetries
+        self.urlSession = urlSession ?? buildURLSession(timeoutSeconds: self.timeout)
+    }
+}
+
+private func buildURLSession(timeoutSeconds: Int) -> URLSession {
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
+    return .init(configuration: configuration)
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Public/ClientError.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum ClientError: Error {
+    // Network & Client Errors
+    case invalidURL
+    case encodingError(Error)
+    case decodingError(Error)
+    case invalidResponse
+    case networkError(Error)
+
+    // Generic HTTP Errors (status code based)
+    case badRequest(APIErrorResponse?)  // 400
+    case unauthorized(APIErrorResponse?)  // 401
+    case forbidden(APIErrorResponse?)  // 403
+    case notFound(APIErrorResponse?)  // 404
+    case validationError(APIErrorResponse?)  // 422
+    case serverError(APIErrorResponse?)  // 5xx
+    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .encodingError(let error):
+            return "Failed to encode request: \(error.localizedDescription)"
+        case .decodingError(let error):
+            return "Failed to decode response: \(error.localizedDescription)"
+        case .invalidResponse:
+            return "Invalid response received"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+
+        case .badRequest(let response):
+            return formatErrorMessage("Bad request", response)
+        case .unauthorized(let response):
+            return formatErrorMessage("Unauthorized", response)
+        case .forbidden(let response):
+            return formatErrorMessage("Forbidden", response)
+        case .notFound(let response):
+            return formatErrorMessage("Not found", response)
+        case .validationError(let response):
+            return formatErrorMessage("Validation error", response)
+        case .serverError(let response):
+            return formatErrorMessage("Server error", response)
+        case .httpError(let statusCode, let response):
+            return formatErrorMessage("HTTP error (\(statusCode))", response)
+        }
+    }
+
+    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
+        -> String
+    {
+        guard let response = response else {
+            return defaultMessage
+        }
+
+        var message = defaultMessage
+
+        // Use server message if available and meaningful
+        if let serverMessage = response.message, !serverMessage.isEmpty {
+            message = serverMessage
+        }
+
+        // Always include the status code
+        message += " (Code: \(response.code))"
+
+        // Include type if available
+        if let type = response.type, !type.isEmpty {
+            message += " [Type: \(type)]"
+        }
+
+        return message
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Public/JSONValue.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// A type that can represent any JSON value.
+public enum JSONValue: Codable, Hashable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .number(Double(int))
+        } else if let double = try? container.decode(Double.self) {
+            self = .number(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([JSONValue].self) {
+            self = .array(array)
+        } else if let object = try? container.decode([String: JSONValue].self) {
+            self = .object(object)
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unable to decode JSONValue"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .string(let string):
+            try container.encode(string)
+        case .number(let number):
+            try container.encode(number)
+        case .bool(let bool):
+            try container.encode(bool)
+        case .null:
+            try container.encodeNil()
+        case .array(let array):
+            try container.encode(array)
+        case .object(let object):
+            try container.encode(object)
+        }
+    }
+}
+
+// MARK: - Convenience initializers
+extension JSONValue {
+    public init(_ value: String) {
+        self = .string(value)
+    }
+
+    public init(_ value: Int) {
+        self = .number(Double(value))
+    }
+
+    public init(_ value: Double) {
+        self = .number(value)
+    }
+
+    public init(_ value: Bool) {
+        self = .bool(value)
+    }
+
+    public init(_ value: [JSONValue]) {
+        self = .array(value)
+    }
+
+    public init(_ value: [String: JSONValue]) {
+        self = .object(value)
+    }
+}
+
+// MARK: - Value extraction
+extension JSONValue {
+    public var stringValue: String? {
+        if case .string(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var numberValue: Double? {
+        if case .number(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var intValue: Int? {
+        if case .number(let value) = self {
+            return Int(value)
+        }
+        return nil
+    }
+
+    public var boolValue: Bool? {
+        if case .bool(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var arrayValue: [JSONValue]? {
+        if case .array(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var objectValue: [String: JSONValue]? {
+        if case .object(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    public var isNull: Bool {
+        if case .null = self {
+            return true
+        }
+        return false
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Public/RequestOptions.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Options for customizing an individual API request.
+///
+/// Use this struct to override or supplement client-wide configuration for a single request.
+public struct RequestOptions {
+    /// The API key to use for this request, overriding the client-wide API key if provided.
+    let apiKey: String?
+
+    /// The token to use for this request, overriding the client-wide token if provided.
+    let token: String?
+
+    /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
+    let timeout: Int?
+
+    /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
+    let maxRetries: Int?
+
+    /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
+    let additionalHeaders: [String: String]?
+
+    /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
+    let additionalQueryParameters: [String: String]?
+
+    // TODO(kafkas): Omit for file uploads
+    /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
+    let additionalBodyParameters: [String: String]?
+
+    public init(
+        apiKey: String? = nil,
+        token: String? = nil,
+        timeout: Int? = nil,
+        maxRetries: Int? = nil,
+        additionalHeaders: [String: String]? = nil,
+        additionalQueryParameters: [String: String]? = nil,
+        additionalBodyParameters: [String: String]? = nil
+    ) {
+        self.apiKey = apiKey
+        self.token = token
+        self.timeout = timeout
+        self.maxRetries = maxRetries
+        self.additionalHeaders = additionalHeaders
+        self.additionalQueryParameters = additionalQueryParameters
+        self.additionalBodyParameters = additionalBodyParameters
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Requests/Requests.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Requests/Requests.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Container for all inline request types used throughout the SDK.
+///
+/// This enum serves as a namespace to organize request types that are defined inline within endpoint specifications.
+public enum Requests {}

--- a/seed/swift-sdk/nullable-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public final class NullableOptionalClient_: Sendable {
+    private let httpClient: HTTPClient
+
+    public init(config: ClientConfig) {
+        self.httpClient = HTTPClient(config: config)
+    }
+
+    /// Get a user by ID
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getUser(userId: String, requestOptions: RequestOptions? = nil) async throws -> UserResponse {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users/\(userId)",
+            requestOptions: requestOptions,
+            responseType: UserResponse.self
+        )
+    }
+
+    /// Create a new user
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func createUser(request: CreateUserRequest, requestOptions: RequestOptions? = nil) async throws -> UserResponse {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/api/users",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: UserResponse.self
+        )
+    }
+
+    /// Update a user (partial update)
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func updateUser(userId: String, request: UpdateUserRequest, requestOptions: RequestOptions? = nil) async throws -> UserResponse {
+        return try await httpClient.performRequest(
+            method: .patch,
+            path: "/api/users/\(userId)",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: UserResponse.self
+        )
+    }
+
+    /// List all users
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func listUsers(limit: Int? = nil, offset: Int? = nil, includeDeleted: Bool? = nil, sortBy: JSONValue? = nil, requestOptions: RequestOptions? = nil) async throws -> [UserResponse] {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users",
+            queryParams: [
+                "limit": limit.map { .int($0) }, 
+                "offset": offset.map { .int($0) }, 
+                "includeDeleted": includeDeleted.map { .bool($0) }, 
+                "sortBy": sortBy.map { .unknown($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: [UserResponse].self
+        )
+    }
+
+    /// Search users
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func searchUsers(query: String, department: JSONValue, role: String? = nil, isActive: JSONValue? = nil, requestOptions: RequestOptions? = nil) async throws -> [UserResponse] {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users/search",
+            queryParams: [
+                "query": .string(query), 
+                "department": .unknown(department), 
+                "role": role.map { .string($0) }, 
+                "isActive": isActive.map { .unknown($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: [UserResponse].self
+        )
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/Address.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/Address.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Nested object for testing
+public struct Address: Codable, Hashable, Sendable {
+    public let street: String
+    public let city: JSONValue
+    public let state: String?
+    public let zipCode: String
+    public let country: JSONValue?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        street: String,
+        city: JSONValue,
+        state: String? = nil,
+        zipCode: String,
+        country: JSONValue? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.street = street
+        self.city = city
+        self.state = state
+        self.zipCode = zipCode
+        self.country = country
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.street = try container.decode(String.self, forKey: .street)
+        self.city = try container.decode(JSONValue.self, forKey: .city)
+        self.state = try container.decodeIfPresent(String.self, forKey: .state)
+        self.zipCode = try container.decode(String.self, forKey: .zipCode)
+        self.country = try container.decodeIfPresent(JSONValue.self, forKey: .country)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.street, forKey: .street)
+        try container.encode(self.city, forKey: .city)
+        try container.encodeIfPresent(self.state, forKey: .state)
+        try container.encode(self.zipCode, forKey: .zipCode)
+        try container.encodeIfPresent(self.country, forKey: .country)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case street
+        case city
+        case state
+        case zipCode
+        case country
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/CreateUserRequest.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/CreateUserRequest.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct CreateUserRequest: Codable, Hashable, Sendable {
+    public let username: String
+    public let email: JSONValue
+    public let phone: String?
+    public let address: JSONValue?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        username: String,
+        email: JSONValue,
+        phone: String? = nil,
+        address: JSONValue? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.username = username
+        self.email = email
+        self.phone = phone
+        self.address = address
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.username = try container.decode(String.self, forKey: .username)
+        self.email = try container.decode(JSONValue.self, forKey: .email)
+        self.phone = try container.decodeIfPresent(String.self, forKey: .phone)
+        self.address = try container.decodeIfPresent(JSONValue.self, forKey: .address)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.username, forKey: .username)
+        try container.encode(self.email, forKey: .email)
+        try container.encodeIfPresent(self.phone, forKey: .phone)
+        try container.encodeIfPresent(self.address, forKey: .address)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case username
+        case email
+        case phone
+        case address
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/UpdateUserRequest.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/UpdateUserRequest.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// For testing PATCH operations
+public struct UpdateUserRequest: Codable, Hashable, Sendable {
+    public let username: String?
+    public let email: JSONValue?
+    public let phone: String?
+    public let address: JSONValue?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        username: String? = nil,
+        email: JSONValue? = nil,
+        phone: String? = nil,
+        address: JSONValue? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.username = username
+        self.email = email
+        self.phone = phone
+        self.address = address
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.username = try container.decodeIfPresent(String.self, forKey: .username)
+        self.email = try container.decodeIfPresent(JSONValue.self, forKey: .email)
+        self.phone = try container.decodeIfPresent(String.self, forKey: .phone)
+        self.address = try container.decodeIfPresent(JSONValue.self, forKey: .address)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encodeIfPresent(self.username, forKey: .username)
+        try container.encodeIfPresent(self.email, forKey: .email)
+        try container.encodeIfPresent(self.phone, forKey: .phone)
+        try container.encodeIfPresent(self.address, forKey: .address)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case username
+        case email
+        case phone
+        case address
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/UserProfile.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/UserProfile.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Test object with nullable and optional fields
+public struct UserProfile: Codable, Hashable, Sendable {
+    public let id: String
+    public let username: String
+    public let nullableString: JSONValue
+    public let nullableInteger: JSONValue
+    public let nullableBoolean: JSONValue
+    public let nullableDate: JSONValue
+    public let nullableObject: JSONValue
+    public let nullableList: JSONValue
+    public let nullableMap: JSONValue
+    public let optionalString: String?
+    public let optionalInteger: Int?
+    public let optionalBoolean: Bool?
+    public let optionalDate: Date?
+    public let optionalObject: Address?
+    public let optionalList: [String]?
+    public let optionalMap: [String: String]?
+    public let optionalNullableString: JSONValue?
+    public let optionalNullableObject: JSONValue?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        id: String,
+        username: String,
+        nullableString: JSONValue,
+        nullableInteger: JSONValue,
+        nullableBoolean: JSONValue,
+        nullableDate: JSONValue,
+        nullableObject: JSONValue,
+        nullableList: JSONValue,
+        nullableMap: JSONValue,
+        optionalString: String? = nil,
+        optionalInteger: Int? = nil,
+        optionalBoolean: Bool? = nil,
+        optionalDate: Date? = nil,
+        optionalObject: Address? = nil,
+        optionalList: [String]? = nil,
+        optionalMap: [String: String]? = nil,
+        optionalNullableString: JSONValue? = nil,
+        optionalNullableObject: JSONValue? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.id = id
+        self.username = username
+        self.nullableString = nullableString
+        self.nullableInteger = nullableInteger
+        self.nullableBoolean = nullableBoolean
+        self.nullableDate = nullableDate
+        self.nullableObject = nullableObject
+        self.nullableList = nullableList
+        self.nullableMap = nullableMap
+        self.optionalString = optionalString
+        self.optionalInteger = optionalInteger
+        self.optionalBoolean = optionalBoolean
+        self.optionalDate = optionalDate
+        self.optionalObject = optionalObject
+        self.optionalList = optionalList
+        self.optionalMap = optionalMap
+        self.optionalNullableString = optionalNullableString
+        self.optionalNullableObject = optionalNullableObject
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.username = try container.decode(String.self, forKey: .username)
+        self.nullableString = try container.decode(JSONValue.self, forKey: .nullableString)
+        self.nullableInteger = try container.decode(JSONValue.self, forKey: .nullableInteger)
+        self.nullableBoolean = try container.decode(JSONValue.self, forKey: .nullableBoolean)
+        self.nullableDate = try container.decode(JSONValue.self, forKey: .nullableDate)
+        self.nullableObject = try container.decode(JSONValue.self, forKey: .nullableObject)
+        self.nullableList = try container.decode(JSONValue.self, forKey: .nullableList)
+        self.nullableMap = try container.decode(JSONValue.self, forKey: .nullableMap)
+        self.optionalString = try container.decodeIfPresent(String.self, forKey: .optionalString)
+        self.optionalInteger = try container.decodeIfPresent(Int.self, forKey: .optionalInteger)
+        self.optionalBoolean = try container.decodeIfPresent(Bool.self, forKey: .optionalBoolean)
+        self.optionalDate = try container.decodeIfPresent(Date.self, forKey: .optionalDate)
+        self.optionalObject = try container.decodeIfPresent(Address.self, forKey: .optionalObject)
+        self.optionalList = try container.decodeIfPresent([String].self, forKey: .optionalList)
+        self.optionalMap = try container.decodeIfPresent([String: String].self, forKey: .optionalMap)
+        self.optionalNullableString = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableString)
+        self.optionalNullableObject = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableObject)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.username, forKey: .username)
+        try container.encode(self.nullableString, forKey: .nullableString)
+        try container.encode(self.nullableInteger, forKey: .nullableInteger)
+        try container.encode(self.nullableBoolean, forKey: .nullableBoolean)
+        try container.encode(self.nullableDate, forKey: .nullableDate)
+        try container.encode(self.nullableObject, forKey: .nullableObject)
+        try container.encode(self.nullableList, forKey: .nullableList)
+        try container.encode(self.nullableMap, forKey: .nullableMap)
+        try container.encodeIfPresent(self.optionalString, forKey: .optionalString)
+        try container.encodeIfPresent(self.optionalInteger, forKey: .optionalInteger)
+        try container.encodeIfPresent(self.optionalBoolean, forKey: .optionalBoolean)
+        try container.encodeIfPresent(self.optionalDate, forKey: .optionalDate)
+        try container.encodeIfPresent(self.optionalObject, forKey: .optionalObject)
+        try container.encodeIfPresent(self.optionalList, forKey: .optionalList)
+        try container.encodeIfPresent(self.optionalMap, forKey: .optionalMap)
+        try container.encodeIfPresent(self.optionalNullableString, forKey: .optionalNullableString)
+        try container.encodeIfPresent(self.optionalNullableObject, forKey: .optionalNullableObject)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case nullableString
+        case nullableInteger
+        case nullableBoolean
+        case nullableDate
+        case nullableObject
+        case nullableList
+        case nullableMap
+        case optionalString
+        case optionalInteger
+        case optionalBoolean
+        case optionalDate
+        case optionalObject
+        case optionalList
+        case optionalMap
+        case optionalNullableString
+        case optionalNullableObject
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/UserResponse.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/UserResponse.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public struct UserResponse: Codable, Hashable, Sendable {
+    public let id: String
+    public let username: String
+    public let email: JSONValue
+    public let phone: String?
+    public let createdAt: Date
+    public let updatedAt: JSONValue
+    public let address: Address?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        id: String,
+        username: String,
+        email: JSONValue,
+        phone: String? = nil,
+        createdAt: Date,
+        updatedAt: JSONValue,
+        address: Address? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.id = id
+        self.username = username
+        self.email = email
+        self.phone = phone
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.address = address
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.username = try container.decode(String.self, forKey: .username)
+        self.email = try container.decode(JSONValue.self, forKey: .email)
+        self.phone = try container.decodeIfPresent(String.self, forKey: .phone)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.updatedAt = try container.decode(JSONValue.self, forKey: .updatedAt)
+        self.address = try container.decodeIfPresent(Address.self, forKey: .address)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.username, forKey: .username)
+        try container.encode(self.email, forKey: .email)
+        try container.encodeIfPresent(self.phone, forKey: .phone)
+        try container.encode(self.createdAt, forKey: .createdAt)
+        try container.encode(self.updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(self.address, forKey: .address)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case email
+        case phone
+        case createdAt
+        case updatedAt
+        case address
+    }
+}

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -29,6 +29,7 @@ defaultCustomConfig: {}
 fixtures:
   client-side-params:
     - customConfig:
+        moduleName: MyCustomModule
         clientClassName: MyCustomClient
       outputFolder: with-custom-config
     - customConfig: null


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Adds a `moduleName` generator config option that lets users set the Swift module used in client code (e.g., `import MyCustomModule`). When provided, the generator aligns the library, product and target to this name by default.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Adjusted `AbstractSwiftGeneratorContext` to register module name on initialization. Module name is registered before all other symbols.
- Extended `ProjectSymbolRegistry` to support module name
- Updated `client-side-params` seed fixture to include `moduleName` 
- Updated seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

