### PR TITLE
feat(ci): Add swift-sdk to autogeneration of seed files

### DIFF
--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -1,0 +1,68 @@
+name: Auto Update Seed
+description: Run seed and then automatically create and merge PR with changes
+
+# Note: mostly matching inputs to cached-seed since this is a passthrough file
+# However, we don't need to validate git diff since we are always updating the seed
+inputs:
+  generator-name:
+    description: Generator to use (e.g., go-sdk, ruby-sdk)
+    required: true
+  generator-path:
+    description: The path to the source code of the generator (e.g., generators/go, generators/ruby)
+    required: true
+  language-name:
+    description: The name of the language (e.g., go, ruby)
+    required: true
+  skip-scripts:
+    description: Whether to skip running scripts during seed generation
+    required: false
+    default: "false"
+  allow-unexpected-failures:
+    description: Whether to allow unexpected failures during seed generation
+    required: false
+    default: "false"
+  cache-disabled:
+    description: "Whether to skip caching and always regenerate"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run seed
+      uses: ./.github/actions/cached-seed
+      with:
+        generator-name: ${{ inputs.generator-name }}
+        generator-path: ${{ inputs.generator-path }}
+        validate-git-diff: false
+        allow-unexpected-failures: ${{ inputs.allow-unexpected-failures }}
+        skip-scripts: ${{ inputs.skip-scripts }}
+        cache-disabled: ${{ inputs.cache-disabled }}
+
+    - name: Create Pull Request
+      id: cpr
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.FERN_GITHUB_PAT }}
+        commit-message: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
+        title: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
+        branch: update-${{ inputs.generator-name }}-seed
+        delete-branch: true
+        labels: |
+          seed
+          language/${{ inputs.language-name }}
+
+    - name: Enable Pull Request Automerge
+      if: steps.cpr.outputs.pull-request-operation == 'created'
+      uses: peter-evans/enable-pull-request-automerge@v3
+      with:
+        token: ${{ secrets.FERN_GITHUB_PAT }}
+        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+        merge-method: squash
+
+    - name: Approve PR
+      if: steps.cpr.outputs.pull-request-operation == 'created'
+      uses: ./.github/actions/auto-approve
+      with:
+        approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -59,6 +59,24 @@ runs:
           seed
           language/${{ inputs.language-name }}
 
+    - name: Log PR Creation Failure
+      if: steps.cpr.outputs.pull-request-operation != 'created'
+      env:
+        FORCE_COLOR: "2"
+      shell: bash
+      # Print in yellow and reset
+      run: |
+        echo -e "\033[33mPR was not created\033[0m"
+
+    - name: Log PR Details
+      if: steps.cpr.outputs.pull-request-operation == 'created'
+      env:
+        FORCE_COLOR: "2"
+      shell: bash
+      # Print in green and reset
+      run: |
+        echo -e "\033[32mPR Created: ${{ steps.cpr.outputs.pull-request-url }}\033[0m"
+
     - name: Enable Pull Request Automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'
       uses: peter-evans/enable-pull-request-automerge@v3

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -47,6 +47,7 @@ runs:
         commit-message: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         title: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         branch: update-${{ inputs.generator-name }}-seed
+        body: "Auto-generated PR, triggered by GitHub event: ${GITHUB_EVENT_NAME} from branch: ${GITHUB_REF_NAME}"
         delete-branch: true
         labels: |
           seed

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -53,7 +53,7 @@ runs:
         commit-message: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         title: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         branch: update-${{ inputs.generator-name }}-seed
-        body: "Auto-generated PR, triggered by GitHub event: ${GITHUB_EVENT_NAME} from branch: ${GITHUB_REF_NAME}"
+        body: "Auto-generated PR, triggered by GitHub event: ${{ github.event_name }} from branch: ${{ github.ref_name }}"
         delete-branch: true
         labels: |
           seed

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -53,7 +53,7 @@ runs:
         commit-message: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         title: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         branch: update-${{ inputs.generator-name }}-seed
