### PR TITLE
fix(go): remove obviated use of "flat" PackageLayout

### DIFF
--- a/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
+++ b/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
@@ -17,7 +17,6 @@ export const baseGoCustomConfigSchema = z.object({
     includeLegacyClientOptions: z.boolean().optional(),
     inlinePathParameters: z.boolean().optional(),
     inlineFileProperties: z.boolean().optional(),
-    packageLayout: z.enum(["flat", "nested"]).optional(),
     union: z.enum(["v0", "v1"]).optional(),
     useReaderForBytesRequest: z.boolean().optional(),
     useDefaultRequestParameterValues: z.boolean().optional()

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -105,9 +105,6 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getClientImportPath(): string {
-        if (this.customConfig?.packageLayout === "flat") {
-            return this.rootImportPath;
-        }
         return `${this.rootImportPath}/client`;
     }
 

--- a/generators/go-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorContext.ts
@@ -63,9 +63,6 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
         if (subpackage == null && this.customConfig.clientName != null) {
             return this.customConfig.clientName;
         }
-        if (subpackage != null && this.isFlatPackageLayout()) {
-            return `${this.getClassName(subpackage.name)}Client`;
-        }
         return "Client";
     }
 
@@ -78,16 +75,10 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
                 return `New${this.customConfig.clientName}`;
             }
         }
-        if (subpackage != null && this.isFlatPackageLayout()) {
-            return `New${this.getClassName(subpackage.name)}Client`;
-        }
         return "NewClient";
     }
 
     public getClientFilename(subpackage?: Subpackage): string {
-        if (subpackage != null && this.isFlatPackageLayout()) {
-            return `${this.getFilename(subpackage.name)}.go`;
-        }
         return "client.go";
     }
 
@@ -97,18 +88,12 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
 
     public getRawClientClassName(subpackage?: Subpackage): string {
         if (subpackage != null) {
-            if (this.isFlatPackageLayout()) {
-                return `Raw${this.getClassName(subpackage.name)}Client`;
-            }
             return "RawClient";
         }
         return `Raw${this.getClientClassName()}`;
     }
 
     public getRawClientFilename(subpackage?: Subpackage): string {
-        if (subpackage != null && this.isFlatPackageLayout()) {
-            return `raw_${this.getFilename(subpackage.name)}.go`;
-        }
         return "raw_client.go";
     }
 
@@ -168,23 +153,14 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
     }
 
     public getRootClientDirectory(): RelativeFilePath {
-        if (this.isFlatPackageLayout()) {
-            return RelativeFilePath.of(".");
-        }
         return RelativeFilePath.of(this.getRootClientPackageName());
     }
 
     public getRootClientImportPath(): string {
-        if (this.isFlatPackageLayout()) {
-            return this.getRootImportPath();
-        }
         return `${this.getRootImportPath()}/${this.getRootClientPackageName()}`;
     }
 
     public getRootClientPackageName(): string {
-        if (this.isFlatPackageLayout()) {
-            return this.getRootPackageName();
-        }
         return "client";
     }
 
@@ -255,9 +231,6 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
         fernFilepath: FernFilepath;
         subpackage?: Subpackage;
     }): FileLocation {
-        if (this.isFlatPackageLayout()) {
-            return this.getPackageLocation(fernFilepath);
-        }
         return this.getFileLocationForClient({ fernFilepath, subpackage });
     }
 
@@ -664,10 +637,6 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
             name: this.getNetHttpMethodTypeReferenceName(method),
             importPath: "net/http"
         });
