### PR TITLE
fix(swift): prevent `guard` fallthrough in `HTTPClient`

### DIFF
--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.11.1
+  createdAt: "2025-09-03"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed release-mode compilation error in `Core/Networking/HTTPClient.swift` where a guard used precondition (returns `Void`) and could be flagged as falling through. Switched to `preconditionFailure` (returns `Never`) to satisfy the compiler at all optimization levels.
+  irVersion: 59
+
 - version: 0.11.0
   createdAt: "2025-08-26"
   changelogEntry:

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/nullable-optional/Sources/Requests/Requests+SearchRequest.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Requests/Requests+SearchRequest.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension Requests {
+    public struct SearchRequest: Codable, Hashable, Sendable {
+        public let query: String
+        public let filters: [String: JSONValue]?
+        public let includeTypes: JSONValue
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            query: String,
+            filters: [String: JSONValue]? = nil,
+            includeTypes: JSONValue,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.query = query
+            self.filters = filters
+            self.includeTypes = includeTypes
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.query = try container.decode(String.self, forKey: .query)
+            self.filters = try container.decodeIfPresent([String: JSONValue].self, forKey: .filters)
+            self.includeTypes = try container.decode(JSONValue.self, forKey: .includeTypes)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.query, forKey: .query)
+            try container.encodeIfPresent(self.filters, forKey: .filters)
+            try container.encode(self.includeTypes, forKey: .includeTypes)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case query
+            case filters
+            case includeTypes
+        }
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Requests/Requests+UpdateComplexProfileRequest.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Requests/Requests+UpdateComplexProfileRequest.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+extension Requests {
+    public struct UpdateComplexProfileRequest: Codable, Hashable, Sendable {
+        public let nullableRole: JSONValue?
+        public let nullableStatus: JSONValue?
+        public let nullableNotification: JSONValue?
+        public let nullableSearchResult: JSONValue?
+        public let nullableArray: JSONValue?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            nullableRole: JSONValue? = nil,
+            nullableStatus: JSONValue? = nil,
+            nullableNotification: JSONValue? = nil,
+            nullableSearchResult: JSONValue? = nil,
+            nullableArray: JSONValue? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.nullableRole = nullableRole
+            self.nullableStatus = nullableStatus
+            self.nullableNotification = nullableNotification
+            self.nullableSearchResult = nullableSearchResult
+            self.nullableArray = nullableArray
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.nullableRole = try container.decodeIfPresent(JSONValue.self, forKey: .nullableRole)
+            self.nullableStatus = try container.decodeIfPresent(JSONValue.self, forKey: .nullableStatus)
+            self.nullableNotification = try container.decodeIfPresent(JSONValue.self, forKey: .nullableNotification)
+            self.nullableSearchResult = try container.decodeIfPresent(JSONValue.self, forKey: .nullableSearchResult)
+            self.nullableArray = try container.decodeIfPresent(JSONValue.self, forKey: .nullableArray)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encodeIfPresent(self.nullableRole, forKey: .nullableRole)
+            try container.encodeIfPresent(self.nullableStatus, forKey: .nullableStatus)
+            try container.encodeIfPresent(self.nullableNotification, forKey: .nullableNotification)
+            try container.encodeIfPresent(self.nullableSearchResult, forKey: .nullableSearchResult)
+            try container.encodeIfPresent(self.nullableArray, forKey: .nullableArray)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case nullableRole
+            case nullableStatus
+            case nullableNotification
+            case nullableSearchResult
+            case nullableArray
+        }
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Requests/Requests+UpdateTagsRequest.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Requests/Requests+UpdateTagsRequest.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension Requests {
+    public struct UpdateTagsRequest: Codable, Hashable, Sendable {
+        public let tags: JSONValue
+        public let categories: [String]?
+        public let labels: JSONValue?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            tags: JSONValue,
+            categories: [String]? = nil,
+            labels: JSONValue? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.tags = tags
+            self.categories = categories
+            self.labels = labels
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.tags = try container.decode(JSONValue.self, forKey: .tags)
+            self.categories = try container.decodeIfPresent([String].self, forKey: .categories)
+            self.labels = try container.decodeIfPresent(JSONValue.self, forKey: .labels)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.tags, forKey: .tags)
+            try container.encodeIfPresent(self.categories, forKey: .categories)
+            try container.encodeIfPresent(self.labels, forKey: .labels)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case tags
+            case categories
+            case labels
+        }
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
@@ -80,4 +80,110 @@ public final class NullableOptionalClient_: Sendable {
             responseType: [UserResponse].self
         )
     }
