### PR TITLE
fix(swift): restrict request headers to string values

### DIFF
--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/generators/swift/codegen/src/ast/Type.ts
+++ b/generators/swift/codegen/src/ast/Type.ts
@@ -435,6 +435,9 @@ export class Type extends AstNode {
     }
 
     public static optional(valueType: Type): Type {
+        if (valueType.internalType.type === "optional") {
+            return valueType;
+        }
         return new this({ type: "optional", valueType });
     }
 

--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -75,8 +75,8 @@ export class EndpointMethodGenerator {
                 swift.functionParameter({
                     argumentLabel: header.name.name.camelCase.unsafeName,
                     unsafeName: header.name.name.camelCase.unsafeName,
-                    type: swift.Type.optional(swift.Type.string()),
-                    defaultValue: swift.Expression.rawValue("nil"),
+                    type: swiftType,
+                    defaultValue: swiftType.isOptional ? swift.Expression.rawValue("nil") : undefined,
                     docsContent: header.docs
                 })
             );

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,12 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.12.2
+  createdAt: "2025-09-05"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Request headers in endpoint methods are now restricted to String types only.
+  irVersion: 59
+
 - version: 0.12.1
   createdAt: "2025-09-05"
   changelogEntry:
     - type: fix
       summary: |
         Required bearer token param in root client convenience initializer is now correctly marked as `@escaping` and the relevant argument is now initialized properly.
