### PR TITLE
fix(ci): Ignore tests to get php-sdk passing CI

### DIFF
--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -32,6 +32,8 @@ scripts:
       - composer test
 
 allowedFailures:
+  - alias-extends
+  - extends
   # Generating a union called "Exception" makes our references to Exception throws be escaped incorrectly
   - examples
   # Enums don't support the fromJson method yet.

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -118,6 +118,8 @@ allowedFailures:
   - pagination-custom
   # Dynamic snippets need to add support for global headers included in the client constructor.
   - auth-environment-variables
+  # TODO: Add support for bytes upload.
+  - bytes-upload
   # Basic auth is not supported yet.
   - basic-auth
   # Generating a union called "Exception" makes our references to Exception throws be escaped incorrectly


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6396/php-ignore-broken-seed-tests
Adding one more failing test to allowed failures to get CI passing for PHP
Added a few others, appears to have intermittent failures

## Changes Made
Adding to php-sdk's seed.yml

## Testing
Ran through CI and verified a passing check for php (in progress)