-    }
-
-    public isFlatPackageLayout(): boolean {
-        return this.customConfig.packageLayout === "flat";
     }
 
     public getFileLocationForClient({

--- a/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -1067,9 +1067,6 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         if (subpackage == null) {
             return this.context.getRootClientReceiverName();
         }
-        if (subpackage != null && this.context.isFlatPackageLayout()) {
-            return this.context.getReceiverName(subpackage.name);
-        }
         return "c";
     }
 

--- a/generators/go/cmd/fern-go-fiber/main.go
+++ b/generators/go/cmd/fern-go-fiber/main.go
@@ -42,7 +42,6 @@ func run(config *cmd.Config, coordinator *coordinator.Client) ([]*generator.File
 		config.PackageName,
 		config.PackagePath,
 		config.ExportedClientName,
-		config.PackageLayout,
 		config.UnionVersion,
 		config.Module,
 	)

--- a/generators/go/cmd/fern-go-model/main.go
+++ b/generators/go/cmd/fern-go-model/main.go
@@ -42,7 +42,6 @@ func run(config *cmd.Config, coordinator *coordinator.Client) ([]*generator.File
 		config.PackageName,
 		config.PackagePath,
 		config.ExportedClientName,
-		config.PackageLayout,
 		config.UnionVersion,
 		config.Module,
 	)

--- a/generators/go/cmd/fern-go-sdk/main.go
+++ b/generators/go/cmd/fern-go-sdk/main.go
@@ -42,7 +42,6 @@ func run(config *cmd.Config, coordinator *coordinator.Client) ([]*generator.File
 		config.PackageName,
 		config.PackagePath,
 		config.ExportedClientName,
-		config.PackageLayout,
 		config.UnionVersion,
 		config.Module,
 	)

--- a/generators/go/internal/cmd/cmd.go
+++ b/generators/go/internal/cmd/cmd.go
@@ -73,7 +73,6 @@ type Config struct {
 	ExportedClientName           string
 	PackageName                  string
 	PackagePath                  string
-	PackageLayout                string
 	UnionVersion                 string
 	Module                       *generator.ModuleConfig
 	Writer                       *writer.Config
@@ -228,7 +227,6 @@ func newConfig(configFilename string) (*Config, error) {
 		PackageName:                  customConfig.PackageName,
 		PackagePath:                  customConfig.PackagePath,
 		ExportedClientName:           customConfig.ExportedClientName,
-		PackageLayout:                customConfig.PackageLayout,
 		UnionVersion:                 customConfig.UnionVersion,
 		Module:                       moduleConfig,
 		Writer:                       writerConfig,
@@ -282,7 +280,6 @@ type customConfig struct {
 	PackageName                  string        `json:"packageName,omitempty"`
 	PackagePath                  string        `json:"packagePath,omitempty"`
 	ExportedClientName           string        `json:"exportedClientName,omitempty"`
-	PackageLayout                string        `json:"packageLayout,omitempty"`
 	UnionVersion                 string        `json:"union,omitempty"`
 	Module                       *moduleConfig `json:"module,omitempty"`
 }

--- a/generators/go/internal/generator/config.go
+++ b/generators/go/internal/generator/config.go
@@ -5,16 +5,6 @@ import (
 	"path"
 )
 
-// PackageLayout represents the different package layouts supported by the generator.
-type PackageLayout uint
-
-// Enumerates the supported package layouts.
-const (
-	PackageLayoutUnspecified PackageLayout = iota
-	PackageLayoutNested
-	PackageLayoutFlat
-)
-
 // UnionVersion represents the different union versions supported by the generator.
 type UnionVersion uint
 
@@ -46,7 +36,6 @@ type Config struct {
 	PackageName                  string
 	PackagePath                  string
 	ExportedClientName           string
-	PackageLayout                PackageLayout
 	UnionVersion                 UnionVersion
 
 	// If not specified, a go.mod and go.sum will not be generated.
@@ -90,14 +79,9 @@ func NewConfig(
 	packageName string,
 	packagePath string,
 	exportedClientName string,
-	packageLayout string,
 	unionVersion string,
 	moduleConfig *ModuleConfig,
 ) (*Config, error) {
-	pl, err := parsePackageLayout(packageLayout)
-	if err != nil {
-		return nil, err
-	}
 	uv, err := parseUnionVersion(unionVersion)
 	if err != nil {
 		return nil, err
@@ -122,7 +106,6 @@ func NewConfig(
 		PackageName:                  packageName,
 		PackagePath:                  packagePath,
 		ExportedClientName:           exportedClientName,
-		PackageLayout:                pl,
 		UnionVersion:                 uv,
 		ModuleConfig:                 moduleConfig,
 	}, nil
@@ -138,16 +121,4 @@ func parseUnionVersion(unionVersion string) (UnionVersion, error) {
 		return UnionVersionV1, nil
 	}
 	return UnionVersionUnspecified, fmt.Errorf("unrecognized union version %q", unionVersion)
-}
-
-func parsePackageLayout(packageLayout string) (PackageLayout, error) {
-	switch packageLayout {
-	case "":
-		return PackageLayoutUnspecified, nil
-	case "nested":
-		return PackageLayoutNested, nil
-	case "flat":
-		return PackageLayoutFlat, nil
-	}
-	return PackageLayoutUnspecified, fmt.Errorf("unrecognized package layout %q", packageLayout)
 }

--- a/generators/go/internal/generator/fiber.go
+++ b/generators/go/internal/generator/fiber.go
@@ -34,11 +34,11 @@ func (f *fileWriter) WriteFiberRequestType(fernFilepath *ir.FernFilepath, endpoi
 			)
 			continue
 		}
-		goType := typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+		goType := typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		f.P(header.Name.Name.PascalCase.UnsafeName, " ", goType, " `header:\"", header.Name.Name.OriginalName, "\"`")
 	}
 	for _, queryParam := range endpoint.QueryParameters {
-		value := typeReferenceToGoType(queryParam.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+		value := typeReferenceToGoType(queryParam.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		if queryParam.AllowMultiple {
 			value = fmt.Sprintf("[]%s", value)
 		}
@@ -95,7 +95,7 @@ func (f *fileWriter) WriteFiberRequestType(fernFilepath *ir.FernFilepath, endpoi
 	)
 	if reference := endpoint.RequestBody.Reference; reference != nil {
 		referenceType = strings.TrimPrefix(
-			typeReferenceToGoType(reference.RequestBodyType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout),
+			typeReferenceToGoType(reference.RequestBodyType, f.types, f.scope, f.baseImportPath, importPath, false),
 			"*",
 		)
 		referenceIsPointer = reference.RequestBodyType.Named != nil && isPointer(f.types[reference.RequestBodyType.Named.TypeId])

--- a/generators/go/internal/generator/file_writer.go
+++ b/generators/go/internal/generator/file_writer.go
@@ -37,7 +37,6 @@ type fileWriter struct {
 	inlineFileProperties         bool
 	useReaderForBytesRequest     bool
 	unionVersion                 UnionVersion
-	packageLayout                PackageLayout
 	scope                        *gospec.Scope
 	types                        map[ir.TypeId]*ir.TypeDeclaration
 	errors                       map[ir.ErrorId]*ir.ErrorDeclaration
@@ -56,7 +55,6 @@ func newFileWriter(
 	inlinePathParameters bool,
 	inlineFileProperties bool,
 	useReaderForBytesRequest bool,
-	packageLayout PackageLayout,
 	unionVersion UnionVersion,
 	types map[ir.TypeId]*ir.TypeDeclaration,
 	errors map[ir.ErrorId]*ir.ErrorDeclaration,
@@ -100,7 +98,6 @@ func newFileWriter(
 		inlinePathParameters:         inlinePathParameters,
 		inlineFileProperties:         inlineFileProperties,
 		useReaderForBytesRequest:     useReaderForBytesRequest,
-		packageLayout:                packageLayout,
 		unionVersion:                 unionVersion,
 		scope:                        scope,
 		types:                        types,
@@ -180,7 +177,6 @@ func (f *fileWriter) clone() *fileWriter {
 		f.inlinePathParameters,
 		f.inlineFileProperties,
 		f.useReaderForBytesRequest,
-		f.packageLayout,
 		f.unionVersion,
 		f.types,
 		f.errors,

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -200,6 +200,7 @@ func (g *Generator) generateModelTypes(ir *fernir.IntermediateRepresentation, mo
 						return nil, nil, err
 					}
 				}
+			}
 		}
 		file, err := writer.File()
 		if err != nil {
@@ -304,7 +305,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			
 			g.config.UnionVersion,
 			nil,
 			nil,
@@ -354,7 +354,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -387,7 +386,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -414,7 +412,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -448,7 +445,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -472,7 +468,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -499,7 +494,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -525,7 +519,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -585,7 +578,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -1160,10 +1152,8 @@ func newClientTestFile(
 	clientNameOverride string,
 	clientConstructorNameOverride string,
 ) (*File, error) {
-	var (
-		filename    = "client_test.go"
-		packageName = rootPackageName
-	)
+	var filename = "client/client_test.go"
+	var packageName = "client"
 	f := newFileWriter(
 		filename,
 		packageName,

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -156,7 +156,6 @@ func (g *Generator) generateModelTypes(ir *fernir.IntermediateRepresentation, mo
 		ir.ServiceTypeReferenceInfo,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		g.config.PackageLayout,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -173,7 +172,6 @@ func (g *Generator) generateModelTypes(ir *fernir.IntermediateRepresentation, mo
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			g.config.PackageLayout,
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -202,29 +200,6 @@ func (g *Generator) generateModelTypes(ir *fernir.IntermediateRepresentation, mo
 						return nil, nil, err
 					}
 				}
-			case g.config.PackageLayout == PackageLayoutFlat && typeToGenerate.Endpoint == nil && typeToGenerate.Service != nil:
-				generatedClient, err := writer.WriteClient(
-					ir.Auth,
-					typeToGenerate.Service.Endpoints,
-					ir.Headers,
-					typeToGenerate.Service.Headers,
-					ir.IdempotencyHeaders,
-					nil, // Subpackages are not supported with the flat package layout.
-					ir.Environments,
-					ir.ErrorDiscriminationStrategy,
-					typeToGenerate.FernFilepath,
-					rootClientInstantiation,
-					g.config.InlinePathParameters,
-					g.config.InlineFileProperties,
-					g.config.PackageLayout,
-					"",
-					"",
-				)
-				if err != nil {
-					return nil, nil, err
-				}
-				generatedRootClients = append(generatedRootClients, generatedClient)
-			}
 		}
 		file, err := writer.File()
 		if err != nil {
@@ -250,20 +225,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 						referencedType.TypeId,
 					)
 				}
-			}
-		}
-	}
-	if g.config.PackageLayout == PackageLayoutFlat {
-		for _, subpackage := range ir.Subpackages {
-			if subpackage.FernFilepath.PackagePath != nil && len(subpackage.FernFilepath.PackagePath) > 0 {
-				var packagePathElements []string
-				for _, packagePathElement := range subpackage.FernFilepath.AllParts {
-					packagePathElements = append(packagePathElements, packagePathElement.OriginalName)
-				}
-				return nil, fmt.Errorf(
-					"the flat package layout setting is not supported for APIs defined in nested directories (e.g. %s)",
-					strings.Join(packagePathElements, "/"),
-				)
 			}
 		}
 	}
@@ -321,7 +282,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			g.config.PackageLayout,
 			g.config.UnionVersion,
 			nil,
 			nil,
@@ -344,7 +304,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			g.config.PackageLayout,
+			
 			g.config.UnionVersion,
 			nil,
 			nil,
@@ -394,7 +354,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			g.config.PackageLayout,
+			
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -427,7 +387,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				g.config.PackageLayout,
+				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -454,7 +414,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			g.config.PackageLayout,
+			
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -475,7 +435,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			generatedEnvironment,
 			exportedClientName,
 			g.config.ClientConstructorName,
-			g.config.PackageLayout,
+			
 		)
 		if len(ir.IdempotencyHeaders) > 0 {
 			fileInfo = fileInfoForIdempotentRequestOptionsDefinition()
@@ -488,7 +448,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				g.config.PackageLayout,
+				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -512,7 +472,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				g.config.PackageLayout,
+				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -539,7 +499,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				g.config.PackageLayout,
+				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -565,7 +525,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			g.config.InlinePathParameters,
 			g.config.InlineFileProperties,
 			g.config.UseReaderForBytesRequest,
-			g.config.PackageLayout,
+			
 			g.config.UnionVersion,
 			ir.Types,
 			ir.Errors,
@@ -609,7 +569,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			files = append(files, newPagerFile(g.coordinator, g.config.FullImportPath))
 			files = append(files, newPagerTestFile(g.coordinator))
 		}
-		clientTestFile, err := newClientTestFile(g.config.FullImportPath, rootPackageName, g.coordinator, g.config.PackageLayout, g.config.ClientName, g.config.ClientConstructorName)
+		clientTestFile, err := newClientTestFile(g.config.FullImportPath, rootPackageName, g.coordinator,  g.config.ClientName, g.config.ClientConstructorName)
 		if err != nil {
 			return nil, err
 		}
@@ -625,7 +585,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.InlinePathParameters,
 				g.config.InlineFileProperties,
 				g.config.UseReaderForBytesRequest,
-				g.config.PackageLayout,
+				
 				g.config.UnionVersion,
 				ir.Types,
 				ir.Errors,
@@ -687,7 +647,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			}
 		}
 		// Then generate the client for all of the subpackages.
-		if g.config.PackageLayout != PackageLayoutFlat {
 			for _, subpackageToGenerate := range subpackagesToGenerate {
 				irSubpackage := subpackageToGenerate.Subpackage
 				var subpackages []*fernir.Subpackage
@@ -735,7 +694,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				// Merge this client's endpoints with the root generated client.
 				generatedRootClient.Endpoints = append(generatedRootClient.Endpoints, generatedClient.Endpoints...)
 			}
-		}
 	}
 	// Write the snippets, if any.
 	if g.config.SnippetFilepath != "" {
@@ -786,7 +744,7 @@ func (g *Generator) generateRootService(
 	originalFernFilepath *fernir.FernFilepath,
 	rootPackageName string,
 ) (*File, *GeneratedClient, error) {
-	fileInfo := fileInfoForRootService(irService.Name.FernFilepath, rootPackageName, g.config.PackageLayout)
+	fileInfo := fileInfoForRootService(irService.Name.FernFilepath, rootPackageName)
 	writer := newFileWriter(
 		fileInfo.filename,
 		fileInfo.packageName,
@@ -796,7 +754,7 @@ func (g *Generator) generateRootService(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		g.config.PackageLayout,
+		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -815,7 +773,7 @@ func (g *Generator) generateRootService(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		g.config.PackageLayout,
+		
 		g.config.ClientName,
 		g.config.ClientConstructorName,
 	)
@@ -846,7 +804,7 @@ func (g *Generator) generateService(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		g.config.PackageLayout,
+		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -865,7 +823,7 @@ func (g *Generator) generateService(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		g.config.PackageLayout,
+		
 		"",
 		"",
 	)
@@ -899,7 +857,7 @@ func (g *Generator) generateServiceWithoutEndpoints(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		g.config.PackageLayout,
+		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -918,7 +876,7 @@ func (g *Generator) generateServiceWithoutEndpoints(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		g.config.PackageLayout,
+		
 		"",
 		"",
 	); err != nil {
@@ -937,7 +895,7 @@ func (g *Generator) generateRootServiceWithoutEndpoints(
 	rootClientInstantiation *ast.AssignStmt,
 	rootPackageName string,
 ) (*File, *GeneratedClient, error) {
-	fileInfo := fileInfoForRootService(fernFilepath, rootPackageName, g.config.PackageLayout)
+	fileInfo := fileInfoForRootService(fernFilepath, rootPackageName)
 	writer := newFileWriter(
 		fileInfo.filename,
 		fileInfo.packageName,
@@ -947,7 +905,7 @@ func (g *Generator) generateRootServiceWithoutEndpoints(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		g.config.PackageLayout,
+		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -966,7 +924,7 @@ func (g *Generator) generateRootServiceWithoutEndpoints(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		g.config.PackageLayout,
+		
 		g.config.ClientName,
 		g.config.ClientConstructorName,
 	)
@@ -1199,7 +1157,6 @@ func newClientTestFile(
 	baseImportPath string,
 	rootPackageName string,
 	coordinator *coordinator.Client,
-	packageLayout PackageLayout,
 	clientNameOverride string,
 	clientConstructorNameOverride string,
 ) (*File, error) {
@@ -1207,10 +1164,6 @@ func newClientTestFile(
 		filename    = "client_test.go"
 		packageName = rootPackageName
 	)
-	if packageLayout != PackageLayoutFlat {
-		filename = "client/client_test.go"
-		packageName = "client"
-	}
 	f := newFileWriter(
 		filename,
 		packageName,
@@ -1220,7 +1173,6 @@ func newClientTestFile(
 		false,
 		false,
 		false,
-		packageLayout,
 		UnionVersionUnspecified,
 		nil,
 		nil,
@@ -1565,10 +1517,7 @@ func fileInfoForPackageDocs(fernFilepath *fernir.FernFilepath) *fileInfo {
 	}
 }
 
-func fileInfoForRootService(fernFilepath *fernir.FernFilepath, rootPackageName string, packageLayout PackageLayout) *fileInfo {
-	if packageLayout != PackageLayoutFlat {
-		return fileInfoForService(fernFilepath)
-	}
+func fileInfoForRootService(fernFilepath *fernir.FernFilepath, rootPackageName string) *fileInfo {
 	return &fileInfo{
 		filename:    "client.go",
 		packageName: rootPackageName,
@@ -1713,20 +1662,10 @@ func fileInfoToTypes(
 	irServiceTypeReferenceInfo *fernir.ServiceTypeReferenceInfo,
 	inlinePathParameters bool,
 	inlineFileProperties bool,
-	packageLayout PackageLayout,
 ) (map[fileInfo][]*typeToGenerate, error) {
 	result := make(map[fileInfo][]*typeToGenerate)
 	for _, irService := range irServices {
 		fileInfo := fileInfoForType(rootPackageName, irService.Name.FernFilepath)
-		if packageLayout == PackageLayoutFlat && irService.Name.FernFilepath.File != nil {
-			result[fileInfo] = append(
-				result[fileInfo],
-				&typeToGenerate{
-					FernFilepath: irService.Name.FernFilepath,
-					Service:      irService,
-				},
-			)
-		}
 		for _, irEndpoint := range irService.Endpoints {
 			if shouldSkipRequestType(irEndpoint, inlinePathParameters, inlineFileProperties) {
 				continue

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -746,7 +746,6 @@ func (g *Generator) generateRootService(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -765,7 +764,6 @@ func (g *Generator) generateRootService(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		
 		g.config.ClientName,
 		g.config.ClientConstructorName,
 	)
@@ -796,7 +794,6 @@ func (g *Generator) generateService(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -815,7 +812,6 @@ func (g *Generator) generateService(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		
 		"",
 		"",
 	)
@@ -849,7 +845,6 @@ func (g *Generator) generateServiceWithoutEndpoints(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -868,7 +863,6 @@ func (g *Generator) generateServiceWithoutEndpoints(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		
 		"",
 		"",
 	); err != nil {
@@ -897,7 +891,6 @@ func (g *Generator) generateRootServiceWithoutEndpoints(
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
 		g.config.UseReaderForBytesRequest,
-		
 		g.config.UnionVersion,
 		ir.Types,
 		ir.Errors,
@@ -916,7 +909,6 @@ func (g *Generator) generateRootServiceWithoutEndpoints(
 		rootClientInstantiation,
 		g.config.InlinePathParameters,
 		g.config.InlineFileProperties,
-		
 		g.config.ClientName,
 		g.config.ClientConstructorName,
 	)

--- a/generators/go/internal/generator/model.go
+++ b/generators/go/internal/generator/model.go
@@ -54,7 +54,7 @@ type typeVisitor struct {
 var _ ir.TypeVisitor = (*typeVisitor)(nil)
 
 func (t *typeVisitor) VisitAlias(alias *ir.AliasTypeDeclaration) error {
-	t.writer.P("type ", t.typeName, " = ", typeReferenceToGoType(alias.AliasOf, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout))
+	t.writer.P("type ", t.typeName, " = ", typeReferenceToGoType(alias.AliasOf, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false))
 	t.writer.P()
 	return nil
 }
@@ -307,14 +307,14 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 			literals = append(literals, &literal{Name: property.Name, Value: property.ValueType.Container.Literal})
 			continue
 		}
-		t.writer.P(property.Name.Name.PascalCase.UnsafeName, " ", typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout))
+		t.writer.P(property.Name.Name.PascalCase.UnsafeName, " ", typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false))
 	}
 	// We handle the union's literals separate from the extended and base
 	// literals because we only want to set them if they were actually
 	// specified by the user.
 	var unionLiterals []*literal
 	for _, unionType := range union.Types {
-		singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, t.writer.packageLayout)
+		singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath)
 		typeName := singleUnionProperty.goType
 		if typeName == "" {
 			// If the union has no properties, there's nothing for us to do.
@@ -354,7 +354,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 			t.writer.P("func New", t.typeName, "With", unionType.DiscriminantValue.Name.PascalCase.UnsafeName, "() *", t.typeName, "{")
 			t.writer.P("return &", t.typeName, "{", discriminantName, ": \"", unionType.DiscriminantValue.WireValue, "\", ", fieldName, ": ", literalToValue(literal), "}")
 		} else if t.unionVersion != UnionVersionV1 {
-			singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, t.writer.packageLayout)
+			singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath)
 			t.writer.P("func New", t.typeName, "From", unionType.DiscriminantValue.Name.PascalCase.UnsafeName, "(value ", singleUnionProperty.goType, ") *", t.typeName, "{")
 			t.writer.P("return &", t.typeName, "{", discriminantName, ": \"", unionType.DiscriminantValue.WireValue, "\", ", fieldName, ": value}")
 		} else {
@@ -397,7 +397,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 		propertyNames = append(propertyNames, extendedObjectProperties.names...)
 	}
 	for _, property := range union.BaseProperties {
-		t.writer.P(property.Name.Name.PascalCase.UnsafeName, " ", typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout), jsonTagForType(property.Name.WireValue, property.ValueType, t.writer.types, t.alwaysSendRequiredProperties))
+		t.writer.P(property.Name.Name.PascalCase.UnsafeName, " ", typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false), jsonTagForType(property.Name.WireValue, property.ValueType, t.writer.types, t.alwaysSendRequiredProperties))
 		if property.ValueType.Container == nil || property.ValueType.Container.Literal == nil {
 			propertyNames = append(propertyNames, property.Name.Name.PascalCase.UnsafeName)
 		}
@@ -454,7 +454,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 			//    Boolean bool  `json:"value"`
 			//  }
 			t.writer.P("var valueUnmarshaler struct {")
-			singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, t.writer.packageLayout)
+			singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath)
 			t.writer.P(unionType.DiscriminantValue.Name.PascalCase.UnsafeName, " ", singleUnionProperty.valueMarshalerGoType, jsonTagForType(unionType.Shape.SingleProperty.Name.WireValue, unionType.Shape.SingleProperty.Type, t.writer.types, t.alwaysSendRequiredProperties))
 			t.writer.P("}")
 			t.writer.P("if err := json.Unmarshal(data, &valueUnmarshaler); err != nil {")
@@ -463,7 +463,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 			t.writer.P(receiver, ".", unionType.DiscriminantValue.Name.PascalCase.UnsafeName, " = valueUnmarshaler.", unionType.DiscriminantValue.Name.PascalCase.UnsafeName, singleUnionProperty.valueUnmarshalerMethodSuffix)
 			continue
 		}
-		t.writer.P(singleUnionTypePropertiesToInitializer(unionType.Shape, t.writer.types, t.writer.scope, t.writer.packageLayout, t.baseImportPath, t.importPath, unionType.DiscriminantValue.Name.PascalCase.UnsafeName, receiver))
+		t.writer.P(singleUnionTypePropertiesToInitializer(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, unionType.DiscriminantValue.Name.PascalCase.UnsafeName, receiver))
 		t.writer.P("if err := json.Unmarshal(data, &value); err != nil {")
 		t.writer.P("return err")
 		t.writer.P("}")
@@ -546,12 +546,12 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 			if property.ValueType.Container != nil && property.ValueType.Container.Literal != nil {
 				continue
 			}
-			t.writer.P(property.Name.Name.PascalCase.UnsafeName, " ", typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout), jsonTagForType(property.Name.WireValue, property.ValueType, t.writer.types, t.alwaysSendRequiredProperties))
+			t.writer.P(property.Name.Name.PascalCase.UnsafeName, " ", typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false), jsonTagForType(property.Name.WireValue, property.ValueType, t.writer.types, t.alwaysSendRequiredProperties))
 		}
 		for _, literal := range literals {
 			t.writer.P(literal.Name.Name.PascalCase.UnsafeName, " ", literalToGoType(literal.Value), " `json:\"", literal.Name.WireValue, "\"`")
 		}
-		singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, t.writer.packageLayout)
+		singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath)
 		typeName := singleUnionProperty.goType
 		switch unionType.Shape.PropertiesType {
 		case "singleProperty":
@@ -602,7 +602,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 	// Generate the Visitor interface.
 	t.writer.P("type ", t.typeName, "Visitor interface {")
 	for _, unionType := range union.Types {
-		singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, t.writer.packageLayout)
+		singleUnionProperty := singleUnionTypePropertiesToGoType(unionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath)
 		t.writer.P("Visit", unionType.DiscriminantValue.Name.PascalCase.UnsafeName, "(", singleUnionProperty.goType, ") error")
 	}
 	t.writer.P("}")
@@ -795,7 +795,7 @@ func (t *typeVisitor) VisitUndiscriminatedUnion(union *ir.UndiscriminatedUnionTy
 				field:                        field,
 				variable:                     fmt.Sprintf("value%s", strings.Title(field)),
 				caseName:                     firstLetterToLower(field),
-				value:                        typeReferenceToGoType(unionMember.Type, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout),
+				value:                        typeReferenceToGoType(unionMember.Type, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false),
 				zeroValue:                    zeroValueForTypeReference(unionMember.Type, t.writer.types),
 				docs:                         unionMember.Docs,
 				literal:                      literal,
@@ -1082,7 +1082,7 @@ func (t *typeVisitor) visitObjectProperties(
 		if date := maybeDateProperty(property.ValueType, property.Name, false); date != nil {
 			dates = append(dates, date)
 		}
-		goType := typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, includeOptionals, t.writer.packageLayout)
+		goType := typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, includeOptionals)
 		if includeJSONTags {
 			var structTag string
 			if includeURLTags {
@@ -1134,7 +1134,7 @@ func (t *typeVisitor) getTypeFieldsForObject(object *ir.ObjectTypeDeclaration) [
 		}
 		fields = append(fields, &typeField{
 			Name:      property.Name.Name.PascalCase.UnsafeName,
-			GoType:    typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout),
+			GoType:    typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false),
 			ZeroValue: zeroValueForTypeReference(property.ValueType, t.writer.types),
 		})
 	}
@@ -1162,7 +1162,7 @@ func (t *typeVisitor) getTypeFieldsForUnion(union *ir.UnionTypeDeclaration) []*t
 		}
 		fields = append(fields, &typeField{
 			Name:      property.Name.Name.PascalCase.UnsafeName,
-			GoType:    typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout),
+			GoType:    typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false),
 			ZeroValue: zeroValueForTypeReference(property.ValueType, t.writer.types),
 		})
 	}
@@ -1176,7 +1176,7 @@ func (t *typeVisitor) getTypeFieldsForUnion(union *ir.UnionTypeDeclaration) []*t
 }
 
 func (t *typeVisitor) typeFieldForSingleUnionType(singleUnionType *ir.SingleUnionType) *typeField {
-	singleUnionProperty := singleUnionTypePropertiesToGoType(singleUnionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, t.writer.packageLayout)
+	singleUnionProperty := singleUnionTypePropertiesToGoType(singleUnionType.Shape, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath)
 	return &typeField{
 		Name:      singleUnionType.DiscriminantValue.Name.PascalCase.UnsafeName,
 		GoType:    singleUnionProperty.goType,
@@ -1192,7 +1192,7 @@ func (t *typeVisitor) getTypeFieldsForUndiscriminatedUnion(undiscriminatedUnion 
 		}
 		typeFields = append(typeFields, &typeField{
 			Name:      typeReferenceToUndiscriminatedUnionField(member.Type, t.writer.types, scope),
-			GoType:    typeReferenceToGoType(member.Type, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false, t.writer.packageLayout),
+			GoType:    typeReferenceToGoType(member.Type, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, false),
 			ZeroValue: zeroValueForTypeReference(member.Type, t.writer.types),
 		})
 	}
@@ -1207,7 +1207,6 @@ type typeReferenceVisitor struct {
 	importPath       string
 	scope            *gospec.Scope
 	types            map[ir.TypeId]*ir.TypeDeclaration
-	packageLayout    PackageLayout
 	includeOptionals bool
 }
 
@@ -1215,7 +1214,7 @@ type typeReferenceVisitor struct {
 var _ ir.TypeReferenceVisitor = (*typeReferenceVisitor)(nil)
 
 func (t *typeReferenceVisitor) VisitContainer(container *ir.ContainerType) error {
-	t.value = containerTypeToGoType(container, t.types, t.scope, t.baseImportPath, t.importPath, t.includeOptionals, t.packageLayout)
+	t.value = containerTypeToGoType(container, t.types, t.scope, t.baseImportPath, t.importPath, t.includeOptionals)
 	return nil
 }
 
@@ -1225,7 +1224,7 @@ func (t *typeReferenceVisitor) VisitNamed(named *ir.NamedType) error {
 		format = "*%s"
 	}
 	name := named.Name.PascalCase.UnsafeName
-	if importPath := fernFilepathToImportPath(t.baseImportPath, named.FernFilepath); importPath != t.importPath && t.packageLayout != PackageLayoutFlat {
+	if importPath := fernFilepathToImportPath(t.baseImportPath, named.FernFilepath); importPath != t.importPath {
 		name = t.scope.AddImport(importPath) + "." + name
 	}
 	t.value = fmt.Sprintf(format, name)
@@ -1251,19 +1250,18 @@ type containerTypeVisitor struct {
 	scope            *gospec.Scope
 	types            map[ir.TypeId]*ir.TypeDeclaration
 	includeOptionals bool
-	packageLayout    PackageLayout
 }
 
 // Compile-time assertion.
 var _ ir.ContainerTypeVisitor = (*containerTypeVisitor)(nil)
 
 func (c *containerTypeVisitor) VisitList(list *ir.TypeReference) error {
-	c.value = fmt.Sprintf("[]%s", typeReferenceToGoType(list, c.types, c.scope, c.baseImportPath, c.importPath, false, c.packageLayout))
+	c.value = fmt.Sprintf("[]%s", typeReferenceToGoType(list, c.types, c.scope, c.baseImportPath, c.importPath, false))
 	return nil
 }
 
 func (c *containerTypeVisitor) VisitMap(mapType *ir.MapType) error {
-	c.value = fmt.Sprintf("map[%s]%s", typeReferenceToGoType(mapType.KeyType, c.types, c.scope, c.baseImportPath, c.importPath, false, c.packageLayout), typeReferenceToGoType(mapType.ValueType, c.types, c.scope, c.baseImportPath, c.importPath, false, c.packageLayout))
+	c.value = fmt.Sprintf("map[%s]%s", typeReferenceToGoType(mapType.KeyType, c.types, c.scope, c.baseImportPath, c.importPath, false), typeReferenceToGoType(mapType.ValueType, c.types, c.scope, c.baseImportPath, c.importPath, false))
 	return nil
 }
 
@@ -1279,7 +1277,7 @@ func (c *containerTypeVisitor) VisitOptional(optionalOrNullable *ir.TypeReferenc
 	//
 	// We also don't want to specify pointers for any container types because those
 	// values are already nil-able.
-	value := strings.TrimLeft(typeReferenceToGoType(optionalOrNullable, c.types, c.scope, c.baseImportPath, c.importPath, c.includeOptionals, c.packageLayout), "*")
+	value := strings.TrimLeft(typeReferenceToGoType(optionalOrNullable, c.types, c.scope, c.baseImportPath, c.importPath, c.includeOptionals), "*")
 	if c.includeOptionals {
 		c.value = fmt.Sprintf("*core.Optional[%s]", value)
 		return nil
@@ -1308,7 +1306,7 @@ func (c *containerTypeVisitor) VisitOptional(optionalOrNullable *ir.TypeReferenc
 }
 
 func (c *containerTypeVisitor) VisitSet(set *ir.TypeReference) error {
-	c.value = fmt.Sprintf("[]%s", typeReferenceToGoType(set, c.types, c.scope, c.baseImportPath, c.importPath, false, c.packageLayout))
+	c.value = fmt.Sprintf("[]%s", typeReferenceToGoType(set, c.types, c.scope, c.baseImportPath, c.importPath, false))
 	return nil
 }
 
@@ -1330,7 +1328,6 @@ type singleUnionTypePropertiesVisitor struct {
 	importPath     string
 	scope          *gospec.Scope
 	types          map[ir.TypeId]*ir.TypeDeclaration
-	packageLayout  PackageLayout
 }
 
 // Compile-time assertion.
@@ -1342,7 +1339,7 @@ func (c *singleUnionTypePropertiesVisitor) VisitSamePropertiesAsObject(named *ir
 		format = "*%s"
 	}
 	name := named.Name.PascalCase.UnsafeName
-	if importPath := fernFilepathToImportPath(c.baseImportPath, named.FernFilepath); importPath != c.importPath && c.packageLayout != PackageLayoutFlat {
+	if importPath := fernFilepathToImportPath(c.baseImportPath, named.FernFilepath); importPath != c.importPath {
 		name = c.scope.AddImport(importPath) + "." + name
 	}
 	c.goType = fmt.Sprintf(format, name)
@@ -1352,7 +1349,7 @@ func (c *singleUnionTypePropertiesVisitor) VisitSamePropertiesAsObject(named *ir
 }
 
 func (c *singleUnionTypePropertiesVisitor) VisitSingleProperty(property *ir.SingleUnionTypeProperty) error {
-	c.goType = typeReferenceToGoType(property.Type, c.types, c.scope, c.baseImportPath, c.importPath, false, c.packageLayout)
+	c.goType = typeReferenceToGoType(property.Type, c.types, c.scope, c.baseImportPath, c.importPath, false)
 	c.zeroValue = zeroValueForTypeReference(property.Type, c.types)
 
 	if date := maybeDateProperty(property.Type, property.Name, false); date != nil {
@@ -1386,7 +1383,6 @@ type singleUnionTypePropertiesInitializerVisitor struct {
 	importPath       string
 	scope            *gospec.Scope
 	types            map[ir.TypeId]*ir.TypeDeclaration
-	packageLayout    PackageLayout
 }
 
 // Compile-time assertion.
@@ -1398,7 +1394,7 @@ func (c *singleUnionTypePropertiesInitializerVisitor) VisitSamePropertiesAsObjec
 		format = "value := new(%s)"
 	}
 	name := named.Name.PascalCase.UnsafeName
-	if importPath := fernFilepathToImportPath(c.baseImportPath, named.FernFilepath); importPath != c.importPath && c.packageLayout != PackageLayoutFlat {
+	if importPath := fernFilepathToImportPath(c.baseImportPath, named.FernFilepath); importPath != c.importPath {
 		name = c.scope.AddImport(importPath) + "." + name
 	}
 	c.value = fmt.Sprintf(format, name)
@@ -1461,7 +1457,7 @@ func typeReferenceToGoType(
 	baseImportPath string,
 	importPath string,
 	includeOptionals bool,
-	packageLayout PackageLayout,
+	
 ) string {
 	visitor := &typeReferenceVisitor{
 		baseImportPath:   baseImportPath,
@@ -1469,7 +1465,7 @@ func typeReferenceToGoType(
 		scope:            scope,
 		types:            types,
 		includeOptionals: includeOptionals,
-		packageLayout:    packageLayout,
+		
 	}
 	_ = typeReference.Accept(visitor)
 	return visitor.value
@@ -1483,7 +1479,7 @@ func containerTypeToGoType(
 	baseImportPath string,
 	importPath string,
 	includeOptionals bool,
-	packageLayout PackageLayout,
+	
 ) string {
 	visitor := &containerTypeVisitor{
 		baseImportPath:   baseImportPath,
@@ -1491,7 +1487,7 @@ func containerTypeToGoType(
 		scope:            scope,
 		types:            types,
 		includeOptionals: includeOptionals,
-		packageLayout:    packageLayout,
+		
 	}
 	_ = containerType.Accept(visitor)
 	return visitor.value
@@ -1514,14 +1510,13 @@ func singleUnionTypePropertiesToGoType(
 	scope *gospec.Scope,
 	baseImportPath string,
 	importPath string,
-	packageLayout PackageLayout,
+	
 ) *singleUnionProperty {
 	visitor := &singleUnionTypePropertiesVisitor{
 		baseImportPath: baseImportPath,
 		importPath:     importPath,
 		scope:          scope,
 		types:          types,
-		packageLayout:  packageLayout,
 	}
 	_ = singleUnionTypeProperties.Accept(visitor)
 	return &singleUnionProperty{
@@ -1541,7 +1536,7 @@ func singleUnionTypePropertiesToInitializer(
 	singleUnionTypeProperties *ir.SingleUnionTypeProperties,
 	types map[ir.TypeId]*ir.TypeDeclaration,
 	scope *gospec.Scope,
-	packageLayout PackageLayout,
+	
 	baseImportPath string,
 	importPath string,
 	discriminantName string,
@@ -1554,7 +1549,7 @@ func singleUnionTypePropertiesToInitializer(
 		importPath:       importPath,
 		scope:            scope,
 		types:            types,
-		packageLayout:    packageLayout,
+		
 	}
 	_ = singleUnionTypeProperties.Accept(visitor)
 	return visitor.value

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -187,7 +187,7 @@ func (f *fileWriter) WriteLegacyClientOptions(
 				pascalCase = authScheme.Header.Name.Name.PascalCase.UnsafeName
 				camelCase  = authScheme.Header.Name.Name.CamelCase.SafeName
 				optionName = fmt.Sprintf("With%s", pascalCase)
-				goType     = typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, "", false, f.packageLayout)
+				goType     = typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, "", false)
 				typeName   = "*core." + pascalCase + "Option"
 			)
 			f.P("// ", optionName, " sets the ", camelCase, " auth request header.")
@@ -210,7 +210,7 @@ func (f *fileWriter) WriteLegacyClientOptions(
 			pascalCase = header.Name.Name.PascalCase.UnsafeName
 			camelCase  = header.Name.Name.CamelCase.SafeName
 			optionName = fmt.Sprintf("With%s", pascalCase)
-			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, "", false, f.packageLayout)
+			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, "", false)
 			typeName   = "*core." + pascalCase + "Option"
 		)
 		f.P("// ", optionName, " sets the ", camelCase, " request header.")
@@ -252,7 +252,7 @@ func (f *fileWriter) WriteIdempotentRequestOptionsDefinition(idempotencyHeaders 
 		f.P(
 			header.Name.Name.PascalCase.UnsafeName,
 			" ",
-			typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout),
+			typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false),
 		)
 	}
 
@@ -281,7 +281,7 @@ func (f *fileWriter) WriteIdempotentRequestOptionsDefinition(idempotencyHeaders 
 	for _, header := range idempotencyHeaders {
 		var (
 			pascalCase = header.Name.Name.PascalCase.UnsafeName
-			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		)
 		if err := f.writeOptionStruct(pascalCase, goType, false, true); err != nil {
 			return err
@@ -352,7 +352,7 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 			f.P(
 				authScheme.Header.Name.Name.PascalCase.UnsafeName,
 				" ",
-				typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout),
+				typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false),
 			)
 		}
 	}
@@ -363,7 +363,7 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 		f.P(
 			header.Name.Name.PascalCase.UnsafeName,
 			" ",
-			typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout),
+			typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false),
 		)
 	}
 	f.P("}")
@@ -577,7 +577,7 @@ func (f *fileWriter) writeRequestOptionStructs(
 				}
 				var (
 					pascalCase = authScheme.Header.Name.Name.PascalCase.UnsafeName
-					goType     = typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout)
+					goType     = typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, "" /* The type is always imported */, false)
 				)
 				if err := f.writeOptionStruct(pascalCase, goType, true, asIdempotentRequestOption); err != nil {
 					return err
@@ -592,7 +592,7 @@ func (f *fileWriter) writeRequestOptionStructs(
 		}
 		var (
 			pascalCase = header.Name.Name.PascalCase.UnsafeName
-			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout)
+			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, "" /* The type is always imported */, false)
 		)
 		if err := f.writeOptionStruct(pascalCase, goType, true, asIdempotentRequestOption); err != nil {
 			return err
@@ -661,7 +661,7 @@ func (f *fileWriter) WriteIdempotentRequestOptions(
 			pascalCase = header.Name.Name.PascalCase.UnsafeName
 			camelCase  = header.Name.Name.CamelCase.SafeName
 			optionName = fmt.Sprintf("With%s", pascalCase)
-			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+			goType     = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		)
 		f.P("// ", optionName, " sets the ", camelCase, " request header.")
 		if header.Docs != nil && len(*header.Docs) > 0 {
@@ -832,7 +832,7 @@ func (f *fileWriter) WriteRequestOptions(
 				optionName = fmt.Sprintf("With%s", pascalCase)
 				field      = authScheme.Header.Name.Name.PascalCase.UnsafeName
 				param      = authScheme.Header.Name.Name.CamelCase.SafeName
-				value      = typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+				value      = typeReferenceToGoType(authScheme.Header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 			)
 			if i == 0 {
 				option = ast.NewCallExpr(
@@ -873,7 +873,7 @@ func (f *fileWriter) WriteRequestOptions(
 			optionName = fmt.Sprintf("With%s", pascalCase)
 			field      = header.Name.Name.PascalCase.UnsafeName
 			param      = header.Name.Name.CamelCase.SafeName
-			value      = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+			value      = typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		)
 		f.P("// ", optionName, " sets the ", param, " request header.")
 		if header.Docs != nil && len(*header.Docs) > 0 {
@@ -923,7 +923,6 @@ func (f *fileWriter) WriteClient(
 	rootClientInstantiation *ast.AssignStmt,
 	inlinePathParameters bool,
 	inlineFileProperties bool,
-	packageLayout PackageLayout,
 	clientNameOverride string,
 	clientConstructorNameOverride string,
 ) (*GeneratedClient, error) {
@@ -935,7 +934,7 @@ func (f *fileWriter) WriteClient(
 	// Reformat the endpoint data into a structure that's suitable for code generation.
 	var endpoints []*endpoint
 	for _, irEndpoint := range irEndpoints {
-		endpoint, err := f.endpointFromIR(fernFilepath, irEndpoint, environmentsConfig, errorDiscriminationStrategy, serviceHeaders, idempotencyHeaders, inlinePathParameters, inlineFileProperties, packageLayout)
+		endpoint, err := f.endpointFromIR(fernFilepath, irEndpoint, environmentsConfig, errorDiscriminationStrategy, serviceHeaders, idempotencyHeaders, inlinePathParameters, inlineFileProperties)
 		if err != nil {
 			return nil, err
 		}
@@ -948,12 +947,6 @@ func (f *fileWriter) WriteClient(
 		clientConstructorName    = "NewClient"
 		rawClientConstructorName = "NewRawClient"
 	)
-	if packageLayout == PackageLayoutFlat && fernFilepath.File != nil {
-		clientName = fernFilepath.File.PascalCase.UnsafeName + "Client"
-		rawClientName = "Raw" + fernFilepath.File.PascalCase.UnsafeName + "Client"
-		clientConstructorName = "New" + clientName
-		rawClientConstructorName = "New" + rawClientName
-	}
 	if clientNameOverride != "" {
 		clientName = clientNameOverride
 		rawClientName = "Raw" + clientNameOverride
@@ -977,15 +970,11 @@ func (f *fileWriter) WriteClient(
 		f.P("WithRawResponse *", rawClientName)
 	}
 	for _, subpackage := range subpackages {
-		if packageLayout == PackageLayoutFlat {
-			f.P(subpackage.Name.PascalCase.UnsafeName, " *", subpackage.Name.PascalCase.UnsafeName, "Client")
-		} else {
-			var (
-				importPath     = packagePathToImportPath(f.baseImportPath, packagePathForClient(subpackage.FernFilepath))
-				clientTypeName = f.scope.AddImport(importPath) + "." + "Client"
-			)
-			f.P(subpackage.Name.PascalCase.UnsafeName, " *", clientTypeName)
-		}
+		var (
+			importPath     = packagePathToImportPath(f.baseImportPath, packagePathForClient(subpackage.FernFilepath))
+			clientTypeName = f.scope.AddImport(importPath) + "." + "Client"
+		)
+		f.P(subpackage.Name.PascalCase.UnsafeName, " *", clientTypeName)
 	}
 	f.P("}")
 	f.P()
@@ -1037,15 +1026,11 @@ func (f *fileWriter) WriteClient(
 		f.P(" WithRawResponse: ", rawClientConstructorName, "(options),")
 	}
 	for _, subpackage := range subpackages {
-		if packageLayout == PackageLayoutFlat {
-			f.P(subpackage.Name.PascalCase.UnsafeName, ": ", "New", subpackage.Name.PascalCase.UnsafeName, "Client(opts...),")
-		} else {
-			var (
-				importPath        = packagePathToImportPath(f.baseImportPath, packagePathForClient(subpackage.FernFilepath))
-				clientConstructor = f.scope.AddImport(importPath) + ".NewClient(opts...),"
-			)
-			f.P(subpackage.Name.PascalCase.UnsafeName, ": ", clientConstructor)
-		}
+		var (
+			importPath        = packagePathToImportPath(f.baseImportPath, packagePathForClient(subpackage.FernFilepath))
+			clientConstructor = f.scope.AddImport(importPath) + ".NewClient(opts...),"
+		)
+		f.P(subpackage.Name.PascalCase.UnsafeName, ": ", clientConstructor)
 	}
 	f.P("}")
 	f.P("}")
@@ -1132,12 +1117,8 @@ func (f *fileWriter) WriteClient(
 				for _, responseError := range endpoint.Errors {
 					var errorType string
 					errorDeclaration := f.errors[responseError.Error.ErrorId]
-					if packageLayout == PackageLayoutFlat {
-						errorType = errorDeclaration.Name.Name.PascalCase.UnsafeName
-					} else {
-						errorImportPath := fernFilepathToImportPath(f.baseImportPath, errorDeclaration.Name.FernFilepath)
-						errorType = f.scope.AddImport(errorImportPath) + "." + errorDeclaration.Name.Name.PascalCase.UnsafeName
-					}
+					errorImportPath := fernFilepathToImportPath(f.baseImportPath, errorDeclaration.Name.FernFilepath)
+					errorType = f.scope.AddImport(errorImportPath) + "." + errorDeclaration.Name.Name.PascalCase.UnsafeName
 					f.P(fmt.Sprintf("%d: func(apiError *core.APIError) error {", errorDeclaration.StatusCode))
 					f.P("return &", errorType, "{")
 					f.P("APIError: apiError,")
@@ -1172,12 +1153,8 @@ func (f *fileWriter) WriteClient(
 				for _, responseError := range endpoint.Errors {
 					var errorType string
 					errorDeclaration := f.errors[responseError.Error.ErrorId]
-					if packageLayout == PackageLayoutFlat {
-						errorType = errorDeclaration.Name.Name.PascalCase.UnsafeName
-					} else {
-						errorImportPath := fernFilepathToImportPath(f.baseImportPath, errorDeclaration.Name.FernFilepath)
-						errorType = f.scope.AddImport(errorImportPath) + "." + errorDeclaration.Name.Name.PascalCase.UnsafeName
-					}
+					errorImportPath := fernFilepathToImportPath(f.baseImportPath, errorDeclaration.Name.FernFilepath)
+					errorType = f.scope.AddImport(errorImportPath) + "." + errorDeclaration.Name.Name.PascalCase.UnsafeName
 					if errorDiscriminationByPropertyStrategy != nil {
 						f.P(`case "`, errorDeclaration.DiscriminantValue.WireValue, `":`)
 					} else {
@@ -1649,7 +1626,7 @@ func (f *fileWriter) getPaginationInfo(
 			Type:                      t,
 			PageName:                  nameAndWireValue.Name,
 			PageNilCheck:              fmt.Sprintf("if %s.%s != %s {", requestParameterName, nameAndWireValue.Name.PascalCase.UnsafeName, valueTypeFormat.ZeroValue),
-			PageGoType:                typeReferenceToGoType(valueType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
+			PageGoType:                typeReferenceToGoType(valueType, f.types, scope, f.baseImportPath, "", false),
 			PageZeroValue:             valueTypeFormat.ZeroValue,
 			PageFirstRequestParameter: fmt.Sprintf("%s.%s", requestParameterName, nameAndWireValue.Name.PascalCase.UnsafeName),
 			PageIsOptional:            pageIsOptional,
@@ -1657,12 +1634,12 @@ func (f *fileWriter) getPaginationInfo(
 			Results:                   pagination.Cursor.Results,
 			ResultsPropertyPath:       responsePropertyPathToFullPathString("response", pagination.Cursor.Results.PropertyPath),
 			ResultsNilCheck:           responsePropertyPathToNilCheck("response", pagination.Cursor.Results.PropertyPath),
-			ResultsSingleGoType:       typeReferenceToGoType(resultsSingleType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
-			ResultsGoType:             typeReferenceToGoType(pagination.Cursor.Results.Property.ValueType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
+			ResultsSingleGoType:       typeReferenceToGoType(resultsSingleType, f.types, scope, f.baseImportPath, "", false),
+			ResultsGoType:             typeReferenceToGoType(pagination.Cursor.Results.Property.ValueType, f.types, scope, f.baseImportPath, "", false),
 			NextCursor:                pagination.Cursor.Next,
 			NextCursorPropertyPath:    responsePropertyPathToFullPathString("response", pagination.Cursor.Next.PropertyPath),
 			NextCursorNilCheck:        responsePropertyPathToNilCheck("response", pagination.Cursor.Next.PropertyPath),
-			NextCursorGoType:          typeReferenceToGoType(pagination.Cursor.Next.Property.ValueType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
+			NextCursorGoType:          typeReferenceToGoType(pagination.Cursor.Next.Property.ValueType, f.types, scope, f.baseImportPath, "", false),
 			NextCursorIsOptional:      nextCursorIsOptional,
 		}, nil
 	case "offset":
@@ -1695,7 +1672,7 @@ func (f *fileWriter) getPaginationInfo(
 			Type:                      t,
 			PageName:                  nameAndWireValue.Name,
 			PageNilCheck:              fmt.Sprintf("if %s.%s != %s {", requestParameterName, nameAndWireValue.Name.PascalCase.UnsafeName, valueTypeFormat.ZeroValue),
-			PageGoType:                typeReferenceToGoType(valueType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
+			PageGoType:                typeReferenceToGoType(valueType, f.types, scope, f.baseImportPath, "", false),
 			PageZeroValue:             valueTypeFormat.ZeroValue,
 			PageFirstRequestParameter: pageFirstRequestParameter,
 			PageIsOptional:            pageIsOptional,
@@ -1704,8 +1681,8 @@ func (f *fileWriter) getPaginationInfo(
 			Results:                   pagination.Offset.Results,
 			ResultsPropertyPath:       responsePropertyPathToFullPathString("response", pagination.Offset.Results.PropertyPath),
 			ResultsNilCheck:           responsePropertyPathToNilCheck("response", pagination.Offset.Results.PropertyPath),
-			ResultsGoType:             typeReferenceToGoType(pagination.Offset.Results.Property.ValueType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
-			ResultsSingleGoType:       typeReferenceToGoType(resultsSingleType, f.types, scope, f.baseImportPath, "", false, f.packageLayout),
+			ResultsGoType:             typeReferenceToGoType(pagination.Offset.Results.Property.ValueType, f.types, scope, f.baseImportPath, "", false),
+			ResultsSingleGoType:       typeReferenceToGoType(resultsSingleType, f.types, scope, f.baseImportPath, "", false),
 		}, nil
 	default:
 		return nil, fmt.Errorf("%s pagination is not supported yet", t)
@@ -2164,7 +2141,6 @@ func generatedClientInstantiation(
 	generatedEnvironment *GeneratedEnvironment,
 	exportedClientName string,
 	clientConstructorNameOverride string,
-	packageLayout PackageLayout,
 ) *ast.AssignStmt {
 	var parameters []ast.Expr
 	if generatedAuth != nil {
@@ -2174,9 +2150,7 @@ func generatedClientInstantiation(
 		parameters = append(parameters, generatedEnvironment.Option)
 	}
 	rootImportPath := baseImportPath
-	if packageLayout != PackageLayoutFlat {
-		rootImportPath = packagePathToImportPath(baseImportPath, packagePathForClient(new(ir.FernFilepath)))
-	}
+	rootImportPath = packagePathToImportPath(baseImportPath, packagePathForClient(new(ir.FernFilepath)))
 	constructorName := fmt.Sprintf("New%s", exportedClientName)
 	if clientConstructorNameOverride != "" {
 		constructorName = clientConstructorNameOverride
@@ -2288,7 +2262,6 @@ func (f *fileWriter) endpointFromIR(
 	idempotencyHeaders []*ir.HttpHeader,
 	inlinePathParameters bool,
 	inlineFileProperties bool,
-	packageLayout PackageLayout,
 ) (*endpoint, error) {
 	importPath := fernFilepathToImportPath(f.baseImportPath, fernFilepath)
 
@@ -2337,7 +2310,7 @@ func (f *fileWriter) endpointFromIR(
 			if !ok {
 				return nil, fmt.Errorf("internal error: path parameter %s not found in endpoint %s", pathParameter.Name.OriginalName, irEndpoint.Name.OriginalName)
 			}
-			parameterType := typeReferenceToGoType(pathParameter.ValueType, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout)
+			parameterType := typeReferenceToGoType(pathParameter.ValueType, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false)
 			if isLiteralType(pathParameter.ValueType, f.types) {
 				continue
 			}
@@ -2404,7 +2377,7 @@ func (f *fileWriter) endpointFromIR(
 			if requestBody := irEndpoint.SdkRequest.Shape.JustRequestBody; requestBody != nil {
 				switch requestBody.Type {
 				case "typeReference":
-					requestType = typeReferenceToGoType(requestBody.TypeReference.RequestBodyType, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout)
+					requestType = typeReferenceToGoType(requestBody.TypeReference.RequestBodyType, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false)
 				case "bytes":
 					requestType = "[]byte"
 					requestValueName = "requestBuffer"
@@ -2422,11 +2395,7 @@ func (f *fileWriter) endpointFromIR(
 			}
 			if irEndpoint.SdkRequest.Shape.Wrapper != nil {
 				requestImportPath := fernFilepathToImportPath(f.baseImportPath, fernFilepath)
-				if packageLayout == PackageLayoutFlat {
-					requestType = "*" + irEndpoint.SdkRequest.Shape.Wrapper.WrapperName.PascalCase.UnsafeName
-				} else {
-					requestType = fmt.Sprintf("*%s.%s", scope.AddImport(requestImportPath), irEndpoint.SdkRequest.Shape.Wrapper.WrapperName.PascalCase.UnsafeName)
-				}
+				requestType = fmt.Sprintf("*%s.%s", scope.AddImport(requestImportPath), irEndpoint.SdkRequest.Shape.Wrapper.WrapperName.PascalCase.UnsafeName)
 				if irEndpoint.RequestBody != nil && irEndpoint.RequestBody.Bytes != nil {
 					requestValueName = "requestBuffer"
 					if f.useReaderForBytesRequest {
@@ -2500,7 +2469,7 @@ func (f *fileWriter) endpointFromIR(
 			if typeReference == nil {
 				return nil, fmt.Errorf("unsupported json response type: %s", irEndpoint.Response.Body.Json.Type)
 			}
-			responseType = typeReferenceToGoType(typeReference, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout)
+			responseType = typeReferenceToGoType(typeReference, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false)
 			responseInitializerFormat = "var response %s"
 			responseIsOptionalParameter = getOptionalOrNullableContainer(typeReference) != nil
 			responseParameterName = "&response"
@@ -2511,7 +2480,7 @@ func (f *fileWriter) endpointFromIR(
 			if irEndpoint.Response.Body.Json.NestedPropertyAsResponse != nil && irEndpoint.Response.Body.Json.NestedPropertyAsResponse.ResponseProperty != nil {
 				responseProperty := irEndpoint.Response.Body.Json.NestedPropertyAsResponse.ResponseProperty
 				responsePropertyTypeReference := responseProperty.ValueType
-				responsePropertyType := typeReferenceToGoType(responsePropertyTypeReference, f.types, f.scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout)
+				responsePropertyType := typeReferenceToGoType(responsePropertyTypeReference, f.types, f.scope, f.baseImportPath, "" /* The type is always imported */, false)
 				signatureReturnValues = fmt.Sprintf("(%s, error)", responsePropertyType)
 				successfulReturnValues = fmt.Sprintf("response.%s, nil", responseProperty.Name.Name.PascalCase.UnsafeName)
 				errorReturnValues = fmt.Sprintf("%s, err", defaultValueForTypeReference(responsePropertyTypeReference, f.types))
@@ -2542,7 +2511,7 @@ func (f *fileWriter) endpointFromIR(
 			if err != nil {
 				return nil, err
 			}
-			responseType = strings.TrimPrefix(typeReferenceToGoType(typeReference, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false, f.packageLayout), "*")
+			responseType = strings.TrimPrefix(typeReferenceToGoType(typeReference, f.types, scope, f.baseImportPath, "" /* The type is always imported */, false), "*")
 			responseParameterName = "response"
 			signatureReturnValues = fmt.Sprintf("(*core.Stream[%s], error)", responseType)
 			errorReturnValues = "nil, err"
@@ -2701,7 +2670,7 @@ func (f *fileWriter) WriteError(errorDeclaration *ir.ErrorDeclaration) error {
 	}
 	var (
 		importPath = fernFilepathToImportPath(f.baseImportPath, errorDeclaration.Name.FernFilepath)
-		value      = typeReferenceToGoType(errorDeclaration.Type, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+		value      = typeReferenceToGoType(errorDeclaration.Type, f.types, f.scope, f.baseImportPath, importPath, false)
 	)
 	var literal string
 	if errorDeclaration.Type.Container != nil && errorDeclaration.Type.Container.Literal != nil {
@@ -2792,18 +2761,18 @@ func (f *fileWriter) WriteRequestType(
 			)
 			continue
 		}
-		goType := typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+		goType := typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		f.P(header.Name.Name.PascalCase.UnsafeName, " ", goType, " `json:\"-\" url:\"-\"`")
 	}
 	if includePathParametersInWrappedRequest(endpoint, f.inlinePathParameters) {
 		for _, pathParameter := range endpoint.AllPathParameters {
-			value := typeReferenceToGoType(pathParameter.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+			value := typeReferenceToGoType(pathParameter.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 			f.WriteDocs(pathParameter.Docs)
 			f.P(pathParameter.Name.PascalCase.UnsafeName, " ", value, " `json:\"-\" url:\"-\"`")
 		}
 	}
 	for _, queryParam := range endpoint.QueryParameters {
-		value := typeReferenceToGoType(queryParam.ValueType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout)
+		value := typeReferenceToGoType(queryParam.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
 		if queryParam.AllowMultiple {
 			value = fmt.Sprintf("[]%s", value)
 		}
@@ -2864,7 +2833,7 @@ func (f *fileWriter) WriteRequestType(
 	)
 	if reference := endpoint.RequestBody.Reference; reference != nil {
 		referenceType = strings.TrimPrefix(
-			typeReferenceToGoType(reference.RequestBodyType, f.types, f.scope, f.baseImportPath, importPath, false, f.packageLayout),
+			typeReferenceToGoType(reference.RequestBodyType, f.types, f.scope, f.baseImportPath, importPath, false),
 			"*",
 		)
 		referenceIsPointer = reference.RequestBodyType.Named != nil && isPointer(f.types[reference.RequestBodyType.Named.TypeId])
@@ -3217,7 +3186,7 @@ func (r *requestBodyVisitor) VisitReference(reference *ir.HttpRequestBodyReferen
 	r.writer.P(
 		r.bodyField,
 		" ",
-		typeReferenceToGoType(reference.RequestBodyType, r.types, r.scope, r.baseImportPath, r.importPath, false, r.writer.packageLayout),
+		typeReferenceToGoType(reference.RequestBodyType, r.types, r.scope, r.baseImportPath, r.importPath, false),
 		" `json:\"-\" url:\"-\"`",
 	)
 	return nil

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.6.7
+  changelogEntry:
+    - summary: |
+        Removes legacy logic for flat package layout.
+      type: fix
+  createdAt: "2025-08-27"
+  irVersion: 58
+
 - version: 1.6.6-rc0
   changelogEntry:
     - summary: |

--- a/seed/.vscode/settings.json
+++ b/seed/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/seed/.vscode/settings.json
+++ b/seed/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -79,14 +79,6 @@ fixtures:
   imdb:
     - outputFolder: no-custom-config
       customConfig: null
-    - outputFolder: flat-package-layout
-      customConfig:
-        packageLayout: flat
-    - outputFolder: flat-package-layout-with-custom-client-name
-      customConfig:
-        packageLayout: flat
-        clientName: Acme
-        clientConstructorName: New
     - outputFolder: package-path
       customConfig:
         packagePath: inhereplease
@@ -158,14 +150,6 @@ fixtures:
   package-yml:
     - outputFolder: no-custom-config
       customConfig: null
-    - outputFolder: flat-package-layout
-      customConfig:
-        packageLayout: flat
-    - outputFolder: flat-package-layout-with-custom-client-name
-      customConfig:
-        packageLayout: flat
-        clientName: Acme
-        clientConstructorName: New
   streaming:
     - outputFolder: .
       outputVersion: v2.0.0


### PR DESCRIPTION
## Description
Based on this Slack Thread we do not need to fix the broken seed tests asserting the "flat" PackageLayout configuration since it is unused so better to remove the option entirely.

## Changes Made
- Remove all refereces to PackageLayout in go/go-v2 generators

## Testing
<!-- Describe how you tested these changes -->
- [x] Seed tests removed

