### PR TITLE
fix(ci): Ignore failing tests for ruby-sdk (v1)

### DIFF
--- a/seed/ruby-sdk/seed.yml
+++ b/seed/ruby-sdk/seed.yml
@@ -53,9 +53,16 @@ fixtures:
 allowedFailures:
   - any-auth
   - circular-references
+  - enum
+  - errors
   - literal
+  - literals-unions
   - mixed-file-directory
+  - multiple-request-bodies
+  - nullable-optional
   - objects-with-imports
+  - websocket-bearer-auth
+  - websocket-inferred-auth
 features:
   requestOptions: true
   idempotency: false


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6398/ruby-ignore-broken-seed-tests-v1
Add failing tests to allowed failures in ruby-sdk seed.yml file

## Changes Made
Updating allowed failure lists for the mentioned seed file

## Testing
Verified locally and then pushed up to verify in CI

