### PR TITLE
feat(ci): Adding flag to enable and disable use of caching for seed generation

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -20,11 +20,16 @@ inputs:
     description: Whether to allow unexpected failures during seed generation
     required: false
     default: "false"
+  cache-disabled:
+    description: "Whether to skip caching and always regenerate"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
   steps:
     - name: Generate input hash
+      if: inputs.cache-disabled != 'true'
       id: hash
       shell: bash
       run: |
@@ -39,6 +44,7 @@ runs:
         echo "hash=${HASH}" >> $GITHUB_OUTPUT
 
     - name: Check cache
+      if: inputs.cache-disabled != 'true'
       id: cache
       uses: actions/cache/restore@v4
       with:
@@ -46,26 +52,26 @@ runs:
         key: seed-${{ inputs.generator-name }}-${{ steps.hash.outputs.hash }}
 
     - name: Install
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' || inputs.cache-disabled == 'true'
       uses: ./.github/actions/install
 
     - uses: bufbuild/buf-setup-action@v1.34.0
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' || inputs.cache-disabled == 'true'
       with:
         github_token: ${{ github.token }}
 
     - uses: actions/setup-go@v5
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' || inputs.cache-disabled == 'true'
       with:
         go-version: "stable"
 
     - name: Install protoc-gen-openapi
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' || inputs.cache-disabled == 'true'
       shell: bash
       run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
 
     - name: Seed Test
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' || inputs.cache-disabled == 'true'
       shell: bash
       env:
         FORCE_COLOR: "2"
@@ -90,7 +96,7 @@ runs:
         fi
 
     - name: Save cache
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.cache-disabled != 'true'
       uses: actions/cache/save@v4
       with:
         path: seed/${{ inputs.generator-name }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6367/turn-off-seed-caching
Added flag to disable caching of seed outputs in CI. Can debug and then turn the flag back to false at a later date.

## Changes Made
Added cache-disabled variable in cached-seed/action.yaml to force actions to run regardless of seed cache state. This flag can be set to false to re-enable caching.

## Testing
Used a test branch `mallinson/turn-off-seed-caching-clean-with-example` that forced changes on pushes to that branch as seen in [this PR link](https://github.com/fern-api/fern/pull/9149) and monitored CI logs. You can note from [this workflow](https://github.com/fern-api/fern/actions/runs/17415489300), more specifically (this job's log)[https://github.com/fern-api/fern/actions/runs/17415489300/job/49442854682] in that workflow, that caching is no longer in use (for seed).
