### PR TITLE
fix(cli): Skip optional<nullable<SELF>> schemas

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -51,7 +51,11 @@ function addSchemas({
         // HACKHACK: Skip self-referencing schemas. I'm not sure if this is the right way to do this.
         if (isRawAliasDefinition(typeDeclaration.schema)) {
             const aliasType = getTypeFromTypeReference(typeDeclaration.schema);
-            if (aliasType === (typeDeclaration.name ?? id) || aliasType === `optional<${typeDeclaration.name ?? id}>`) {
+            if (
+                aliasType === (typeDeclaration.name ?? id) ||
+                aliasType === `optional<${typeDeclaration.name ?? id}>` ||
+                aliasType === `optional<nullable<${typeDeclaration.name ?? id}>>`
+            ) {
                 continue;
             }
         }


### PR DESCRIPTION
## Description
Complete our HACKHACK which was missing `optional<nullable<SELF>>` schema handling

## Changes Made
- See description

## Testing
@tstanmay13 is really excited about adding a test case for this and his other change in a FLUP