### PR TITLE
fix(go): keep nil placeholder for optional method arguments

### DIFF
--- a/generators/go-v2/ast/src/ast/utils/writeArguments.ts
+++ b/generators/go-v2/ast/src/ast/utils/writeArguments.ts
@@ -12,7 +12,7 @@ export function writeArguments({
     multiline?: boolean;
 }): void {
     const modifiedArguments = arguments_.map((argument) => {
-        // A nop argument (nullable/optional type reference) cannot be ommitted (like in a struct literal type instantation with omitempty)
+        // A nop argument (optional type reference) cannot be ommitted (like in a struct literal type instantation with omitempty)
         // but must be replaced with nil
         if (argument instanceof TypeInstantiation && TypeInstantiation.isNop(argument)) {
             return TypeInstantiation.nil();

--- a/generators/go-v2/ast/src/ast/utils/writeArguments.ts
+++ b/generators/go-v2/ast/src/ast/utils/writeArguments.ts
@@ -11,16 +11,23 @@ export function writeArguments({
     arguments_: UnnamedArgument[];
     multiline?: boolean;
 }): void {
-    const filteredArguments = filterNopArguments(arguments_);
-    if (filteredArguments.length === 0) {
+    const modifiedArguments = arguments_.map((argument) => {
+        // A nop argument (nullable/optional type reference) cannot be ommitted (like in a struct literal type instantation with omitempty)
+        // but must be replaced with nil
+        if (argument instanceof TypeInstantiation && TypeInstantiation.isNop(argument)) {
+            return TypeInstantiation.nil();
+        }
+        return argument;
+    });
+    if (modifiedArguments.length === 0) {
         writer.write("()");
         return;
     }
     if (multiline) {
-        writeMultiline({ writer, arguments_: filteredArguments });
+        writeMultiline({ writer, arguments_: modifiedArguments });
         return;
     }
-    writeCompact({ writer, arguments_: filteredArguments });
+    writeCompact({ writer, arguments_: modifiedArguments });
 }
 
 function writeMultiline({ writer, arguments_ }: { writer: Writer; arguments_: UnnamedArgument[] }): void {
@@ -43,10 +50,4 @@ function writeCompact({ writer, arguments_ }: { writer: Writer; arguments_: Unna
         argument.write(writer);
     });
     writer.write(")");
-}
-
-function filterNopArguments(arguments_: UnnamedArgument[]): UnnamedArgument[] {
-    return arguments_.filter(
-        (argument) => !(argument instanceof TypeInstantiation && TypeInstantiation.isNop(argument))
-    );
 }

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -33,7 +33,7 @@ export class DynamicTypeInstantiationMapper {
             });
         }
         if (args.value == null) {
-            return go.TypeInstantiation.nop();
+            return go.TypeInstantiation.nil();
         }
         switch (args.typeReference.type) {
             case "list":

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -33,9 +33,7 @@ export class DynamicTypeInstantiationMapper {
             });
         }
         if (args.value == null) {
-            return this.context.isOptional(args.typeReference)
-                ? go.TypeInstantiation.nil()
-                : go.TypeInstantiation.nop();
+            return go.TypeInstantiation.nop();
         }
         switch (args.typeReference.type) {
             case "list":

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -33,7 +33,9 @@ export class DynamicTypeInstantiationMapper {
             });
         }
         if (args.value == null) {
-            return go.TypeInstantiation.nil();
+            return this.context.isOptional(args.typeReference)
+                ? go.TypeInstantiation.nil()
+                : go.TypeInstantiation.nop();
         }
         switch (args.typeReference.type) {
             case "list":

--- a/seed/go-sdk/examples/always-send-required-properties/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/always-send-required-properties/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/always-send-required-properties/reference.md
+++ b/seed/go-sdk/examples/always-send-required-properties/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/reference.md
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/client-name/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/client-name/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/client-name/reference.md
+++ b/seed/go-sdk/examples/client-name/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/exported-client-name/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/exported-client-name/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/exported-client-name/reference.md
+++ b/seed/go-sdk/examples/exported-client-name/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/no-custom-config/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/no-custom-config/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/no-custom-config/reference.md
+++ b/seed/go-sdk/examples/no-custom-config/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/package-path/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/package-path/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/package-path/reference.md
+++ b/seed/go-sdk/examples/package-path/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/readme-config/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/readme-config/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/readme-config/reference.md
+++ b/seed/go-sdk/examples/readme-config/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```

--- a/seed/go-sdk/examples/v0/dynamic-snippets/example19/snippet.go
+++ b/seed/go-sdk/examples/v0/dynamic-snippets/example19/snippet.go
@@ -17,5 +17,6 @@ func do() {
     )
     client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }

--- a/seed/go-sdk/examples/v0/reference.md
+++ b/seed/go-sdk/examples/v0/reference.md
@@ -769,6 +769,7 @@ client.Service.CreateBigEntity(
 ```go
 client.Service.RefreshToken(
         context.TODO(),
+        nil,
     )
 }
 ```


### PR DESCRIPTION
## Description
Linear ticket: [FER-6288](https://linear.app/buildwithfern/issue/FER-6288/go-dig-into-seed-failures)
In cases where we have a no-op type instantiation (think an optional struct field, etc) we still need to include a nil placeholder in method invocations

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- one line change 😭 
