### PR TITLE
fix(ci): Ignore failing tests for ruby-sdk (v2) 

### DIFF
--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -42,8 +42,8 @@ allowedFailures:
   - api-wide-base-path
   - audiences
   - auth-environment-variables
-  - basic-auth 
-  - basic-auth-environment
+  - basic-auth
+  - basic-auth-environment-variables
   - bearer-token-environment-variable
   - bytes-download
   - bytes-upload

--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -34,7 +34,94 @@ scripts:
       - bundle exec rake test
 
 fixtures: {}
-allowedFailures: []
+allowedFailures: 
+  - accept-header
+  - alias
+  - alias-extends
+  - any-auth
+  - api-wide-base-path
+  - audiences
+  - auth-environment-variables
+  - basic-auth 
+  - basic-auth-environment
+  - bearer-token-environment-variable
+  - bytes-download
+  - bytes-upload
+  - circular-references
+  - circular-references-advanced
+  - client-side-params
+  - content-type
+  - cross-package-type-names
+  - custom-auth
+  - empty-clients
+  - enum
+  - error-property
+  - errors
+  - examples
+  - exhaustive
+  - extends
+  - extra-properties
+  - file-download
+  - file-upload
+  - folders
+  - http-head
+  - idempotency-headers
+  - imdb
+  - inferred-auth-explicit
+  - inferred-auth-implicit
+  - inferred-auth-implicit-no-expiry
+  - license
+  - literal
+  - literals-unions
+  - mixed-case
+  - mixed-file-directory
+  - multi-line-docs
+  - multi-url-environment
+  - multi-url-environment-no-default
+  - multiple-request-bodies
+  - no-environment
+  - nullable
+  - nullable-optional
+  - oauth-client-credentials
+  - oauth-client-credentials-custom
+  - oauth-client-credentials-default
+  - oauth-client-credentials-environment-variables
+  - oauth-client-credentials-nested-root
+  - oauth-client-credentials-with-variables
+  - object
+  - objects-with-imports
+  - optional
+  - package-yml
+  - pagination
+  - pagination-custom
+  - path-parameters
+  - plain-text
+  - public-object
+  - query-parameters
+  - query-parameters-openapi
+  - query-parameters-openapi-as-objects
+  - request-parameters
+  - reserved-keywords
+  - response-property
+  - server-sent-event-examples
+  - server-sent-events
+  - simple-api
+  - simple-fhir
+  - single-url-environment-default
+  - single-url-environment-no-default
+  - streaming
+  - streaming-parameter
+  - trace
+  - undiscriminated-unions
+  - unions
+  - unknown
+  - validation
+  - variables
+  - version
+  - version-no-default
+  - websocket
+  - websocket-bearer-auth
+  - websocket-inferred-auth
 features:
   requestOptions: true
   idempotency: false


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6399/ruby-ignore-broken-seed-tests-v2
Add failing tests to allowed failures in ruby-sdk-v2 seed.yml file

## Changes Made
Updating allowed failure lists for the mentioned seed file (which right now is everything)

## Testing
Verified locally and then pushed up to verify in CI