-        body: "Auto-generated PR, triggered by GitHub event: ${{ github.event_name }} from branch: ${{ github.ref_name }}"
+        body: "Auto-generated PR, triggered by GitHub event: ${{ github.event_name }} from branch: ${{ github.ref_name }} with run ID: ${{ github.run_id }}"
         delete-branch: true
         labels: |
           seed
@@ -61,21 +61,15 @@ runs:
 
     - name: Log PR Creation Failure
       if: steps.cpr.outputs.pull-request-operation != 'created'
-      env:
-        FORCE_COLOR: "2"
       shell: bash
-      # Print in yellow and reset
       run: |
-        echo -e "\033[33mPR was not created\033[0m"
+        echo "PR was not created, likely due to no diff for the generated seed output"
 
-    - name: Log PR Details
+    - name: Log PR Creation Details
       if: steps.cpr.outputs.pull-request-operation == 'created'
-      env:
-        FORCE_COLOR: "2"
       shell: bash
-      # Print in green and reset
       run: |
-        echo -e "\033[32mPR Created: ${{ steps.cpr.outputs.pull-request-url }}\033[0m"
+        echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
 
     - name: Enable Pull Request Automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -25,6 +25,12 @@ inputs:
     description: "Whether to skip caching and always regenerate"
     required: false
     default: "true"
+  secret-fern-github-pat:
+    description: "GitHub Access Token for Fern"
+    required: true
+  secret-pr-bot-gh-pat:
+    description: "GitHub Access Token for PR Bot"
+    required: true
 
 runs:
   using: "composite"
@@ -43,7 +49,7 @@ runs:
       id: cpr
       uses: peter-evans/create-pull-request@v5
       with:
-        token: ${{ secrets.FERN_GITHUB_PAT }}
+        token: ${{ inputs.secret-fern-github-pat }}
         commit-message: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         title: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         branch: update-${{ inputs.generator-name }}-seed
@@ -57,7 +63,7 @@ runs:
       if: steps.cpr.outputs.pull-request-operation == 'created'
       uses: peter-evans/enable-pull-request-automerge@v3
       with:
-        token: ${{ secrets.FERN_GITHUB_PAT }}
+        token: ${{ inputs.secret-fern-github-pat }}
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
         merge-method: squash
 
@@ -65,5 +71,5 @@ runs:
       if: steps.cpr.outputs.pull-request-operation == 'created'
       uses: ./.github/actions/auto-approve
       with:
-        approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+        approver-gh-token: ${{ inputs.secret-pr-bot-gh-pat }}
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -52,6 +52,7 @@ jobs:
         name: Get generator changes
         id: get-generator-changes
         uses: ./.github/actions/get-generator-changes
+
   ruby-model:
     needs: changes
     if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
@@ -62,41 +63,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ruby-model
           generator-path: generators/ruby
-          validate-git-diff: false
+          language-name: ruby
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(ruby): update ruby-model seed"
-          title: "chore(ruby): update ruby-model seed"
-          branch: update-ruby-model-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/ruby
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   ruby-sdk:
     needs: changes
@@ -113,36 +86,8 @@ jobs:
         with:
           generator-name: ruby-sdk
           generator-path: generators/ruby
-          validate-git-diff: false
+          language-name: ruby
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(ruby): update ruby-sdk seed"
-          title: "chore(ruby): update ruby-sdk seed"
-          branch: update-ruby-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/ruby
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   ruby-sdk-v2:
     needs: changes
@@ -154,41 +99,14 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ruby-sdk-v2
           generator-path: generators/ruby-v2
-          validate-git-diff: false
+          language-name: ruby
           allow-unexpected-failures: true
 
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(ruby): update ruby-sdk-v2 seed"
-          title: "chore(ruby): update ruby-sdk-v2 seed"
-          branch: update-ruby-sdk-v2-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/ruby
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
   pydantic-model:
     needs: changes
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
@@ -199,41 +117,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: pydantic
           generator-path: generators/python
-          validate-git-diff: false
+          language-name: python
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(python): update pydantic seed"
-          title: "chore(python): update pydantic seed"
-          branch: update-pydantic-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/python
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   python-sdk:
     needs: changes
@@ -245,41 +135,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: python-sdk
           generator-path: generators/python
