### PR TITLE
feat(cli): Fern diff command can consider from and to generator versions

### DIFF
--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -1,4 +1,3 @@
-import semver from "semver";
 import { describe, expect, it } from "vitest";
 import { diffGeneratorVersions, mergeDiffResults, Result } from "../commands/diff/diff";
 

--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -10,6 +10,13 @@ describe("mergeDiffResults tests", () => {
     });
 
     it.each([
+        { bumpA: undefined, bumpB: undefined, expected: undefined },
+        { bumpA: undefined, bumpB: "major", expected: "major" },
+        { bumpA: "major", bumpB: undefined, expected: "major" },
+        { bumpA: "minor", bumpB: undefined, expected: "minor" },
+        { bumpA: "patch", bumpB: undefined, expected: "patch" },
+        { bumpA: undefined, bumpB: "minor", expected: "minor" },
+        { bumpA: undefined, bumpB: "patch", expected: "patch" },
         { bumpA: "major", bumpB: "major", expected: "major" },
         { bumpA: "major", bumpB: "minor", expected: "major" },
         { bumpA: "major", bumpB: "patch", expected: "major" },
@@ -43,7 +50,7 @@ describe("mergeDiffResults tests", () => {
     });
 
     it.each([
-        { from: "1.0.0", to: "1.0.0", expected: "patch" },
+        { from: "1.0.0", to: "1.0.0", expected: undefined },
         { from: "1.0.0", to: "1.0.1", expected: "patch" },
         { from: "1.0.0", to: "1.0.2", expected: "patch" },
         { from: "1.0.0", to: "1.1.0", expected: "minor" },

--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -1,3 +1,4 @@
+import semver from "semver";
 import { describe, expect, it } from "vitest";
 import { diffGeneratorVersions, mergeDiffResults, Result } from "../commands/diff/diff";
 
@@ -53,5 +54,14 @@ describe("mergeDiffResults tests", () => {
     ])("diffGeneratorVersions $from to $to -> $expected", ({ from, to, expected }) => {
         const result = diffGeneratorVersions({ from, to });
         expect(result.bump).toBe(expected);
+    });
+
+    it.each([
+        { from: "1.0.0", to: "0.0.0" },
+        { from: "1.0.0", to: "0.1.0" },
+        { from: "1.0.0", to: "0.0.1" },
+        { from: "2.0.0", to: "1.0.0" }
+    ])("diffGeneratorVersions $from to $to -> throws", ({ from, to }) => {
+        expect(() => diffGeneratorVersions({ from, to })).toThrow();
     });
 });

--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { type Bump, diffGeneratorVersions, mergeDiffResults } from "../commands/diff/diff";
+import { MockCliContext } from "./mockCliContext";
 
 describe("mergeDiffResults tests", () => {
+    let context: MockCliContext;
+
+    beforeAll(() => {
+        context = new MockCliContext();
+    });
+
     it.each([
         { bumpA: "major", bumpB: "major", expected: "major" },
         { bumpA: "major", bumpB: "minor", expected: "major" },
@@ -49,7 +56,7 @@ describe("mergeDiffResults tests", () => {
         { from: "1.0.0", to: "2.1.1", expected: "major" },
         { from: "1.0.0", to: "3.0.0", expected: "major" }
     ])("diffGeneratorVersions $from to $to -> $expected", ({ from, to, expected }) => {
-        const result = diffGeneratorVersions({ from, to });
+        const result = diffGeneratorVersions(context, { from, to });
         expect(result.bump).toBe(expected);
     });
 
@@ -57,8 +64,10 @@ describe("mergeDiffResults tests", () => {
         { from: "1.0.0", to: "0.0.0" },
         { from: "1.0.0", to: "0.1.0" },
         { from: "1.0.0", to: "0.0.1" },
-        { from: "2.0.0", to: "1.0.0" }
+        { from: "2.0.0", to: "1.0.0" },
+        { from: "1.0.0", to: "abcde" },
+        { from: "abcde", to: "1.0.0" }
     ])("diffGeneratorVersions $from to $to -> throws", ({ from, to }) => {
-        expect(() => diffGeneratorVersions({ from, to })).toThrow();
+        expect(() => diffGeneratorVersions(context, { from, to })).toThrow();
     });
 });

--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { diffGeneratorVersions, mergeDiffResults, Result } from "../commands/diff/diff";
+
+type Bump = Result["bump"];
+
+describe("mergeDiffResults tests", () => {
+    it.each([
+        { bumpA: "major", bumpB: "major", expected: "major" },
+        { bumpA: "major", bumpB: "minor", expected: "major" },
+        { bumpA: "major", bumpB: "patch", expected: "major" },
+        { bumpA: "minor", bumpB: "major", expected: "major" },
+        { bumpA: "minor", bumpB: "minor", expected: "minor" },
+        { bumpA: "minor", bumpB: "patch", expected: "minor" },
+        { bumpA: "patch", bumpB: "major", expected: "major" },
+        { bumpA: "patch", bumpB: "minor", expected: "minor" },
+        { bumpA: "patch", bumpB: "patch", expected: "patch" }
+    ])("mergeDiffResults $bumpA to $bumpB -> $expected", ({ bumpA, bumpB, expected }) => {
+        const result = mergeDiffResults({ bump: bumpA as Bump, errors: [] }, { bump: bumpB as Bump, errors: [] });
+        expect(result.bump).toBe(expected);
+    });
+
+    it.each([
+        { aErrors: [], bErrors: [], expectedErrors: [] },
+        { aErrors: ["foo", "bar"], bErrors: [], expectedErrors: ["foo", "bar"] },
+        { aErrors: [], bErrors: ["baz", "qux"], expectedErrors: ["baz", "qux"] },
+        { aErrors: ["foo", "bar"], bErrors: ["baz", "qux"], expectedErrors: ["foo", "bar", "baz", "qux"] }
+    ])("mergeDiffResults $aErrors to $bErrors -> $expectedErrors", ({ aErrors, bErrors, expectedErrors }) => {
+        const bumps = ["major", "minor", "patch"];
+        for (const aBump of bumps) {
+            for (const bBump of bumps) {
+                const result = mergeDiffResults(
+                    { bump: aBump as Bump, errors: aErrors },
+                    { bump: bBump as Bump, errors: bErrors }
+                );
+                expect(result.errors.toSorted()).toEqual(expectedErrors.toSorted());
+            }
+        }
+    });
+
+    it.each([
+        { from: "1.0.0", to: "1.0.0", expected: "patch" },
+        { from: "1.0.0", to: "1.0.1", expected: "patch" },
+        { from: "1.0.0", to: "1.0.2", expected: "patch" },
+        { from: "1.0.0", to: "1.1.0", expected: "minor" },
+        { from: "1.0.0", to: "1.2.0", expected: "minor" },
+        { from: "1.0.0", to: "1.2.1", expected: "minor" },
+        { from: "1.0.0", to: "2.0.0", expected: "major" },
+        { from: "1.0.0", to: "2.0.1", expected: "major" },
+        { from: "1.0.0", to: "2.0.1", expected: "major" },
+        { from: "1.0.0", to: "2.1.0", expected: "major" },
+        { from: "1.0.0", to: "2.1.1", expected: "major" },
+        { from: "1.0.0", to: "3.0.0", expected: "major" }
+    ])("diffGeneratorVersions $from to $to -> $expected", ({ from, to, expected }) => {
+        const result = diffGeneratorVersions({ from, to });
+        expect(result.bump).toBe(expected);
+    });
+});

--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { diffGeneratorVersions, mergeDiffResults, Result } from "../commands/diff/diff";
-
-type Bump = Result["bump"];
+import { type Bump, diffGeneratorVersions, mergeDiffResults } from "../commands/diff/diff";
 
 describe("mergeDiffResults tests", () => {
     it.each([

--- a/packages/cli/cli/src/__test__/mockCliContext.ts
+++ b/packages/cli/cli/src/__test__/mockCliContext.ts
@@ -1,0 +1,18 @@
+import { CliContext } from "../cli-context/CliContext";
+
+// Create a test-specific context that doesn't exit
+export class MockCliContext extends CliContext {
+    constructor() {
+        // Set required environment variables to prevent constructor from calling exitProgram
+        process.env.CLI_PACKAGE_NAME = "test-package";
+        process.env.CLI_VERSION = "0.0.0";
+        process.env.CLI_NAME = "test-cli";
+
+        super(process.stdout, process.stderr, { isLocal: true });
+    }
+
+    // Override exit to prevent process.exit in tests
+    async exit({ code }: { code?: number } = {}): Promise<never> {
+        throw new Error(`CliContext.exit called with code: ${code}`);
+    }
+}

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -361,6 +361,14 @@ function addDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     string: true,
                     description: "The previous version of the API (e.g. 1.1.0)"
                 })
+                .option("from-generator-version", {
+                    string: true,
+                    description: "The previous version of the generator (e.g. 1.1.0)"
+                })
+                .option("to-generator-version", {
+                    string: true,
+                    description: "The next version of the generator (e.g. 1.1.0)"
+                })
                 .option("quiet", {
                     boolean: true,
                     default: false,
@@ -369,11 +377,27 @@ function addDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 }),
         async (argv) => {
             const fromVersion = argv.fromVersion != null ? argv.fromVersion : undefined;
+            const generatorVersions =
+                argv.fromGeneratorVersion != null && argv.toGeneratorVersion != null
+                    ? {
+                          from: argv.fromGeneratorVersion,
+                          to: argv.toGeneratorVersion
+                      }
+                    : undefined;
+            if (
+                generatorVersions === undefined &&
+                (argv.fromGeneratorVersion != null || argv.toGeneratorVersion != null)
+            ) {
+                return cliContext.failWithoutThrowing(
+                    "Cannot specify --from-generator-version or --to-generator-version without specifying both."
+                );
+            }
             const result = await diff({
                 context: cliContext,
                 from: argv.from,
                 to: argv.to,
-                fromVersion
+                fromVersion,
+                generatorVersions
             });
             if (fromVersion != null) {
                 // If the user specified the --from-version flag, we write the full

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -1,3 +1,4 @@
+import { diffSemverOrThrow } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, resolve } from "@fern-api/fs-utils";
 import { IntermediateRepresentation, serialization } from "@fern-api/ir-sdk";
 import { IntermediateRepresentationChangeDetector } from "@fern-api/ir-utils";
@@ -104,15 +105,14 @@ function maxBump(bumpA: Result["bump"], bumpB: Result["bump"]): Result["bump"] {
 
 // export for testing
 export function diffGeneratorVersions(generatorVersions: { from: string; to: string } | undefined): Result {
-    if (generatorVersions === null || generatorVersions === undefined) {
+    if (generatorVersions === undefined) {
         return {
             bump: "patch",
             errors: []
         };
     }
     const { from, to } = generatorVersions;
-
-    const bump = bumpFromDiff(semver.diff(from, to)) || "patch";
+    const bump = bumpFromDiff(diffSemverOrThrow(from, to)) || "patch";
     let errors: string[] = [];
     if (bump === "major") {
         errors.push("Generator version changed by major version.");

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -8,8 +8,9 @@ import semver from "semver";
 
 import { CliContext } from "../../cli-context/CliContext";
 
+export type Bump = "major" | "minor" | "patch";
 export interface Result {
-    bump: "major" | "minor" | "patch";
+    bump: Bump;
     nextVersion?: string;
     errors: string[];
 }

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -94,7 +94,7 @@ export function mergeDiffResults(diffA: Result, diffB: Result): Result {
     };
 }
 
-function maxBump(bumpA: Result["bump"], bumpB: Result["bump"]): Result["bump"] {
+function maxBump(bumpA: Bump, bumpB: Bump): Bump {
     if (bumpA === "major" || bumpB === "major") {
         return "major";
     }
@@ -125,7 +125,7 @@ export function diffGeneratorVersions(generatorVersions: { from: string; to: str
     };
 }
 
-function bumpFromDiff(diff: semver.ReleaseType | null): Result["bump"] | undefined {
+function bumpFromDiff(diff: semver.ReleaseType | null): Bump | undefined {
     if (diff === null) {
         return undefined;
     }

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -77,8 +77,6 @@ async function readIr({
     return parsed.value;
 }
 
-
-
 function resultFromIRChangeResults(results: IntermediateRepresentationChangeDetector.Result): Result {
     return {
         bump: results.bump,
@@ -86,7 +84,8 @@ function resultFromIRChangeResults(results: IntermediateRepresentationChangeDete
     };
 }
 
-function mergeDiffResults(diffA: Result, diffB: Result): Result {
+// export for testing
+export function mergeDiffResults(diffA: Result, diffB: Result): Result {
     return {
         bump: maxBump(diffA.bump, diffB.bump),
         errors: [...diffA.errors, ...diffB.errors]
@@ -103,7 +102,8 @@ function maxBump(bumpA: Result["bump"], bumpB: Result["bump"]): Result["bump"] {
     return "patch";
 }
 
-function diffGeneratorVersions(generatorVersions: { from: string; to: string } | undefined): Result {
+// export for testing
+export function diffGeneratorVersions(generatorVersions: { from: string; to: string } | undefined): Result {
     if (generatorVersions === null || generatorVersions === undefined) {
         return {
             bump: "patch",

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Fern diff command can consider from and to generator versions.
+      type: feat
+  irVersion: 59
+  createdAt: "2025-09-02"
+  version: 0.69.0
+
+- changelogEntry:
     - summary: Fern cli diff command recognizes availability.
       type: feat
   irVersion: 59

--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",

--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",
@@ -31,9 +33,11 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
+    "@types/semver": "^7.5.8",
     "ajv": "^8.17.1",
     "json-schema": "^0.4.0",
     "lodash-es": "^4.17.21",
+    "semver": "^7.5.8",
     "strip-ansi": "^7.1.0",
     "title": "^3.5.3",
     "ua-parser-js": "^1.0.37",

--- a/packages/commons/core-utils/src/index.ts
+++ b/packages/commons/core-utils/src/index.ts
@@ -12,6 +12,13 @@ export { isNonNullish } from "./isNonNullish";
 export { MediaType } from "./mediaType";
 export { mergeWithOverrides } from "./mergeWithOverrides";
 export { noop } from "./noop";
+export {
+    haveSameNullishness,
+    nullIfNullish,
+    nullIfSomeNullish,
+    undefinedIfNullish,
+    undefinedIfSomeNullish
+} from "./nullishUtils";
 export { type ObjectPropertiesVisitor, visitObject, visitObjectAsync } from "./ObjectPropertiesVisitor";
 export { type Entries, entries } from "./objects/entries";
 export { isPlainObject } from "./objects/isPlainObject";

--- a/packages/commons/core-utils/src/index.ts
+++ b/packages/commons/core-utils/src/index.ts
@@ -23,6 +23,7 @@ export { PLATFORM, type Platform } from "./platform";
 export { removeSuffix } from "./removeSuffix";
 export { replaceEnvVariables } from "./replaceEnvVars";
 export { SymbolRegistry, type SymbolRegistryOptions } from "./SymbolRegistry";
+export { diffSemverOrThrow, parseSemverOrThrow } from "./semverUtils";
 export { type SetRequired } from "./setRequired";
 export { stripLeadingSlash } from "./stripLeadingSlash";
 export { titleCase } from "./titleCase";

--- a/packages/commons/core-utils/src/nullishUtils.ts
+++ b/packages/commons/core-utils/src/nullishUtils.ts
@@ -1,0 +1,41 @@
+import { isNonNullish } from "./isNonNullish";
+
+export function nullIfNullish<T>(value: T | null | undefined): T | null {
+    return isNonNullish(value) ? value : null;
+}
+
+export function undefinedIfNullish<T>(value: T | null | undefined): T | undefined {
+    return isNonNullish(value) ? value : undefined;
+}
+
+export function undefinedIfSomeNullish<T extends Record<string, unknown>>(
+    obj: { [K in keyof T]: T[K] | null | undefined }
+): T | undefined {
+    return allOrNoneIf(obj, (value) => !isNonNullish(value), undefined);
+}
+
+export function nullIfSomeNullish<T extends Record<string, unknown>>(
+    obj: { [K in keyof T]: T[K] | null | undefined }
+): T | null {
+    return allOrNoneIf(obj, (value) => !isNonNullish(value), null);
+}
+
+export function haveSameNullishness(...params: (unknown | null | undefined)[]): boolean {
+    const nullishCount = params.filter((param) => !isNonNullish(param)).length;
+    return nullishCount === 0 || nullishCount === params.length;
+}
+
+function allOrNoneIf<T extends Record<string, unknown>, R, Q>(
+    obj: { [K in keyof T]: T[K] | R },
+    predicate: (value: T[keyof T] | R) => boolean,
+    returnValue: Q
+): T | Q {
+    const entries = Object.entries(obj);
+    const hasMatch = entries.some(([, value]) => predicate(value));
+
+    if (hasMatch) {
+        return returnValue;
+    }
+
+    return obj as T;
+}

--- a/packages/commons/core-utils/src/semverUtils.ts
+++ b/packages/commons/core-utils/src/semverUtils.ts
@@ -1,0 +1,18 @@
+import semver from "semver";
+
+export function parseSemverOrThrow(version: string): semver.SemVer {
+    const parsed = semver.parse(version);
+    if (parsed === null) {
+        throw new Error(`Invalid semver: ${version}`);
+    }
+    return parsed;
+}
+
+export function diffSemverOrThrow(from: string | semver.SemVer, to: string | semver.SemVer): semver.ReleaseType | null {
+    const fromSemver = typeof from === "string" ? parseSemverOrThrow(from) : from;
+    const toSemver = typeof to === "string" ? parseSemverOrThrow(to) : to;
+    if (fromSemver > toSemver) {
+        throw new Error("From semver must be less than or equal to to semver");
+    }
+    return semver.diff(fromSemver, toSemver);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7367,6 +7367,9 @@ importers:
 
   packages/commons/core-utils:
     dependencies:
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.0
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -7376,6 +7379,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      semver:
+        specifier: ^7.5.8
+        version: 7.7.2
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0


### PR DESCRIPTION
## Description
Fern diff command previously only considered a from ir file and a to ir file when calculating the diff.
Now it's possible to input a `from` and a `to` generator version with the intended use to pass in the generator version that was used with the corresponding ir version to generate the sdk.

## Changes Made
- Added params to cli.diff command
- Added utilities to commons/core-utils for handling semvers and handling nullish values.

## Testing
- [x] Unit tests added/updated
- [x] Manually tested with sample ir definitions
