### PR TITLE
fix(cli): Skip optional<nullable<SELF>> schemas

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -51,7 +51,11 @@ function addSchemas({
         // HACKHACK: Skip self-referencing schemas. I'm not sure if this is the right way to do this.
         if (isRawAliasDefinition(typeDeclaration.schema)) {
             const aliasType = getTypeFromTypeReference(typeDeclaration.schema);
-            if (aliasType === (typeDeclaration.name ?? id) || aliasType === `optional<${typeDeclaration.name ?? id}>`) {
+            if (
+                aliasType === (typeDeclaration.name ?? id) ||
+                aliasType === `optional<${typeDeclaration.name ?? id}>` ||
+                aliasType === `optional<nullable<${typeDeclaration.name ?? id}>>`
+            ) {
                 continue;
             }
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
 - changelogEntry:
+    - summary: Ignore self-referential types that are optional<nullable<SELF>>
+      type: fix
+  irVersion: 59
+  createdAt: "2025-08-28"
+  version: 0.66.31
+
+- changelogEntry:
     - summary: |
         Alpha testing: add support for HTTP proxies
       type: feat


### PR DESCRIPTION
## Description
Complete our HACKHACK which was missing `optional<nullable<SELF>>` schema handling

## Changes Made
- See description

## Testing
@tstanmay13 is really excited about adding a test case for this and his other change in a FLUP