### PR TITLE
fix(cli): dont fail hard on single schema parse failure

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/.depcheckrc.json
+++ b/packages/cli/api-importers/openapi-to-ir/.depcheckrc.json
@@ -1,9 +1,4 @@
 {
-  "ignores": [
-    "@fern-api/api-workspace-commons"
-  ],
-  "ignore-patterns": [
-    "lib",
-    "dist"
-  ]
+  "ignores": ["@fern-api/api-workspace-commons"],
+  "ignore-patterns": ["lib", "dist"]
 }

--- a/packages/cli/api-importers/openapi-to-ir/.depcheckrc.json
+++ b/packages/cli/api-importers/openapi-to-ir/.depcheckrc.json
@@ -1,4 +1,9 @@
 {
-  "ignores": [],
-  "ignore-patterns": ["lib", "dist"]
+  "ignores": [
+    "@fern-api/api-workspace-commons"
+  ],
+  "ignore-patterns": [
+    "lib",
+    "dist"
+  ]
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -966,23 +966,21 @@ export function convertSchemaObject(
         });
     }
 
-    if (schema.type == null) {
-        const inferredValue = schema.example ?? schema.default;
-        return SchemaWithExample.unknown({
-            nameOverride,
-            generatedName,
-            title,
-            description,
-            availability,
-            namespace,
-            groupName,
-            example: inferredValue
-        });
+    if (schema.type != null) {
+        context.logger.warn(`Failed to parse an OpenAPI schema at the following location: ${breadcrumbs.join("->")}. Coercing to unknown.`);
     }
 
-    throw new Error(
-        `Failed to convert schema breadcrumbs=${JSON.stringify(breadcrumbs)} value=${JSON.stringify(schema)}`
-    );
+    const inferredValue = schema.example ?? schema.default;
+    return SchemaWithExample.unknown({
+        nameOverride,
+        generatedName,
+        title,
+        description,
+        availability,
+        namespace,
+        groupName,
+        example: inferredValue
+    });
 }
 
 function getBooleanFromDefault(defaultValue: unknown): boolean | undefined {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -967,7 +967,9 @@ export function convertSchemaObject(
     }
 
     if (schema.type != null) {
-        context.logger.warn(`Failed to parse an OpenAPI schema at the following location: ${breadcrumbs.join("->")}. Coercing to unknown.`);
+        context.logger.warn(
+            `Failed to parse an OpenAPI schema at the following location: ${breadcrumbs.join("->")}. Coercing to unknown.`
+        );
     }
 
     const inferredValue = schema.example ?? schema.default;

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/utils/isReferenceObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/utils/isReferenceObject.ts
@@ -9,5 +9,5 @@ export function isReferenceObject(
         | OpenAPIV3.SecuritySchemeObject
 ): parameter is OpenAPIV3.ReferenceObject {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    return (parameter as OpenAPIV3.ReferenceObject).$ref != null;
+    return (parameter as OpenAPIV3.ReferenceObject)?.$ref != null;
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Don't fail SDK generation if a single schema fails to parse. Instead, warn and coerce to unknown.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-09-03"
+  version: 0.70.1
+
+- changelogEntry:
     - summary: Auto generate examples for HTTP endpoint error responses.
       type: feat
   irVersion: 59


### PR DESCRIPTION
## Description
Don't fail SDK generation if a single schema fails to parse. Instead, warn and coerce to unknown.

## Changes Made
- See files changed

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
