### PR TITLE
fix(ci): Update the filter for ruby-v2 in the changes job to filter on the v2 folder not the v1 folder

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       seed: ${{ steps.filter.outputs.seed }}
       ruby: ${{ steps.filter.outputs.ruby }}
-      ruby-v2: ${{ steps.filter.outputs.ruby }}
+      ruby-v2: ${{ steps.filter.outputs.ruby-v2 }}
       openapi: ${{ steps.filter.outputs.openapi }}
       python: ${{ steps.filter.outputs.python }}
       postman: ${{ steps.filter.outputs.postman }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6377/ci-fix-filter-for-ruby-v2
Simple fix to target the proper folder for ruby-v2 changes

## Changes Made
Changed the ruby-v2 changes job to check the ruby-v2 filter instead of the ruby (v1) folder

## Testing
Opened PR [here](https://github.com/fern-api/fern/pull/9152) with these changes, plus a dummy change to the ruby-v2 folder, plus a change to stop the changes in seed.yml from kicking off a job for _all_ generators, and verified the CI job worked properly as seen [here](https://github.com/fern-api/fern/actions/runs/17417032580)