+
+    /// Create a complex profile to test nullable enums and unions
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func createComplexProfile(request: ComplexProfile, requestOptions: RequestOptions? = nil) async throws -> ComplexProfile {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/api/profiles/complex",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: ComplexProfile.self
+        )
+    }
+
+    /// Get a complex profile by ID
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getComplexProfile(profileId: String, requestOptions: RequestOptions? = nil) async throws -> ComplexProfile {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/profiles/complex/\(profileId)",
+            requestOptions: requestOptions,
+            responseType: ComplexProfile.self
+        )
+    }
+
+    /// Update complex profile to test nullable field updates
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func updateComplexProfile(profileId: String, request: Requests.UpdateComplexProfileRequest, requestOptions: RequestOptions? = nil) async throws -> ComplexProfile {
+        return try await httpClient.performRequest(
+            method: .patch,
+            path: "/api/profiles/complex/\(profileId)",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: ComplexProfile.self
+        )
+    }
+
+    /// Test endpoint for validating null deserialization
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func testDeserialization(request: DeserializationTestRequest, requestOptions: RequestOptions? = nil) async throws -> DeserializationTestResponse {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/api/test/deserialization",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: DeserializationTestResponse.self
+        )
+    }
+
+    /// Filter users by role with nullable enum
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func filterByRole(role: JSONValue, status: UserStatus? = nil, secondaryRole: JSONValue? = nil, requestOptions: RequestOptions? = nil) async throws -> [UserResponse] {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users/filter",
+            queryParams: [
+                "role": .unknown(role), 
+                "status": status.map { .string($0.rawValue) }, 
+                "secondaryRole": secondaryRole.map { .unknown($0) }
+            ],
+            requestOptions: requestOptions,
+            responseType: [UserResponse].self
+        )
+    }
+
+    /// Get notification settings which may be null
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getNotificationSettings(userId: String, requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+        return try await httpClient.performRequest(
+            method: .get,
+            path: "/api/users/\(userId)/notifications",
+            requestOptions: requestOptions,
+            responseType: JSONValue.self
+        )
+    }
+
+    /// Update tags to test array handling
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func updateTags(userId: String, request: Requests.UpdateTagsRequest, requestOptions: RequestOptions? = nil) async throws -> [String] {
+        return try await httpClient.performRequest(
+            method: .put,
+            path: "/api/users/\(userId)/tags",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: [String].self
+        )
+    }
+
+    /// Get search results with nullable unions
+    ///
+    /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
+    public func getSearchResults(request: Requests.SearchRequest, requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/api/search",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: JSONValue.self
+        )
+    }
 }

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/Address.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/Address.swift
@@ -7,6 +7,8 @@ public struct Address: Codable, Hashable, Sendable {
     public let state: String?
     public let zipCode: String
     public let country: JSONValue?
+    public let buildingId: NullableUserId
+    public let tenantId: OptionalUserId
     /// Additional properties that are not explicitly defined in the schema
     public let additionalProperties: [String: JSONValue]
 
@@ -16,6 +18,8 @@ public struct Address: Codable, Hashable, Sendable {
         state: String? = nil,
         zipCode: String,
         country: JSONValue? = nil,
+        buildingId: NullableUserId,
+        tenantId: OptionalUserId,
         additionalProperties: [String: JSONValue] = .init()
     ) {
         self.street = street
@@ -23,6 +27,8 @@ public struct Address: Codable, Hashable, Sendable {
         self.state = state
         self.zipCode = zipCode
         self.country = country
+        self.buildingId = buildingId
+        self.tenantId = tenantId
         self.additionalProperties = additionalProperties
     }
 
@@ -33,6 +39,8 @@ public struct Address: Codable, Hashable, Sendable {
         self.state = try container.decodeIfPresent(String.self, forKey: .state)
         self.zipCode = try container.decode(String.self, forKey: .zipCode)
         self.country = try container.decodeIfPresent(JSONValue.self, forKey: .country)
+        self.buildingId = try container.decode(NullableUserId.self, forKey: .buildingId)
+        self.tenantId = try container.decode(OptionalUserId.self, forKey: .tenantId)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 
@@ -44,6 +52,8 @@ public struct Address: Codable, Hashable, Sendable {
         try container.encodeIfPresent(self.state, forKey: .state)
         try container.encode(self.zipCode, forKey: .zipCode)
         try container.encodeIfPresent(self.country, forKey: .country)
+        try container.encode(self.buildingId, forKey: .buildingId)
+        try container.encode(self.tenantId, forKey: .tenantId)
     }
 
     /// Keys for encoding/decoding struct properties.
@@ -53,5 +63,7 @@ public struct Address: Codable, Hashable, Sendable {
         case state
         case zipCode
         case country
+        case buildingId
+        case tenantId
     }
 }

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/ComplexProfile.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/ComplexProfile.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Test object with nullable enums, unions, and arrays
+public struct ComplexProfile: Codable, Hashable, Sendable {
+    public let id: String
+    public let nullableRole: JSONValue
+    public let optionalRole: UserRole?
+    public let optionalNullableRole: JSONValue?
+    public let nullableStatus: JSONValue
+    public let optionalStatus: UserStatus?
+    public let optionalNullableStatus: JSONValue?
+    public let nullableNotification: JSONValue
+    public let optionalNotification: NotificationMethod?
+    public let optionalNullableNotification: JSONValue?
+    public let nullableSearchResult: JSONValue
+    public let optionalSearchResult: SearchResult?
+    public let nullableArray: JSONValue
+    public let optionalArray: [String]?
+    public let optionalNullableArray: JSONValue?
+    public let nullableListOfNullables: JSONValue
+    public let nullableMapOfNullables: JSONValue
+    public let nullableListOfUnions: JSONValue
+    public let optionalMapOfEnums: [String: UserRole]?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        id: String,
+        nullableRole: JSONValue,
+        optionalRole: UserRole? = nil,
+        optionalNullableRole: JSONValue? = nil,
+        nullableStatus: JSONValue,
+        optionalStatus: UserStatus? = nil,
+        optionalNullableStatus: JSONValue? = nil,
+        nullableNotification: JSONValue,
+        optionalNotification: NotificationMethod? = nil,
+        optionalNullableNotification: JSONValue? = nil,
+        nullableSearchResult: JSONValue,
+        optionalSearchResult: SearchResult? = nil,
+        nullableArray: JSONValue,
+        optionalArray: [String]? = nil,
+        optionalNullableArray: JSONValue? = nil,
+        nullableListOfNullables: JSONValue,
+        nullableMapOfNullables: JSONValue,
+        nullableListOfUnions: JSONValue,
+        optionalMapOfEnums: [String: UserRole]? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.id = id
+        self.nullableRole = nullableRole
+        self.optionalRole = optionalRole
+        self.optionalNullableRole = optionalNullableRole
+        self.nullableStatus = nullableStatus
+        self.optionalStatus = optionalStatus
+        self.optionalNullableStatus = optionalNullableStatus
+        self.nullableNotification = nullableNotification
+        self.optionalNotification = optionalNotification
+        self.optionalNullableNotification = optionalNullableNotification
+        self.nullableSearchResult = nullableSearchResult
+        self.optionalSearchResult = optionalSearchResult
+        self.nullableArray = nullableArray
+        self.optionalArray = optionalArray
+        self.optionalNullableArray = optionalNullableArray
+        self.nullableListOfNullables = nullableListOfNullables
+        self.nullableMapOfNullables = nullableMapOfNullables
+        self.nullableListOfUnions = nullableListOfUnions
+        self.optionalMapOfEnums = optionalMapOfEnums
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.nullableRole = try container.decode(JSONValue.self, forKey: .nullableRole)
+        self.optionalRole = try container.decodeIfPresent(UserRole.self, forKey: .optionalRole)
+        self.optionalNullableRole = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableRole)
+        self.nullableStatus = try container.decode(JSONValue.self, forKey: .nullableStatus)
+        self.optionalStatus = try container.decodeIfPresent(UserStatus.self, forKey: .optionalStatus)
+        self.optionalNullableStatus = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableStatus)
+        self.nullableNotification = try container.decode(JSONValue.self, forKey: .nullableNotification)
+        self.optionalNotification = try container.decodeIfPresent(NotificationMethod.self, forKey: .optionalNotification)
+        self.optionalNullableNotification = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableNotification)
+        self.nullableSearchResult = try container.decode(JSONValue.self, forKey: .nullableSearchResult)
+        self.optionalSearchResult = try container.decodeIfPresent(SearchResult.self, forKey: .optionalSearchResult)
+        self.nullableArray = try container.decode(JSONValue.self, forKey: .nullableArray)
+        self.optionalArray = try container.decodeIfPresent([String].self, forKey: .optionalArray)
+        self.optionalNullableArray = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableArray)
+        self.nullableListOfNullables = try container.decode(JSONValue.self, forKey: .nullableListOfNullables)
+        self.nullableMapOfNullables = try container.decode(JSONValue.self, forKey: .nullableMapOfNullables)
+        self.nullableListOfUnions = try container.decode(JSONValue.self, forKey: .nullableListOfUnions)
+        self.optionalMapOfEnums = try container.decodeIfPresent([String: UserRole].self, forKey: .optionalMapOfEnums)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.nullableRole, forKey: .nullableRole)
+        try container.encodeIfPresent(self.optionalRole, forKey: .optionalRole)
+        try container.encodeIfPresent(self.optionalNullableRole, forKey: .optionalNullableRole)
+        try container.encode(self.nullableStatus, forKey: .nullableStatus)
+        try container.encodeIfPresent(self.optionalStatus, forKey: .optionalStatus)
+        try container.encodeIfPresent(self.optionalNullableStatus, forKey: .optionalNullableStatus)
+        try container.encode(self.nullableNotification, forKey: .nullableNotification)
+        try container.encodeIfPresent(self.optionalNotification, forKey: .optionalNotification)
+        try container.encodeIfPresent(self.optionalNullableNotification, forKey: .optionalNullableNotification)
+        try container.encode(self.nullableSearchResult, forKey: .nullableSearchResult)
+        try container.encodeIfPresent(self.optionalSearchResult, forKey: .optionalSearchResult)
+        try container.encode(self.nullableArray, forKey: .nullableArray)
+        try container.encodeIfPresent(self.optionalArray, forKey: .optionalArray)
+        try container.encodeIfPresent(self.optionalNullableArray, forKey: .optionalNullableArray)
+        try container.encode(self.nullableListOfNullables, forKey: .nullableListOfNullables)
+        try container.encode(self.nullableMapOfNullables, forKey: .nullableMapOfNullables)
+        try container.encode(self.nullableListOfUnions, forKey: .nullableListOfUnions)
+        try container.encodeIfPresent(self.optionalMapOfEnums, forKey: .optionalMapOfEnums)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case nullableRole
+        case optionalRole
+        case optionalNullableRole
+        case nullableStatus
+        case optionalStatus
+        case optionalNullableStatus
+        case nullableNotification
+        case optionalNotification
+        case optionalNullableNotification
+        case nullableSearchResult
+        case optionalSearchResult
+        case nullableArray
+        case optionalArray
+        case optionalNullableArray
+        case nullableListOfNullables
+        case nullableMapOfNullables
+        case nullableListOfUnions
+        case optionalMapOfEnums
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/DeserializationTestRequest.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/DeserializationTestRequest.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Request body for testing deserialization of null values
+public struct DeserializationTestRequest: Codable, Hashable, Sendable {
+    public let requiredString: String
+    public let nullableString: JSONValue
+    public let optionalString: String?
+    public let optionalNullableString: JSONValue?
+    public let nullableEnum: JSONValue
+    public let optionalEnum: UserStatus?
+    public let nullableUnion: JSONValue
+    public let optionalUnion: SearchResult?
+    public let nullableList: JSONValue
+    public let nullableMap: JSONValue
+    public let nullableObject: JSONValue
+    public let optionalObject: Organization?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        requiredString: String,
+        nullableString: JSONValue,
+        optionalString: String? = nil,
+        optionalNullableString: JSONValue? = nil,
+        nullableEnum: JSONValue,
+        optionalEnum: UserStatus? = nil,
+        nullableUnion: JSONValue,
+        optionalUnion: SearchResult? = nil,
+        nullableList: JSONValue,
+        nullableMap: JSONValue,
+        nullableObject: JSONValue,
+        optionalObject: Organization? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.requiredString = requiredString
+        self.nullableString = nullableString
+        self.optionalString = optionalString
+        self.optionalNullableString = optionalNullableString
+        self.nullableEnum = nullableEnum
+        self.optionalEnum = optionalEnum
+        self.nullableUnion = nullableUnion
+        self.optionalUnion = optionalUnion
+        self.nullableList = nullableList
+        self.nullableMap = nullableMap
+        self.nullableObject = nullableObject
+        self.optionalObject = optionalObject
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.requiredString = try container.decode(String.self, forKey: .requiredString)
+        self.nullableString = try container.decode(JSONValue.self, forKey: .nullableString)
+        self.optionalString = try container.decodeIfPresent(String.self, forKey: .optionalString)
+        self.optionalNullableString = try container.decodeIfPresent(JSONValue.self, forKey: .optionalNullableString)
+        self.nullableEnum = try container.decode(JSONValue.self, forKey: .nullableEnum)
+        self.optionalEnum = try container.decodeIfPresent(UserStatus.self, forKey: .optionalEnum)
+        self.nullableUnion = try container.decode(JSONValue.self, forKey: .nullableUnion)
+        self.optionalUnion = try container.decodeIfPresent(SearchResult.self, forKey: .optionalUnion)
+        self.nullableList = try container.decode(JSONValue.self, forKey: .nullableList)
+        self.nullableMap = try container.decode(JSONValue.self, forKey: .nullableMap)
+        self.nullableObject = try container.decode(JSONValue.self, forKey: .nullableObject)
+        self.optionalObject = try container.decodeIfPresent(Organization.self, forKey: .optionalObject)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.requiredString, forKey: .requiredString)
+        try container.encode(self.nullableString, forKey: .nullableString)
+        try container.encodeIfPresent(self.optionalString, forKey: .optionalString)
+        try container.encodeIfPresent(self.optionalNullableString, forKey: .optionalNullableString)
+        try container.encode(self.nullableEnum, forKey: .nullableEnum)
+        try container.encodeIfPresent(self.optionalEnum, forKey: .optionalEnum)
+        try container.encode(self.nullableUnion, forKey: .nullableUnion)
+        try container.encodeIfPresent(self.optionalUnion, forKey: .optionalUnion)
+        try container.encode(self.nullableList, forKey: .nullableList)
+        try container.encode(self.nullableMap, forKey: .nullableMap)
+        try container.encode(self.nullableObject, forKey: .nullableObject)
+        try container.encodeIfPresent(self.optionalObject, forKey: .optionalObject)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case requiredString
+        case nullableString
+        case optionalString
+        case optionalNullableString
+        case nullableEnum
+        case optionalEnum
+        case nullableUnion
+        case optionalUnion
+        case nullableList
+        case nullableMap
+        case nullableObject
+        case optionalObject
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/DeserializationTestResponse.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/DeserializationTestResponse.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Response for deserialization test
+public struct DeserializationTestResponse: Codable, Hashable, Sendable {
+    public let echo: DeserializationTestRequest
+    public let processedAt: Date
+    public let nullCount: Int
+    public let presentFieldsCount: Int
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        echo: DeserializationTestRequest,
+        processedAt: Date,
+        nullCount: Int,
+        presentFieldsCount: Int,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.echo = echo
+        self.processedAt = processedAt
+        self.nullCount = nullCount
+        self.presentFieldsCount = presentFieldsCount
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.echo = try container.decode(DeserializationTestRequest.self, forKey: .echo)
+        self.processedAt = try container.decode(Date.self, forKey: .processedAt)
+        self.nullCount = try container.decode(Int.self, forKey: .nullCount)
+        self.presentFieldsCount = try container.decode(Int.self, forKey: .presentFieldsCount)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.echo, forKey: .echo)
+        try container.encode(self.processedAt, forKey: .processedAt)
+        try container.encode(self.nullCount, forKey: .nullCount)
+        try container.encode(self.presentFieldsCount, forKey: .presentFieldsCount)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case echo
+        case processedAt
+        case nullCount
+        case presentFieldsCount
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/Document.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/Document.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public struct Document: Codable, Hashable, Sendable {
+    public let id: String
+    public let title: String
+    public let content: String
+    public let author: JSONValue
+    public let tags: [String]?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        id: String,
+        title: String,
+        content: String,
+        author: JSONValue,
+        tags: [String]? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.author = author
+        self.tags = tags
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.content = try container.decode(String.self, forKey: .content)
+        self.author = try container.decode(JSONValue.self, forKey: .author)
+        self.tags = try container.decodeIfPresent([String].self, forKey: .tags)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.content, forKey: .content)
+        try container.encode(self.author, forKey: .author)
+        try container.encodeIfPresent(self.tags, forKey: .tags)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case title
+        case content
+        case author
+        case tags
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/EmailNotification.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/EmailNotification.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct EmailNotification: Codable, Hashable, Sendable {
+    public let emailAddress: String
+    public let subject: String
+    public let htmlContent: String?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        emailAddress: String,
+        subject: String,
+        htmlContent: String? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.emailAddress = emailAddress
+        self.subject = subject
+        self.htmlContent = htmlContent
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.emailAddress = try container.decode(String.self, forKey: .emailAddress)
+        self.subject = try container.decode(String.self, forKey: .subject)
+        self.htmlContent = try container.decodeIfPresent(String.self, forKey: .htmlContent)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.emailAddress, forKey: .emailAddress)
+        try container.encode(self.subject, forKey: .subject)
+        try container.encodeIfPresent(self.htmlContent, forKey: .htmlContent)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case emailAddress
+        case subject
+        case htmlContent
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/NotificationMethod.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/NotificationMethod.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// Discriminated union for testing nullable unions
+public enum NotificationMethod: Codable, Hashable, Sendable {
+    case email(Email)
+    case sms(Sms)
+    case push(Push)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminant = try container.decode(String.self, forKey: .type)
+        switch discriminant {
+        case "email":
+            self = .email(try Email(from: decoder))
+        case "sms":
+            self = .sms(try Sms(from: decoder))
+        case "push":
+            self = .push(try Push(from: decoder))
+        default:
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown shape discriminant value: \(discriminant)"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        switch self {
+        case .email(let data):
+            try data.encode(to: encoder)
+        case .sms(let data):
+            try data.encode(to: encoder)
+        case .push(let data):
+            try data.encode(to: encoder)
+        }
+    }
+
+    public struct Email: Codable, Hashable, Sendable {
+        public let type: String = "email"
+        public let emailAddress: String
+        public let subject: String
+        public let htmlContent: String?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            emailAddress: String,
+            subject: String,
+            htmlContent: String? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.emailAddress = emailAddress
+            self.subject = subject
+            self.htmlContent = htmlContent
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.emailAddress = try container.decode(String.self, forKey: .emailAddress)
+            self.subject = try container.decode(String.self, forKey: .subject)
+            self.htmlContent = try container.decodeIfPresent(String.self, forKey: .htmlContent)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.emailAddress, forKey: .emailAddress)
+            try container.encode(self.subject, forKey: .subject)
+            try container.encodeIfPresent(self.htmlContent, forKey: .htmlContent)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
+            case emailAddress
+            case subject
+            case htmlContent
+        }
+    }
+
+    public struct Sms: Codable, Hashable, Sendable {
+        public let type: String = "sms"
+        public let phoneNumber: String
+        public let message: String
+        public let shortCode: String?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            phoneNumber: String,
+            message: String,
+            shortCode: String? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.phoneNumber = phoneNumber
+            self.message = message
+            self.shortCode = shortCode
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.phoneNumber = try container.decode(String.self, forKey: .phoneNumber)
+            self.message = try container.decode(String.self, forKey: .message)
+            self.shortCode = try container.decodeIfPresent(String.self, forKey: .shortCode)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.phoneNumber, forKey: .phoneNumber)
+            try container.encode(self.message, forKey: .message)
+            try container.encodeIfPresent(self.shortCode, forKey: .shortCode)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
+            case phoneNumber
+            case message
+            case shortCode
+        }
+    }
+
+    public struct Push: Codable, Hashable, Sendable {
+        public let type: String = "push"
+        public let deviceToken: String
+        public let title: String
+        public let body: String
+        public let badge: Int?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            deviceToken: String,
+            title: String,
+            body: String,
+            badge: Int? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.deviceToken = deviceToken
+            self.title = title
+            self.body = body
+            self.badge = badge
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.deviceToken = try container.decode(String.self, forKey: .deviceToken)
+            self.title = try container.decode(String.self, forKey: .title)
+            self.body = try container.decode(String.self, forKey: .body)
+            self.badge = try container.decodeIfPresent(Int.self, forKey: .badge)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.deviceToken, forKey: .deviceToken)
+            try container.encode(self.title, forKey: .title)
+            try container.encode(self.body, forKey: .body)
+            try container.encodeIfPresent(self.badge, forKey: .badge)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
+            case deviceToken
+            case title
+            case body
+            case badge
+        }
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case type
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/NullableUserId.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/NullableUserId.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// An alias for a nullable user ID
+public typealias NullableUserId = JSONValue

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/OptionalUserId.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/OptionalUserId.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// An alias for an optional user ID
+public typealias OptionalUserId = String?

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/Organization.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/Organization.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct Organization: Codable, Hashable, Sendable {
+    public let id: String
+    public let name: String
+    public let domain: JSONValue
+    public let employeeCount: Int?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        id: String,
+        name: String,
+        domain: JSONValue,
+        employeeCount: Int? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.id = id
+        self.name = name
+        self.domain = domain
+        self.employeeCount = employeeCount
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.domain = try container.decode(JSONValue.self, forKey: .domain)
+        self.employeeCount = try container.decodeIfPresent(Int.self, forKey: .employeeCount)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.domain, forKey: .domain)
+        try container.encodeIfPresent(self.employeeCount, forKey: .employeeCount)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+        case domain
+        case employeeCount
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/PushNotification.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/PushNotification.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct PushNotification: Codable, Hashable, Sendable {
+    public let deviceToken: String
+    public let title: String
+    public let body: String
+    public let badge: Int?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        deviceToken: String,
+        title: String,
+        body: String,
+        badge: Int? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.deviceToken = deviceToken
+        self.title = title
+        self.body = body
+        self.badge = badge
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.deviceToken = try container.decode(String.self, forKey: .deviceToken)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.body = try container.decode(String.self, forKey: .body)
+        self.badge = try container.decodeIfPresent(Int.self, forKey: .badge)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.deviceToken, forKey: .deviceToken)
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.body, forKey: .body)
+        try container.encodeIfPresent(self.badge, forKey: .badge)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case deviceToken
+        case title
+        case body
+        case badge
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/SearchResult.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/SearchResult.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Undiscriminated union for testing
+public enum SearchResult: Codable, Hashable, Sendable {
+    case user(User)
+    case organization(Organization)
+    case document(Document)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminant = try container.decode(String.self, forKey: .type)
+        switch discriminant {
+        case "user":
+            self = .user(try User(from: decoder))
+        case "organization":
+            self = .organization(try Organization(from: decoder))
+        case "document":
+            self = .document(try Document(from: decoder))
+        default:
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown shape discriminant value: \(discriminant)"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        switch self {
+        case .user(let data):
+            try data.encode(to: encoder)
+        case .organization(let data):
+            try data.encode(to: encoder)
+        case .document(let data):
+            try data.encode(to: encoder)
+        }
+    }
+
+    public struct User: Codable, Hashable, Sendable {
+        public let type: String = "user"
+        public let id: String
+        public let username: String
+        public let email: JSONValue
+        public let phone: String?
+        public let createdAt: Date
+        public let updatedAt: JSONValue
+        public let address: Address?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            id: String,
+            username: String,
+            email: JSONValue,
+            phone: String? = nil,
+            createdAt: Date,
+            updatedAt: JSONValue,
+            address: Address? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.id = id
+            self.username = username
+            self.email = email
+            self.phone = phone
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.address = address
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = try container.decode(String.self, forKey: .id)
+            self.username = try container.decode(String.self, forKey: .username)
+            self.email = try container.decode(JSONValue.self, forKey: .email)
+            self.phone = try container.decodeIfPresent(String.self, forKey: .phone)
+            self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+            self.updatedAt = try container.decode(JSONValue.self, forKey: .updatedAt)
+            self.address = try container.decodeIfPresent(Address.self, forKey: .address)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.username, forKey: .username)
+            try container.encode(self.email, forKey: .email)
+            try container.encodeIfPresent(self.phone, forKey: .phone)
+            try container.encode(self.createdAt, forKey: .createdAt)
+            try container.encode(self.updatedAt, forKey: .updatedAt)
+            try container.encodeIfPresent(self.address, forKey: .address)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
+            case id
+            case username
+            case email
+            case phone
+            case createdAt
+            case updatedAt
+            case address
+        }
+    }
+
+    public struct Organization: Codable, Hashable, Sendable {
+        public let type: String = "organization"
+        public let id: String
+        public let name: String
+        public let domain: JSONValue
+        public let employeeCount: Int?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            id: String,
+            name: String,
+            domain: JSONValue,
+            employeeCount: Int? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.id = id
+            self.name = name
+            self.domain = domain
+            self.employeeCount = employeeCount
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = try container.decode(String.self, forKey: .id)
+            self.name = try container.decode(String.self, forKey: .name)
+            self.domain = try container.decode(JSONValue.self, forKey: .domain)
+            self.employeeCount = try container.decodeIfPresent(Int.self, forKey: .employeeCount)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.name, forKey: .name)
+            try container.encode(self.domain, forKey: .domain)
+            try container.encodeIfPresent(self.employeeCount, forKey: .employeeCount)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
+            case id
+            case name
+            case domain
+            case employeeCount
+        }
+    }
+
+    public struct Document: Codable, Hashable, Sendable {
+        public let type: String = "document"
+        public let id: String
+        public let title: String
+        public let content: String
+        public let author: JSONValue
+        public let tags: [String]?
+        /// Additional properties that are not explicitly defined in the schema
+        public let additionalProperties: [String: JSONValue]
+
+        public init(
+            id: String,
+            title: String,
+            content: String,
+            author: JSONValue,
+            tags: [String]? = nil,
+            additionalProperties: [String: JSONValue] = .init()
+        ) {
+            self.id = id
+            self.title = title
+            self.content = content
+            self.author = author
+            self.tags = tags
+            self.additionalProperties = additionalProperties
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = try container.decode(String.self, forKey: .id)
+            self.title = try container.decode(String.self, forKey: .title)
+            self.content = try container.decode(String.self, forKey: .content)
+            self.author = try container.decode(JSONValue.self, forKey: .author)
+            self.tags = try container.decodeIfPresent([String].self, forKey: .tags)
+            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+        }
+
+        public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encoder.encodeAdditionalProperties(self.additionalProperties)
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.title, forKey: .title)
+            try container.encode(self.content, forKey: .content)
+            try container.encode(self.author, forKey: .author)
+            try container.encodeIfPresent(self.tags, forKey: .tags)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
+            case id
+            case title
+            case content
+            case author
+            case tags
+        }
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case type
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/SmsNotification.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/SmsNotification.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct SmsNotification: Codable, Hashable, Sendable {
+    public let phoneNumber: String
+    public let message: String
+    public let shortCode: String?
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        phoneNumber: String,
+        message: String,
+        shortCode: String? = nil,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.phoneNumber = phoneNumber
+        self.message = message
+        self.shortCode = shortCode
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.phoneNumber = try container.decode(String.self, forKey: .phoneNumber)
+        self.message = try container.decode(String.self, forKey: .message)
+        self.shortCode = try container.decodeIfPresent(String.self, forKey: .shortCode)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.phoneNumber, forKey: .phoneNumber)
+        try container.encode(self.message, forKey: .message)
+        try container.encodeIfPresent(self.shortCode, forKey: .shortCode)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case phoneNumber
+        case message
+        case shortCode
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/UserRole.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/UserRole.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Test enum for nullable enum fields
+public enum UserRole: String, Codable, Hashable, CaseIterable, Sendable {
+    case admin = "ADMIN"
+    case user = "USER"
+    case guest = "GUEST"
+    case moderator = "MODERATOR"
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Schemas/UserStatus.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Schemas/UserStatus.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Test enum with values for optional enum fields
+public enum UserStatus: String, Codable, Hashable, CaseIterable, Sendable {
+    case active
+    case inactive
+    case suspended
+    case deleted
+}

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -69,7 +69,7 @@ final class HTTPClient: Sendable {
                 throw ClientError.invalidResponse
             }
         }
