### PR TITLE
fix(ci): Ignore failing tests for C#

### DIFF
--- a/seed/csharp-sdk/seed.yml
+++ b/seed/csharp-sdk/seed.yml
@@ -179,18 +179,12 @@ fixtures:
         client-class-name: System
       outputFolder: system-client
 allowedFailures:
+  - errors
   - imdb:exported-client-class-name
   - oauth-client-credentials-custom
   - pagination:no-custom-config
   - pagination:custom-pager
   - pagination:custom-pager-with-exception-handler
-
-  # these tests are generating code with numbers that overflow the size of members they are meant
-  # to fill.
-  - exhaustive:explicit-namespaces
-  - exhaustive:no-root-namespace-for-core-classes
-  - exhaustive:no-generate-error-types
-  - exhaustive:include-exception-handler
 
   ## COMPILE FAILURES
   - any-auth
@@ -205,11 +199,4 @@ allowedFailures:
 
   ## Dynamic snippets
   - auth-environment-variables # TODO: Add global headers to ExampleEndpointCall.
-  - csharp-grpc-proto # TODO: Add support for ReadOnlyMemory types.
   - trace
-
-  # TODO: Add support for well-known types.
-  - csharp-grpc-proto-exhaustive:no-custom-config
-  - csharp-grpc-proto-exhaustive:package-id
-  - csharp-grpc-proto-exhaustive:read-only-memory
-  - csharp-grpc-proto-exhaustive:include-exception-handler


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6406/c-ignore-broken-seed-tests
Add failing tests to allowed failures in csharp-sdk seed.yml file

## Changes Made
Updating allowed failure lists for the mentioned seed file

## Testing
Verified locally and then pushed up to verify in CI