-
   irVersion: 59
 
 - version: 0.12.0

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/auth-environment-variables/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Resources/Service/ServiceClient.swift
@@ -23,7 +23,7 @@ public final class ServiceClient: Sendable {
     ///
     /// - Parameter xEndpointHeader: Specifies the endpoint key.
     /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
-    public func getWithHeader(xEndpointHeader: String, requestOptions: RequestOptions? = nil) async throws -> String {
+    public func getWithHeader(xEndpointHeader: String? = nil, requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .get,
             path: "/apiKeyInHeader",

--- a/seed/swift-sdk/auth-environment-variables/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Resources/Service/ServiceClient.swift
@@ -23,7 +23,7 @@ public final class ServiceClient: Sendable {
     ///
     /// - Parameter xEndpointHeader: Specifies the endpoint key.
     /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
-    public func getWithHeader(xEndpointHeader: String? = nil, requestOptions: RequestOptions? = nil) async throws -> String {
+    public func getWithHeader(xEndpointHeader: String, requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .get,
             path: "/apiKeyInHeader",

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/enum/Sources/Resources/Headers/HeadersClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/Headers/HeadersClient.swift
@@ -7,16 +7,10 @@ public final class HeadersClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(operand: Operand, maybeOperand: Operand? = nil, operandOrColor: ColorOrOperand, maybeOperandOrColor: ColorOrOperand? = nil, requestOptions: RequestOptions? = nil) async throws -> Void {
+    public func send(requestOptions: RequestOptions? = nil) async throws -> Void {
         return try await httpClient.performRequest(
             method: .post,
             path: "/headers",
-            headers: [
-                "operand": operand, 
-                "maybeOperand": maybeOperand, 
-                "operandOrColor": operandOrColor, 
-                "maybeOperandOrColor": maybeOperandOrColor
-            ],
             requestOptions: requestOptions
         )
     }

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/examples/Sources/Resources/Service/ServiceClient_.swift
+++ b/seed/swift-sdk/examples/Sources/Resources/Service/ServiceClient_.swift
@@ -26,7 +26,7 @@ public final class ServiceClient_: Sendable {
         )
     }
 
-    public func getMetadata(xApiVersion: String? = nil, shallow: Bool? = nil, tag: String? = nil, requestOptions: RequestOptions? = nil) async throws -> MetadataType {
+    public func getMetadata(xApiVersion: String, shallow: Bool? = nil, tag: String? = nil, requestOptions: RequestOptions? = nil) async throws -> MetadataType {
         return try await httpClient.performRequest(
             method: .get,
             path: "/metadata",

--- a/seed/swift-sdk/examples/Sources/Resources/Service/ServiceClient_.swift
+++ b/seed/swift-sdk/examples/Sources/Resources/Service/ServiceClient_.swift
@@ -26,7 +26,7 @@ public final class ServiceClient_: Sendable {
         )
     }
 
-    public func getMetadata(xApiVersion: String, shallow: Bool? = nil, tag: String? = nil, requestOptions: RequestOptions? = nil) async throws -> MetadataType {
+    public func getMetadata(xApiVersion: String? = nil, shallow: Bool? = nil, tag: String? = nil, requestOptions: RequestOptions? = nil) async throws -> MetadataType {
         return try await httpClient.performRequest(
             method: .get,
             path: "/metadata",

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/exhaustive/Sources/Resources/ReqWithHeaders/ReqWithHeadersClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/ReqWithHeaders/ReqWithHeadersClient.swift
@@ -7,7 +7,7 @@ public final class ReqWithHeadersClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getWithCustomHeader(xTestEndpointHeader: String, request: String, requestOptions: RequestOptions? = nil) async throws -> Void {
+    public func getWithCustomHeader(xTestEndpointHeader: String? = nil, request: String, requestOptions: RequestOptions? = nil) async throws -> Void {
         return try await httpClient.performRequest(
             method: .post,
             path: "/test-headers/custom-header",

--- a/seed/swift-sdk/exhaustive/Sources/Resources/ReqWithHeaders/ReqWithHeadersClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/ReqWithHeaders/ReqWithHeadersClient.swift
@@ -7,7 +7,7 @@ public final class ReqWithHeadersClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getWithCustomHeader(xTestEndpointHeader: String? = nil, request: String, requestOptions: RequestOptions? = nil) async throws -> Void {
+    public func getWithCustomHeader(xTestEndpointHeader: String, request: String, requestOptions: RequestOptions? = nil) async throws -> Void {
         return try await httpClient.performRequest(
             method: .post,
             path: "/test-headers/custom-header",

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/literal/Sources/Resources/Headers/HeadersClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Headers/HeadersClient.swift
@@ -7,14 +7,10 @@ public final class HeadersClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(endpointVersion: JSONValue, async: JSONValue, request: Requests.SendLiteralsInHeadersRequest, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
+    public func send(request: Requests.SendLiteralsInHeadersRequest, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/headers",
-            headers: [
-                "endpointVersion": endpointVersion, 
-                "async": async
-            ],
             body: request,
             requestOptions: requestOptions,
             responseType: SendResponse.self

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/trace/Sources/Resources/Migration/MigrationClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Migration/MigrationClient.swift
@@ -7,7 +7,7 @@ public final class MigrationClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getAttemptedMigrations(adminKeyHeader: String? = nil, requestOptions: RequestOptions? = nil) async throws -> [Migration] {
+    public func getAttemptedMigrations(adminKeyHeader: String, requestOptions: RequestOptions? = nil) async throws -> [Migration] {
         return try await httpClient.performRequest(
             method: .get,
             path: "/migration-info/all",

--- a/seed/swift-sdk/trace/Sources/Resources/Migration/MigrationClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Migration/MigrationClient.swift
@@ -7,7 +7,7 @@ public final class MigrationClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getAttemptedMigrations(adminKeyHeader: String, requestOptions: RequestOptions? = nil) async throws -> [Migration] {
+    public func getAttemptedMigrations(adminKeyHeader: String? = nil, requestOptions: RequestOptions? = nil) async throws -> [Migration] {
         return try await httpClient.performRequest(
             method: .get,
             path: "/migration-info/all",

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
@@ -14,7 +14,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil
@@ -36,7 +36,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String] = [:],
+        headers requestHeaders: [String: String?] = [:],
         queryParams requestQueryParams: [String: QueryParameter?] = [:],
         body requestBody: (any Encodable)? = nil,
         requestOptions: RequestOptions? = nil,
@@ -89,7 +89,7 @@ final class HTTPClient: Sendable {
         method: HTTP.Method,
         path: String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestQueryParams: [String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
@@ -162,7 +162,7 @@ final class HTTPClient: Sendable {
 
     private func buildRequestHeaders(
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String],
+        requestHeaders: [String: String?],
         requestOptions: RequestOptions? = nil
     ) async throws -> [String: String] {
         var headers = clientConfig.headers ?? [:]
@@ -177,7 +177,9 @@ final class HTTPClient: Sendable {
             headers["Authorization"] = "Bearer \(bearerAuthToken)"
         }
         for (key, value) in requestHeaders {
-            headers[key] = value
+            if let value = value {
+                headers[key] = value
+            }
         }
         for (key, value) in requestOptions?.additionalHeaders ?? [:] {
             headers[key] = value

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Auth/AuthClient.swift
@@ -7,7 +7,7 @@ public final class AuthClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getTokenWithClientCredentials(xApiKey: String? = nil, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func getTokenWithClientCredentials(xApiKey: String, request: Requests.GetTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token",
@@ -20,7 +20,7 @@ public final class AuthClient: Sendable {
         )
     }
 
-    public func refreshToken(xApiKey: String? = nil, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
+    public func refreshToken(xApiKey: String, request: Requests.RefreshTokenRequest, requestOptions: RequestOptions? = nil) async throws -> TokenResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/token/refresh",


### PR DESCRIPTION
## Description
Linear ticket: [FER-6327](https://linear.app/buildwithfern/issue/FER-6327/dont-pass-jsonvalue-instances-in-request-level-headers)

<!-- Provide a clear and concise description of the changes made in this PR -->
Ensures that generated endpoint methods only accept request headers that resolve to `String`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `EndpointMethodGenerator` to generate header parameters only for header value types that resolve to String
- Updated `HTTPClient` to accept optional `String?` values in request headers
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
