### PR TITLE
feat(cli): add Maven publish target support for Java generators

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: |
+        Add Maven publish target support for Java generators. Extract Maven coordinates from 
+        generator config and create PublishTarget.maven() with repository credentials. Supports 
+        coordinate, group/artifact, and hyphenated field formats.
+      type: feat
+  irVersion: 59
+  createdAt: "2025-08-28"
+  version: 0.66.30
+
+- changelogEntry:
     - summary: Update docs workspace validator to skip file type validation when running in selfhosted mode
       type: fix
   irVersion: 59


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6325/java-add-publishtarget-to-java-similar-to-how-other-generators-do-it

This PR adds Maven publish target configuration to Java SDK generation, bringing it to feature parity with Python's PyPi support. Following the PR here https://github.com/fern-api/fern/pull/9068. 

## Changes Made
- Extract Maven coordinates from generator config (coordinate, group/artifact, or hyphenated variants)
- Create Maven publish targets in IR with repository credentials via environment variables
- Support all Java generator variants (java-sdk, java-spring)
- 
```
  Configuration Example:
  generators:
    - name: fernapi/fern-java-sdk
      config:
        coordinate: "com.example:my-sdk"  # or use group/artifact fields
```

