### PR TITLE
chore(internal): Upgrade dynamic-ir-sdk usages to v59

### DIFF
--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "59.3.0",
+    "@fern-api/dynamic-ir-sdk": "59.4.0",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/path-utils": "workspace:*",

--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "58.2.0",
+    "@fern-api/dynamic-ir-sdk": "59.3.0",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/path-utils": "workspace:*",

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -38,7 +38,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/csharp-codegen": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/path-utils": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "18.15.3",

--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -280,46 +280,34 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.Auth;
         values: FernIr.dynamic.AuthValues;
     }): NamedArgument[] {
+        if (values.type !== auth.type) {
+            this.addError(this.context.newAuthMismatchError({ auth, values }).message);
+            return [];
+        }
+
         switch (auth.type) {
             case "basic":
-                if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorBasicAuthArg({ auth, values });
+                return values.type === "basic" ? this.getConstructorBasicAuthArg({ auth, values }) : [];
             case "bearer":
-                if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorBearerAuthArgs({ auth, values });
+                return values.type === "bearer" ? this.getConstructorBearerAuthArgs({ auth, values }) : [];
             case "header":
-                if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorHeaderAuthArgs({ auth, values });
+                return values.type === "header" ? this.getConstructorHeaderAuthArgs({ auth, values }) : [];
             case "oauth":
-                if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorOAuthArgs({ auth, values });
+                return values.type === "oauth" ? this.getConstructorOAuthArgs({ auth, values }) : [];
+            case "inferred":
+                this.addWarning("The C# SDK Generator does not support Inferred auth scheme yet");
+                return [];
             default:
                 assertNever(auth);
         }
+    }
+
+    private addError(message: string): void {
+        this.context.errors.add({ severity: Severity.Critical, message });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getConstructorBasicAuthArg({

--- a/generators/go-v2/dynamic-snippets/package.json
+++ b/generators/go-v2/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/go-ast": "workspace:*",
     "@fern-api/go-formatter": "workspace:*",
     "@fern-api/path-utils": "workspace:*",

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -10,6 +10,7 @@ const SNIPPET_PACKAGE_NAME = "example";
 const SNIPPET_IMPORT_PATH = "fern";
 const SNIPPET_FUNC_NAME = "do";
 const CLIENT_VAR_NAME = "client";
+const TypeInst = go.TypeInstantiation;
 
 export class EndpointSnippetGenerator {
     private context: DynamicSnippetsGeneratorContext;
@@ -145,50 +146,34 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.Auth;
         values: FernIr.dynamic.AuthValues;
     }): go.AstNode {
+        if (values.type !== auth.type) {
+            this.addError(this.context.newAuthMismatchError({ auth, values }).message);
+            return TypeInst.nop();
+        }
         switch (auth.type) {
             case "basic":
-                if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return go.TypeInstantiation.nop();
-                }
-                return this.getConstructorBasicAuthArg({ auth, values });
+                return values.type === "basic" ? this.getConstructorBasicAuthArg({ auth, values }) : TypeInst.nop();
             case "bearer":
-                if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return go.TypeInstantiation.nop();
-                }
-                return this.getConstructorBearerAuthArg({ auth, values });
+                return values.type === "bearer" ? this.getConstructorBearerAuthArg({ auth, values }) : TypeInst.nop();
             case "header":
-                if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return go.TypeInstantiation.nop();
-                }
-                return this.getConstructorHeaderAuthArg({ auth, values });
+                return values.type === "header" ? this.getConstructorHeaderAuthArg({ auth, values }) : TypeInst.nop();
             case "oauth":
-                if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return go.TypeInstantiation.nop();
-                }
-                this.context.errors.add({
-                    severity: Severity.Warning,
-                    message: "The Go SDK doesn't support OAuth client credentials yet"
-                });
-                return go.TypeInstantiation.nop();
+                this.addWarning("The Go SDK doesn't support OAuth client credentials yet");
+                return TypeInst.nop();
+            case "inferred":
+                this.addWarning("The Go SDK Generator does not support Inferred auth scheme yet");
+                return TypeInst.nop();
             default:
                 assertNever(auth);
         }
