### PR TITLE
fix(ci): Adding to allowed go-model failures

### DIFF
--- a/seed/go-model/seed.yml
+++ b/seed/go-model/seed.yml
@@ -54,5 +54,6 @@ allowedFailures:
   - exhaustive
   - literal
   - mixed-case
+  - nullable-optional
   - reserved-keywords
   - trace


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6439/fixci-add-to-go-model-allowed-failures
New, consistent failure popped up. Adding to allowed failures list

## Changes Made
Added to allowed failures list for go-model

## Testing
Saw issue on other PRs, pushing here and if CI passes then this can be considered a pass
