### PR TITLE
fix(java): correct Maven Central signing configuration to use 3-parameter useInMemoryPgpKeys

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -146,9 +146,10 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
                 writer.addNewLine();
 
                 writer.beginControlFlow("signing");
-                writer.addLine("def signingKeyId = \"$System.env." + MAVEN_SIGNING_KEY + "\"");
+                writer.addLine("def signingKeyId = \"$System.env." + MAVEN_SIGNING_KEY_ID + "\"");
+                writer.addLine("def signingKey = \"$System.env." + MAVEN_SIGNING_KEY + "\"");
                 writer.addLine("def signingPassword = \"$System.env." + MAVEN_SIGNING_PASSWORD + "\"");
-                writer.addLine("useInMemoryPgpKeys(signingKeyId, signingPassword)");
+                writer.addLine("useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)");
                 writer.addLine("sign publishing.publications.maven");
                 writer.endControlFlow();
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,13 @@
+- version: 2.43.1
+  changelogEntry:
+    - summary: |
+        Fix Maven Central signing configuration to correctly use 3-parameter useInMemoryPgpKeys() method.
+        The signing block was incorrectly using MAVEN_SIGNATURE_SECRET_KEY as the key ID parameter
+        instead of MAVEN_SIGNATURE_KID, causing Sonatype Central validation failures during deployment.
+      type: fix
+  createdAt: "2025-09-02"
+  irVersion: 59
+
 - version: 2.43.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/publish-to/build.gradle
+++ b/seed/java-sdk/exhaustive/publish-to/build.gradle
@@ -122,9 +122,10 @@ sonatypeCentralUpload {
 }
 
 signing {
-    def signingKeyId = "$System.env.MAVEN_SIGNATURE_SECRET_KEY"
+    def signingKeyId = "$System.env.MAVEN_SIGNATURE_KID"
+    def signingKey = "$System.env.MAVEN_SIGNATURE_SECRET_KEY"
     def signingPassword = "$System.env.MAVEN_SIGNATURE_PASSWORD"
-    useInMemoryPgpKeys(signingKeyId, signingPassword)
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications.maven
 }
 

--- a/seed/java-sdk/exhaustive/signed_publish/build.gradle
+++ b/seed/java-sdk/exhaustive/signed_publish/build.gradle
@@ -122,9 +122,10 @@ sonatypeCentralUpload {
 }
 
 signing {
-    def signingKeyId = "$System.env.MAVEN_SIGNATURE_SECRET_KEY"
+    def signingKeyId = "$System.env.MAVEN_SIGNATURE_KID"
+    def signingKey = "$System.env.MAVEN_SIGNATURE_SECRET_KEY"
     def signingPassword = "$System.env.MAVEN_SIGNATURE_PASSWORD"
-    useInMemoryPgpKeys(signingKeyId, signingPassword)
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications.maven
 }
 


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6362/java-payabli-correct-maven-central-signing-configuration-to-use-3
Fixed incorrect GPG signing configuration in `GeneratedBuildGradle.java` that was causing Sonatype Central validation failures. The signing block was using `MAVEN_SIGNATURE_SECRET_KEY` as the key ID parameter instead of `MAVEN_SIGNATURE_KID`, causing deployment validation errors.

## Changes Made
- Use MAVEN_SIGNING_KEY_ID for the key ID parameter
- Pass signing key as separate second parameter
- Call useInMemoryPgpKeys with all 3 required parameters (keyId, secretKey, password)

## Testing
<!-- Describe how you tested these changes -->
- [Not needed] Unit tests added/updated
- [X] Manual testing completed
