### PR TITLE
fix(cli): skip OpenAPI 3.1 type: "null" properties instead of failing

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
@@ -197,7 +197,16 @@ export function convertObject({
         }
     }
 
-    const convertedProperties: ObjectPropertyWithExample[] = Object.entries(propertiesToConvert).map(
+    const filteredPropertiesToConvert = Object.fromEntries(
+        Object.entries(propertiesToConvert).filter(([_, propertySchema]) => {
+            if (!isReferenceObject(propertySchema) && (propertySchema.type as string) === "null") {
+                return false;
+            }
+            return true;
+        })
+    );
+
+    const convertedProperties: ObjectPropertyWithExample[] = Object.entries(filteredPropertiesToConvert).map(
         ([propertyName, propertySchema]) => {
             const audiences = getExtension<string[]>(propertySchema, FernOpenAPIExtension.AUDIENCES) ?? [];
             const availability = convertAvailability(propertySchema);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -522,20 +522,6 @@ export function convertSchemaObject(
         });
     }
 
-    // null type (OpenAPI 3.1 spec)
-    if ((schema.type as string) === "null") {
-        return SchemaWithExample.unknown({
-            nameOverride,
-            generatedName,
-            title,
-            description,
-            availability,
-            namespace,
-            groupName,
-            example: null
-        });
-    }
-
     // arrays
     if (schema.type === "array") {
         return convertArray({

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -522,6 +522,20 @@ export function convertSchemaObject(
         });
     }
 
+    // null type (OpenAPI 3.1 spec)
+    if ((schema.type as string) === "null") {
+        return SchemaWithExample.unknown({
+            nameOverride,
+            generatedName,
+            title,
+            description,
+            availability,
+            namespace,
+            groupName,
+            example: null
+        });
+    }
+
     // arrays
     if (schema.type === "array") {
         return convertArray({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
-    - summary: Add support for OpenAPI 3.1 null type schema
+    - summary: Skip OpenAPI 3.1 null type properties instead of failing
       type: fix
   irVersion: 59
   createdAt: "2025-08-28"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
-    - summary: Add support for OpenAPI 3.1 `type: "null"` schema
+    - summary: Add support for OpenAPI 3.1 type: "null" schema
       type: fix
   irVersion: 59
   createdAt: "2025-08-28"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Add support for OpenAPI 3.1 `type: "null"` schema
+      type: fix
+  irVersion: 59
+  createdAt: "2025-08-28"
+  version: 0.66.30
+
+- changelogEntry:
     - summary: Update docs workspace validator to skip file type validation when running in selfhosted mode
       type: fix
   irVersion: 59

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
-    - summary: Add support for OpenAPI 3.1 type: "null" schema
+    - summary: Add support for OpenAPI 3.1 null type schema
       type: fix
   irVersion: 59
   createdAt: "2025-08-28"


### PR DESCRIPTION
## Description
OpenAPI 3.1 allows explicit null type definition using `type: "null"` for fields that are always null. The importer was throwing "Failed to convert schema" errors when encountering this valid schema type.

## Changes
Based on team discussion, we're skipping properties with type: "null" entirely rather than including them in the generated SDKs. This approach:
  - Fixes the immediate parsing issue
  - Produces cleaner SDKs (no fields that are always null)
  - Works well for response schemas where null fields are mostly informational
  - Serves a  as a temporary solution until we implement proper null type support the IR

## Testing
Verified fix by testing with and without the change:
- Conversion fails without the fix
- Conversion succeeds with the fix on customer's folderit OpenAPI spec