-        
+
         if responseType == String.self {
             if let string = String(data: data, encoding: .utf8) as? T {
                 return string
@@ -137,8 +137,7 @@ final class HTTPClient: Sendable {
     ) -> URL {
         let endpointURL: String = "\(clientConfig.baseURL)\(path)"
         guard var components: URLComponents = URLComponents(string: endpointURL) else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
@@ -154,8 +153,7 @@ final class HTTPClient: Sendable {
                 })
         }
         guard let url = components.url else {
-            precondition(
-                false,
+            preconditionFailure(
                 "Failed to construct URL from components - this indicates an unexpected error in the SDK."
             )
         }
@@ -207,8 +205,7 @@ final class HTTPClient: Sendable {
                 // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
-                precondition(
-                    false,
+                preconditionFailure(
                     "Failed to encode request body: \(error) - this indicates an unexpected error in the SDK."
                 )
             }


### PR DESCRIPTION
## Description
Linear ticket: [FER-6384](https://linear.app/buildwithfern/issue/FER-6384/replace-precondition-calls-with-preconditionfailure)
<!-- Provide a clear and concise description of the changes made in this PR -->
Replaces `precondition(false, msg)` with `preconditionFailure(msg)` in `HTTPClient` so the `guard … else` block is non-returning in release mode builds. The latter returns `Never`. This removes the “guard body may not fall through” error in Release builds. No runtime behavior change.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Replaced `precondition(false, msg)` with `preconditionFailure(msg)` in `HTTPClient`
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