-          validate-git-diff: false
+          language-name: python
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(python): update python-sdk seed"
-          title: "chore(python): update python-sdk seed"
-          branch: update-python-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/python
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   fastapi:
     needs: changes
@@ -291,41 +153,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: fastapi
           generator-path: generators/python
-          validate-git-diff: false
+          language-name: python
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(python): update fastapi seed"
-          title: "chore(python): update fastapi seed"
-          branch: update-fastapi-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/python
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   openapi:
     needs: changes
@@ -337,41 +171,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: openapi
           generator-path: generators/openapi
-          validate-git-diff: false
+          language-name: openapi
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(openapi): update openapi seed"
-          title: "chore(openapi): update openapi seed"
-          branch: update-openapi-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/openapi
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   postman:
     needs: changes
@@ -383,41 +189,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: postman
           generator-path: generators/postman
-          validate-git-diff: false
+          language-name: postman
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(postman): update postman seed"
-          title: "chore(postman): update postman seed"
-          branch: update-postman-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/postman
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   java-sdk:
     needs: changes
@@ -429,41 +207,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-sdk
           generator-path: generators/java
-          validate-git-diff: false
+          language-name: java
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(java): update java-sdk seed"
-          title: "chore(java): update java-sdk seed"
-          branch: update-java-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/java
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   java-model:
     needs: changes
@@ -475,41 +225,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-model
           generator-path: generators/java
-          validate-git-diff: false
+          language-name: java
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(java): update java-model seed"
-          title: "chore(java): update java-model seed"
-          branch: update-java-model-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/java
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   java-spring:
     needs: changes
@@ -521,41 +243,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-spring
           generator-path: generators/java
-          validate-git-diff: false
+          language-name: java
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(java): update java-spring seed"
-          title: "chore(java): update java-spring seed"
-          branch: update-java-spring-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/java
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   typescript-sdk:
     needs: changes
@@ -567,41 +261,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ts-sdk
           generator-path: generators/typescript
-          validate-git-diff: false
+          language-name: typescript
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(typescript): update typescript-sdk seed"
-          title: "chore(typescript): update typescript-sdk seed"
-          branch: update-typescript-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/typescript
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   typescript-express:
     needs: changes
@@ -613,41 +279,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ts-express
           generator-path: generators/typescript
-          validate-git-diff: false
+          language-name: typescript
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(typescript): update typescript-express seed"
-          title: "chore(typescript): update typescript-express seed"
-          branch: update-typescript-express-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/typescript
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   go-fiber:
     needs: changes
@@ -664,36 +302,8 @@ jobs:
         with:
           generator-name: go-fiber
           generator-path: generators/go
-          validate-git-diff: false
+          language-name: go
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(go): update go-fiber seed"
-          title: "chore(go): update go-fiber seed"
-          branch: update-go-fiber-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/go
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   go-model:
     needs: changes
@@ -705,41 +315,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-model
           generator-path: generators/go
-          validate-git-diff: false
+          language-name: go
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(go): update go-model seed"
-          title: "chore(go): update go-model seed"
-          branch: update-go-model-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/go
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   go-sdk:
     needs: changes
@@ -750,42 +332,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-sdk
           generator-path: generators/go
-          validate-git-diff: false
+          language-name: go
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(go): update go-sdk seed"
-          title: "chore(go): update go-sdk seed"
-          branch: update-go-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/go
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   csharp-model:
     needs: changes
@@ -797,41 +350,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: csharp-model
           generator-path: generators/csharp
-          validate-git-diff: false
+          language-name: csharp
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(csharp): update csharp-model seed"
-          title: "chore(csharp): update csharp-model seed"
-          branch: update-csharp-model-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/csharp
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   csharp-sdk:
     needs: changes
@@ -843,41 +368,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: csharp-sdk
           generator-path: generators/csharp
-          validate-git-diff: false
+          language-name: csharp
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(csharp): update csharp-sdk seed"
-          title: "chore(csharp): update csharp-sdk seed"
-          branch: update-csharp-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/csharp
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   php-model:
     needs: changes
@@ -889,41 +386,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: php-model
           generator-path: generators/php
