### PR TITLE
feat(ci): Adding ruby-sdk-v2 to update-seed workflows

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -68,6 +68,7 @@ jobs:
               - 'seed/ruby-model/**'
             ruby-v2:
               - 'generators/ruby-v2/**'
+              - 'seed/ruby-sdk-v2/**'
             openapi:
               - 'generators/openapi/**'
               - 'seed/openapi/**'

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       seed: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.seed }}
       ruby: ${{ steps.filter.outputs.ruby }}
+      ruby-v2: ${{ steps.filter.outputs.ruby-v2 }}
       openapi: ${{ steps.filter.outputs.openapi }}
       python: ${{ steps.filter.outputs.python }}
       postman: ${{ steps.filter.outputs.postman }}
@@ -56,6 +57,9 @@ jobs:
               - 'generators/ruby/**'
               - seed/ruby-sdk/seed.yml
               - seed/ruby-model/seed.yml
+            ruby-v2:
+              - 'generators/ruby-v2/**'
+              - seed/ruby-sdk-v2/seed.yml
             openapi:
               - 'generators/openapi/**'
               - seed/openapi/seed.yml
@@ -182,6 +186,51 @@ jobs:
           approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
+  ruby-sdk-v2:
+    needs: changes
+    if: ${{ needs.changes.outputs.ruby-v2 == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    runs-on: Seed
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: ruby-sdk-v2
+          generator-path: generators/ruby-v2
+          validate-git-diff: false
+          allow-unexpected-failures: true
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+          commit-message: "chore(ruby): update ruby-sdk-v2 seed"
+          title: "chore(ruby): update ruby-sdk-v2 seed"
+          branch: update-ruby-sdk-v2-seed
+          delete-branch: true
+          labels: |
+            seed
+            language/ruby
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
+
+      - name: Approve PR
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: ./.github/actions/auto-approve
+        with:
+          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
   pydantic-model:
     needs: changes
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6379/ci-add-ruby-v2-to-seed-generation-updates-in-update-seedyml-job
Adding job to `update-seed.yml` so that `ruby-sdk-v2` seed files will be automatically be updated on merge

## Changes Made
- New job added to `update-seed.yml` workflow
- Minor change to `changes` job in `seed.yml` to include `seed/ruby-sdk-v2` as part of what detects as a change

## Testing
Pushed to branch https://github.com/fern-api/fern/tree/refs/heads/mallinson/ruby-v2-update-seed-workflow-with-examples with updates to target this branch instead of main and verified a ruby-sdk-v2 changes job kicked off for the `update-seed` workflow here: https://github.com/fern-api/fern/actions/runs/17442764956