### PR TITLE
chore(ruby): Remove circular dependency logs from ruby generator

### DIFF
--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -528,14 +528,7 @@ class ModuleFile {
         });
 
         const { sorted, cycles } = topologicalSortWithCycleDetection(filteredTypeDeclarations, dependsOn);
-        if (cycles.length > 0) {
-            const cycleDescriptions = cycles.map((cycle) =>
-                cycle.map((typeDeclaration) => typeDeclaration.name.typeId).join(" --> ")
-            );
-            cycleDescriptions.forEach((cycleDescription) => {
-                this.context.logger.warn(`Circular dependency detected: ${cycleDescription}`);
-            });
-        }
+
         sorted.forEach((typeDeclaration) => {
             const typeFilePath = join(
                 this.project.absolutePathToOutputDirectory,

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc19
+  createdAt: "2025-08-29"
+  changelogEntry:
+    - type: chore
+      summary: Removed circular dependency logs.
+  irVersion: 58
+
 - version: 1.0.0-rc18
   createdAt: "2025-08-26"
   changelogEntry:


### PR DESCRIPTION
## Description
Linear ticket: [FER-6300](https://linear.app/buildwithfern/issue/FER-6300/chore-remove-extra-logs-from-ruby-generator)
Removed circular dependency logs from ruby generator

## Testing
Just logs removal, no testing needed