-          validate-git-diff: false
+          language-name: php
           allow-unexpected-failures: true
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(php): update php-model seed"
-          title: "chore(php): update php-model seed"
-          branch: update-php-model-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/php
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
   php-sdk:
     needs: changes
@@ -934,39 +403,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: php-sdk
           generator-path: generators/php
-          validate-git-diff: false
+          language-name: php
           allow-unexpected-failures: true
 
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
+  swift-sdk:
+    needs: changes
+    if: ${{ needs.changes.outputs.swift == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    runs-on: Seed
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
-          commit-message: "chore(php): update php-sdk seed"
-          title: "chore(php): update php-sdk seed"
-          branch: update-php-sdk-seed
-          delete-branch: true
-          labels: |
-            seed
-            language/php
 
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
-      - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: ./.github/actions/auto-approve
-        with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          generator-name: swift-sdk
+          generator-path: generators/swift
+          language-name: swift
+          allow-unexpected-failures: true

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -70,6 +70,8 @@ jobs:
           generator-path: generators/ruby
           language-name: ruby
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   ruby-sdk:
     needs: changes
@@ -88,6 +90,8 @@ jobs:
           generator-path: generators/ruby
           language-name: ruby
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   ruby-sdk-v2:
     needs: changes
@@ -106,6 +110,8 @@ jobs:
           generator-path: generators/ruby-v2
           language-name: ruby
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   pydantic-model:
     needs: changes
@@ -124,6 +130,8 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   python-sdk:
     needs: changes
@@ -142,6 +150,8 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   fastapi:
     needs: changes
@@ -160,6 +170,8 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   openapi:
     needs: changes
@@ -178,6 +190,8 @@ jobs:
           generator-path: generators/openapi
           language-name: openapi
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   postman:
     needs: changes
@@ -196,6 +210,8 @@ jobs:
           generator-path: generators/postman
           language-name: postman
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   java-sdk:
     needs: changes
@@ -214,6 +230,8 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   java-model:
     needs: changes
@@ -232,6 +250,8 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   java-spring:
     needs: changes
@@ -250,6 +270,8 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   typescript-sdk:
     needs: changes
@@ -268,6 +290,8 @@ jobs:
           generator-path: generators/typescript
           language-name: typescript
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   typescript-express:
     needs: changes
@@ -286,6 +310,8 @@ jobs:
           generator-path: generators/typescript
           language-name: typescript
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   go-fiber:
     needs: changes
@@ -304,6 +330,8 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   go-model:
     needs: changes
@@ -322,6 +350,8 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   go-sdk:
     needs: changes
@@ -339,6 +369,8 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   csharp-model:
     needs: changes
@@ -357,6 +389,8 @@ jobs:
           generator-path: generators/csharp
           language-name: csharp
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   csharp-sdk:
     needs: changes
@@ -375,6 +409,8 @@ jobs:
           generator-path: generators/csharp
           language-name: csharp
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   php-model:
     needs: changes
@@ -393,6 +429,8 @@ jobs:
           generator-path: generators/php
           language-name: php
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   php-sdk:
     needs: changes
@@ -410,6 +448,8 @@ jobs:
           generator-path: generators/php
           language-name: php
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   swift-sdk:
     needs: changes
@@ -428,3 +468,5 @@ jobs:
           generator-path: generators/swift
           language-name: swift
           allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6477/ci-add-swift-generator-to-update-seed-workflow
Ensure changes to the swift generator or seed folders regenerate seed files on main

## Changes Made
Add generator to update-seed workflow
Added the label `language/swift` for use in GitHub

## Testing
1. Made a replica branch and forced a change to swift seed to kick off this workflow. That run can be found here: https://github.com/fern-api/fern/actions/runs/17660964578/job/50194200971 where you can see at the bottom of the `Update Seed` step that a PR gets created and adds a link. 
2. That PR is here: https://github.com/fern-api/fern/pull/9355 with description linking it back to the event, branch and run ID it was created from
3. Merge to that test branch triggered another update seed run but that run results in the `Update Seed` step logging `PR was not created` which can be seen here: https://github.com/fern-api/fern/actions/runs/17661103580/job/50194577265
