### PR TITLE
fix(cli): do not fail sdk generation on missing websocket header

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
-    - summary: Example generation ignores headers that don't exist in the channel instead of faling hard.
+    - summary: Example generation ignores headers that don't exist in the channel instead of failing hard.
       type: fix
   irVersion: 59
   createdAt: "2025-09-02"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Example generation ignores headers that don't exist in the channel instead of faling hard.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-09-02"
+  version: 0.69.1
+
+- changelogEntry:
     - summary: Fern diff command can consider from and to generator versions.
       type: feat
   irVersion: 59

--- a/packages/cli/generation/ir-generator/src/converters/convertChannel.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertChannel.ts
@@ -433,8 +433,6 @@ function convertHeaders({
                         workspace
                     })
                 });
-            } else {
-                throw new Error(`Heder ${wireKey} does not exist`);
             }
         }
     }


### PR DESCRIPTION
## Description
Unblocks customer trying to upgrade to the latest version of the TypeScript SDK generator .

## Changes Made
- Don't fail hard when converting websocket header to IR. 

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