+    }
+
+    private addError(message: string): void {
+        this.context.errors.add({ severity: Severity.Critical, message });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getConstructorBasicAuthArg({

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/java-ast": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@types/lodash-es": "^4.17.12",

--- a/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -235,46 +235,33 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.Auth;
         values: FernIr.dynamic.AuthValues;
     }): java.BuilderParameter[] {
+        if (values.type !== auth.type) {
+            this.addError(this.context.newAuthMismatchError({ auth, values }).message);
+            return [];
+        }
         switch (auth.type) {
             case "basic":
-                if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getRootClientBasicAuthArgs({ auth, values });
+                return values.type === "basic" ? this.getRootClientBasicAuthArgs({ auth, values }) : [];
             case "bearer":
-                if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getRootClientBearerAuthArgs({ auth, values });
+                return values.type === "bearer" ? this.getRootClientBearerAuthArgs({ auth, values }) : [];
             case "header":
-                if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getRootClientHeaderAuthArgs({ auth, values });
+                return values.type === "header" ? this.getRootClientHeaderAuthArgs({ auth, values }) : [];
             case "oauth":
-                if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getRootClientOAuthArgs({ auth, values });
+                return values.type === "oauth" ? this.getRootClientOAuthArgs({ auth, values }) : [];
+            case "inferred":
+                this.addWarning("The Java SDK Generator does not support Inferred auth scheme yet");
+                return [];
             default:
                 assertNever(auth);
         }
+    }
+
+    private addError(message: string): void {
+        this.context.errors.add({ severity: Severity.Critical, message });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getRootClientBasicAuthArgs({

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/php-codegen": "workspace:*",
     "@types/lodash-es": "^4.17.12",

--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -152,50 +152,34 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.Auth;
         values: FernIr.dynamic.AuthValues;
     }): NamedArgument[] {
+        if (values.type !== auth.type) {
+            this.addError(this.context.newAuthMismatchError({ auth, values }).message);
+            return [];
+        }
         switch (auth.type) {
             case "basic":
-                if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorBasicAuthArgs({ auth, values });
+                return values.type === "basic" ? this.getConstructorBasicAuthArgs({ auth, values }) : [];
             case "bearer":
-                if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorBearerAuthArgs({ auth, values });
+                return values.type === "bearer" ? this.getConstructorBearerAuthArgs({ auth, values }) : [];
             case "header":
-                if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                return this.getConstructorHeaderAuthArgs({ auth, values });
+                return values.type === "header" ? this.getConstructorHeaderAuthArgs({ auth, values }) : [];
             case "oauth":
-                if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return [];
-                }
-                this.context.errors.add({
-                    severity: Severity.Warning,
-                    message: "The PHP SDK doesn't support OAuth client credentials yet"
-                });
+                this.addWarning("The PHP SDK doesn't support OAuth client credentials yet");
+                return [];
+            case "inferred":
+                this.addWarning("The PHP SDK Generator does not support Inferred auth scheme yet");
                 return [];
             default:
                 assertNever(auth);
         }
+    }
+
+    private addError(message: string): void {
+        this.context.errors.add({ severity: Severity.Critical, message });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getConstructorBasicAuthArgs({

--- a/generators/python-v2/dynamic-snippets/package.json
+++ b/generators/python-v2/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/python-ast": "workspace:*",
     "@fern-api/python-browser-compatible-base": "workspace:*",

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -207,43 +207,49 @@ export class EndpointSnippetGenerator {
         switch (auth.type) {
             case "basic":
                 if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorBasicAuthArg({ auth, values });
             case "bearer":
                 if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorBearerAuthArgs({ auth, values });
             case "header":
                 if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorHeaderAuthArgs({ auth, values });
             case "oauth":
                 if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorOAuthArgs({ auth, values });
+            case "inferred":
+                if (values.type !== "inferred") {
+                    this.addAuthMismatchError(auth, values);
+                    return [];
+                }
+                this.addWarning("The Python SDK Generator does not support Inferred auth scheme yet");
+                return [];
             default:
                 assertNever(auth);
         }
+    }
+
+    private addAuthMismatchError(auth: FernIr.dynamic.Auth, values: FernIr.dynamic.AuthValues): void {
+        this.context.errors.add({
+            severity: Severity.Critical,
+            message: this.context.newAuthMismatchError({ auth, values }).message
+        });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getConstructorBasicAuthArg({

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/ruby-ast": "workspace:*",
     "@types/node": "18.15.3",

--- a/generators/rust/dynamic-snippets/package.json
+++ b/generators/rust/dynamic-snippets/package.json
@@ -31,7 +31,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/rust-codegen": "workspace:*",
     "@types/lodash-es": "^4.17.12",

--- a/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -420,50 +420,35 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.Auth;
         values: FernIr.dynamic.AuthValues;
     }): rust.Expression {
+        const mismatchResult = () => rust.Expression.raw('todo!("Auth mismatch error")');
+        if (values.type !== auth.type) {
+            this.addError(this.context.newAuthMismatchError({ auth, values }).message);
+            return mismatchResult();
+        }
+
+        const notImplementedResult = (name: string) => rust.Expression.raw(`todo!("${name}not implemented")`);
         switch (auth.type) {
             case "basic":
-                if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return rust.Expression.raw('todo!("Auth mismatch error")');
-                }
-                return this.getConstructorBasicAuthArg({ auth, values });
+                return values.type === "basic" ? this.getConstructorBasicAuthArg({ auth, values }) : mismatchResult();
             case "bearer":
-                if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return rust.Expression.raw('todo!("Auth mismatch error")');
-                }
-                return this.getConstructorBearerAuthArg({ auth, values });
+                return values.type === "bearer" ? this.getConstructorBearerAuthArg({ auth, values }) : mismatchResult();
             case "header":
-                if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return rust.Expression.raw('todo!("Auth mismatch error")');
-                }
-                return this.getConstructorHeaderAuthArg({ auth, values });
+                return values.type === "header" ? this.getConstructorHeaderAuthArg({ auth, values }) : mismatchResult();
             case "oauth":
-                if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
-                    return rust.Expression.raw('todo!("Auth mismatch error")');
-                }
-                this.context.errors.add({
-                    severity: Severity.Warning,
-                    message: "OAuth client credentials are not supported yet"
-                });
-                return rust.Expression.raw('todo!("OAuth not implemented")');
+                return values.type === "oauth" ? notImplementedResult("Oauth") : mismatchResult();
+            case "inferred":
+                return values.type === "inferred" ? notImplementedResult("Inferred Auth Scheme") : mismatchResult();
             default:
                 assertNever(auth);
         }
+    }
+
+    private addError(message: string): void {
+        this.context.errors.add({ severity: Severity.Critical, message });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getConstructorBasicAuthArg({

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^58.2.0",
+    "@fern-api/dynamic-ir-sdk": "^59.4.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-browser-compatible-base": "workspace:*",

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -213,43 +213,49 @@ export class EndpointSnippetGenerator {
         switch (auth.type) {
             case "basic":
                 if (values.type !== "basic") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorBasicAuthArg({ auth, values });
             case "bearer":
                 if (values.type !== "bearer") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorBearerAuthArgs({ auth, values });
             case "header":
                 if (values.type !== "header") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorHeaderAuthArgs({ auth, values });
             case "oauth":
                 if (values.type !== "oauth") {
-                    this.context.errors.add({
-                        severity: Severity.Critical,
-                        message: this.context.newAuthMismatchError({ auth, values }).message
-                    });
+                    this.addAuthMismatchError(auth, values);
                     return [];
                 }
                 return this.getConstructorOAuthArgs({ auth, values });
+            case "inferred":
+                if (values.type !== "inferred") {
+                    this.addAuthMismatchError(auth, values);
+                    return [];
+                }
+                this.addWarning("The TypeScript SDK v2 Generator does not support Inferred auth scheme yet");
+                return [];
             default:
                 assertNever(auth);
         }
+    }
+
+    private addAuthMismatchError(auth: FernIr.dynamic.Auth, values: FernIr.dynamic.AuthValues): void {
+        this.context.errors.add({
+            severity: Severity.Critical,
+            message: this.context.newAuthMismatchError({ auth, values }).message
+        });
+    }
+
+    private addWarning(message: string): void {
+        this.context.errors.add({ severity: Severity.Warning, message });
     }
 
     private getConstructorBasicAuthArg({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 58.2.0
-        version: 58.2.0
+        specifier: 59.3.0
+        version: 59.3.0
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../packages/cli/fern-definition/schema
@@ -281,8 +281,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -546,8 +546,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/go-ast':
         specifier: workspace:*
         version: link:../ast
@@ -773,8 +773,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/java-ast':
         specifier: workspace:*
         version: link:../ast
@@ -1014,8 +1014,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1306,8 +1306,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1574,8 +1574,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1929,8 +1929,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -2461,8 +2461,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^58.2.0
-        version: 58.2.0
+        specifier: ^59.4.0
+        version: 59.4.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -9281,6 +9281,12 @@ packages:
 
   '@fern-api/dynamic-ir-sdk@58.2.0':
     resolution: {integrity: sha512-b5uJwu4nbQ+Jj8DoRMJNyI7A8oureAj0I7n55DS78HPadK0AxQnINboGBfhvwE365mkvwu6KM2FrQIZ3RQdI7A==}
+
+  '@fern-api/dynamic-ir-sdk@59.3.0':
+    resolution: {integrity: sha512-4IFw+u97XuFt9cuSU3it2viPTddUva+81h6GmEI9VQxG0CzFylqD2+DNDsvX8mYfspekNYC4Eojjb1m3sqUiGw==}
+
+  '@fern-api/dynamic-ir-sdk@59.4.0':
+    resolution: {integrity: sha512-7dD5ZK6rm2SiMmVGM3GKfejNd8qmV9WGFx3xTWbw7NnS7jmIS5Wn73f9+MRvawcBfd/TONYfw9SE3sbxh89mUw==}
 
   '@fern-api/fdr-sdk@0.139.10-3367c7e52':
     resolution: {integrity: sha512-8s9VcPbSsLOPKKqdrdWL60Ujw2mKv9JYlc9rtkOi+U6xkAf0+BMAA4UAQJTqiE6+VedNHOWPBJTW29pJN21SEg==}
@@ -16349,6 +16355,10 @@ snapshots:
       - typescript
 
   '@fern-api/dynamic-ir-sdk@58.2.0': {}
+
+  '@fern-api/dynamic-ir-sdk@59.3.0': {}
+
+  '@fern-api/dynamic-ir-sdk@59.4.0': {}
 
   '@fern-api/fdr-sdk@0.139.10-3367c7e52(typescript@5.8.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 59.3.0
-        version: 59.3.0
+        specifier: 59.4.0
+        version: 59.4.0
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../packages/cli/fern-definition/schema
@@ -9282,9 +9282,6 @@ packages:
   '@fern-api/dynamic-ir-sdk@58.2.0':
     resolution: {integrity: sha512-b5uJwu4nbQ+Jj8DoRMJNyI7A8oureAj0I7n55DS78HPadK0AxQnINboGBfhvwE365mkvwu6KM2FrQIZ3RQdI7A==}
 
-  '@fern-api/dynamic-ir-sdk@59.3.0':
-    resolution: {integrity: sha512-4IFw+u97XuFt9cuSU3it2viPTddUva+81h6GmEI9VQxG0CzFylqD2+DNDsvX8mYfspekNYC4Eojjb1m3sqUiGw==}
-
   '@fern-api/dynamic-ir-sdk@59.4.0':
     resolution: {integrity: sha512-7dD5ZK6rm2SiMmVGM3GKfejNd8qmV9WGFx3xTWbw7NnS7jmIS5Wn73f9+MRvawcBfd/TONYfw9SE3sbxh89mUw==}
 
@@ -16355,8 +16352,6 @@ snapshots:
       - typescript
 
   '@fern-api/dynamic-ir-sdk@58.2.0': {}
-
-  '@fern-api/dynamic-ir-sdk@59.3.0': {}
 
   '@fern-api/dynamic-ir-sdk@59.4.0': {}
 


### PR DESCRIPTION
## Description
Upgrade dynamic-ir-sdk usages to v59
Workspace dependencies on generators/browser-compatible-base need to be upgraded to accommodate forthcoming changes.

## Changes Made
- Upgraded dependencies to `dynamic-ir-sdk:^59.4.0`
- Refactored EndpointSnippetGenerator.ts implementations to simplify auth error detection codepath

## Testing
No new releases, so no testing was done other than compile succeeding. All CI tests should still pass.
