### PR TITLE
fix(ci): Adding pydantic-v2 path to update-seed workflows

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -66,6 +66,7 @@ jobs:
             python:
               - 'generators/python/**'
               - seed/pydantic/seed.yml
+              - seed/pydantic-v2/seed.yml
               - seed/python-sdk/seed.yml
               - seed/fastapi/seed.yml
             postman:


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6478/ci-add-pydantic-v2-path-to-update-seed-workflow
Ensure changes to the pydantic-v2 seed file regenerate seed files on main

## Changes Made
Add missing path to update-seed workflow

## Testing
Simple change, adding to filter and verified file exists
