### PR TITLE
fix(ci): Ignore failing tests for python

### DIFF
--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -345,13 +345,10 @@ allowedFailures:
   - examples:client-filename
   - examples:legacy-wire-tests
   - exhaustive:additional_init_exports
-  - exhaustive:pydantic-v1-wrapped
+  - exhaustive:deps_with_min_python_version
   - exhaustive:pydantic-v1-with-utils
   - oauth-client-credentials-custom
   - pagination-custom
-  - public-object
   - response-property
-  - simple-fhir
   - streaming-parameter
   - trace
-  - websocket:websocket-with_generated_clients


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6400/python-ignore-broken-seed-tests
Add failing tests to allowed failures in python seed.yml file

## Changes Made
Updating allowed failure lists for the mentioned seed file

## Testing
Verified locally and then pushed up to verify in CI

