### PR TITLE
fix(ci): Make filtering for seed tests happen at job level to meet PR requirements

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -4,28 +4,10 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/seed.yml"
-      - "packages/seed/**"
-      - "packages/ir-sdk/fern/apis/**"
-      - "packages/cli/generation/ir-generator/**"
-      - "test-definitions/**"
-      - "test-definitions-openapi/**"
-      - "generators/**"
-      - "seed/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-    paths:
-      - ".github/workflows/seed.yml"
-      - "packages/seed/**"
-      - "packages/ir-sdk/fern/apis/**"
-      - "packages/cli/generation/ir-generator/**"
-      - "test-definitions/**"
-      - "test-definitions-openapi/**"
-      - "generators/**"
-      - "seed/**"
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6437/ci-always-have-seed-tests-run
We recently made a change in GitHub to require seed tests to be passing before any merge is allowed. Running the workflow and skipping individual tests on the PR will _pass_ this check. Skipping the workflow a level higher will _fail_ these checks. Updating the filtering for the Seed Snapshot Tests workflow so that filtering happens at the job level and not the workflow level. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Removed filtering at workflow level for Seed Snapshot Tests. Filtering will still occur at job level to prevent overuse of CI minutes

## Testing
- Pushed up and verified with CI
