### PR TITLE
fix(swift): distinguish between `date` and `datetime` field decoding

### DIFF
--- a/generators/swift/base/src/AsIs.ts
+++ b/generators/swift/base/src/AsIs.ts
@@ -60,6 +60,11 @@ const AsIsFileSpecs = {
     },
 
     // Core
+    CalendarDate: {
+        relativePathToDir: "Core",
+        filenameWithoutExtension: "CalendarDate",
+        symbolNames: ["CalendarDate"]
+    },
     StringPlusUrlEncoding: {
         relativePathToDir: "Core",
         filenameWithoutExtension: "String+URLEncoding"

--- a/generators/swift/base/src/asIs/CalendarDate.swift
+++ b/generators/swift/base/src/asIs/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/generators/swift/base/src/asIs/CalendarDate.swift
+++ b/generators/swift/base/src/asIs/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/generators/swift/base/src/asIs/QueryParameter.swift
+++ b/generators/swift/base/src/asIs/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
+++ b/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
@@ -185,7 +185,7 @@ export abstract class AbstractSwiftGeneratorContext<
                     float: () => swift.Type.float(),
                     double: () => swift.Type.double(),
                     bigInteger: () => swift.Type.string(), // TODO(kafkas): We may need to implement our own value type for this
-                    date: () => swift.Type.date(),
+                    date: () => swift.Type.calendarDate(),
                     dateTime: () => swift.Type.date(),
                     base64: () => swift.Type.string(),
                     uuid: () => swift.Type.uuid(),

--- a/generators/swift/codegen/src/ast/Expression.ts
+++ b/generators/swift/codegen/src/ast/Expression.ts
@@ -111,8 +111,8 @@ type DateLiteral = {
     isoString: string;
 };
 
-type DatetimeLiteral = {
-    type: "datetime-literal";
+type CalendarDateLiteral = {
+    type: "calendar-date-literal";
     isoString: string;
 };
 
@@ -165,7 +165,7 @@ type InternalExpression =
     | NumberLiteral
     | BoolLiteral
     | DateLiteral
-    | DatetimeLiteral
+    | CalendarDateLiteral
     | UUIDLiteral
     | DictionaryLiteral
     | ArrayLiteral
@@ -309,8 +309,8 @@ export class Expression extends AstNode {
             case "date-literal":
                 writer.write(`try! Date("${this.internalExpression.isoString}", strategy: .iso8601)`);
                 break;
-            case "datetime-literal":
-                writer.write(`try! Date("${this.internalExpression.isoString}", strategy: .iso8601)`);
+            case "calendar-date-literal":
+                writer.write(`try! CalendarDate("${this.internalExpression.isoString}")`);
                 break;
             case "uuid-literal":
                 writer.write(`UUID(uuidString: "${this.internalExpression.value}")`);
@@ -457,8 +457,8 @@ export class Expression extends AstNode {
         return new this({ type: "date-literal", isoString: isoStringWithoutFractionalSeconds });
     }
 
-    public static datetimeLiteral(isoString: string): Expression {
-        return new this({ type: "date-literal", isoString });
+    public static calendarDateLiteral(isoString: string): Expression {
+        return new this({ type: "calendar-date-literal", isoString });
     }
 
     public static uuidLiteral(value: string): Expression {

--- a/generators/swift/codegen/src/ast/Type.ts
+++ b/generators/swift/codegen/src/ast/Type.ts
@@ -104,6 +104,10 @@ type ExistentialAny = {
     protocolName: string;
 };
 
+type CalendarDate = {
+    type: "calendar-date";
+};
+
 /**
  * Represents our custom `JSONValue` type.
  */
@@ -120,6 +124,7 @@ type InternalType =
     | Optional
     | Custom
     | ExistentialAny
+    | CalendarDate
     | JsonValue;
 
 export class Type extends AstNode {
@@ -203,6 +208,8 @@ export class Type extends AstNode {
                     that.internalType.type === "existential-any" &&
                     this.internalType.protocolName === that.internalType.protocolName
                 );
+            case "calendar-date":
+                return that.internalType.type === "calendar-date";
             default:
                 assertNever(this.internalType);
         }
@@ -273,6 +280,8 @@ export class Type extends AstNode {
                 return camelCase(type.internalType.name);
             case "existential-any":
                 return `any${upperFirst(type.internalType.protocolName)}`;
+            case "calendar-date":
+                return "calendarDate";
             case "json-value":
                 return "json";
             default:
@@ -353,6 +362,9 @@ export class Type extends AstNode {
             case "existential-any":
                 writer.write("any ");
                 writer.write(this.internalType.protocolName);
+                break;
+            case "calendar-date":
+                writer.write("CalendarDate");
                 break;
             case "json-value":
                 writer.write("JSONValue");
@@ -451,6 +463,10 @@ export class Type extends AstNode {
 
     public static existentialAny(protocolName: string): Type {
         return new this({ type: "existential-any", protocolName });
+    }
+
+    public static calendarDate(): Type {
+        return new this({ type: "calendar-date" });
     }
 
     /**

--- a/generators/swift/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/swift/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -161,7 +161,7 @@ private func main() async throws {
         double: 1.1,
         bool: True,
         datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
         base64: "SGVsbG8gd29ybGQh",
         list: [

--- a/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -488,12 +488,7 @@ export class DynamicTypeLiteralMapper {
                 if (date == null) {
                     return swift.Expression.nop();
                 }
-                const timestampMs = new Date(date).getTime();
-                const timestampSec = Math.round(timestampMs / 1000);
-                const roundedDateTime = new Date(timestampSec * 1000).toISOString();
-                // Remove fractional seconds (.000Z -> Z) for Swift compatibility
-                const dateTimeWithoutFractional = roundedDateTime.replace(/\.\d{3}Z$/, "Z");
-                return swift.Expression.dateLiteral(dateTimeWithoutFractional);
+                return swift.Expression.calendarDateLiteral(date);
             }
             case "DATE_TIME": {
                 const dateTime = this.context.getValueAsString({ value });

--- a/generators/swift/sdk/src/generators/client/util/get-query-param-case-name.ts
+++ b/generators/swift/sdk/src/generators/client/util/get-query-param-case-name.ts
@@ -27,6 +27,8 @@ export function getQueryParamCaseName(swiftType: swift.Type): string {
             return "double";
         case "date":
             return "date";
+        case "calendar-date":
+            return "calendarDate";
         case "array":
             // TODO(kafkas): We are assuming string array for now.
             // Revise this to support more complex query param types.

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.12.3
+- version: 0.12.4
   createdAt: "2025-09-09"
   changelogEntry:
     - type: fix

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.12.4
+- version: 0.12.3
   createdAt: "2025-09-09"
   changelogEntry:
     - type: fix

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.12.4
+  createdAt: "2025-09-09"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed incorrect handling of schema `date` fields — now decoded into a new `CalendarDate` type.
+  irVersion: 59
+
 - version: 0.12.3
   createdAt: "2025-09-09"
   changelogEntry:

--- a/seed/swift-sdk/accept-header/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/accept-header/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/alias-extends/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/alias-extends/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/alias/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/alias/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/alias/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/alias/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/alias/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/any-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/any-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/audiences/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/audiences/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/basic-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/basic-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/bytes-upload/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/bytes-upload/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/content-type/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/content-type/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/custom-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/custom-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/enum/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/enum/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/enum/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/enum/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/enum/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/error-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/error-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/errors/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/errors/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/errors/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/errors/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/errors/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/examples/Snippets/Example19.swift
+++ b/seed/swift-sdk/examples/Snippets/Example19.swift
@@ -234,7 +234,7 @@ private func main() async throws {
         ),
         moment: Moment(
             id: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
-            date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+            date: try! CalendarDate("2023-01-15"),
             datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601)
         )
     ))

--- a/seed/swift-sdk/examples/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/examples/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/examples/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/examples/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/examples/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/examples/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/examples/Sources/Schemas/Moment.swift
+++ b/seed/swift-sdk/examples/Sources/Schemas/Moment.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public struct Moment: Codable, Hashable, Sendable {
     public let id: UUID
-    public let date: Date
+    public let date: CalendarDate
     public let datetime: Date
     /// Additional properties that are not explicitly defined in the schema
     public let additionalProperties: [String: JSONValue]
 
     public init(
         id: UUID,
-        date: Date,
+        date: CalendarDate,
         datetime: Date,
         additionalProperties: [String: JSONValue] = .init()
     ) {
@@ -22,7 +22,7 @@ public struct Moment: Codable, Hashable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(UUID.self, forKey: .id)
-        self.date = try container.decode(Date.self, forKey: .date)
+        self.date = try container.decode(CalendarDate.self, forKey: .date)
         self.datetime = try container.decode(Date.self, forKey: .datetime)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }

--- a/seed/swift-sdk/exhaustive/Snippets/Example13.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example13.swift
@@ -16,7 +16,7 @@ private func main() async throws {
             double: 1.1,
             bool: True,
             datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-            date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+            date: try! CalendarDate("2023-01-15"),
             uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
             base64: "SGVsbG8gd29ybGQh",
             list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example15.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example15.swift
@@ -14,7 +14,7 @@ private func main() async throws {
         double: 1.1,
         bool: True,
         datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
         base64: "SGVsbG8gd29ybGQh",
         list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example18.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example18.swift
@@ -16,7 +16,7 @@ private func main() async throws {
             double: 1.1,
             bool: True,
             datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-            date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+            date: try! CalendarDate("2023-01-15"),
             uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
             base64: "SGVsbG8gd29ybGQh",
             list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example19.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example19.swift
@@ -18,7 +18,7 @@ private func main() async throws {
                 double: 1.1,
                 bool: True,
                 datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-                date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+                date: try! CalendarDate("2023-01-15"),
                 uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
                 base64: "SGVsbG8gd29ybGQh",
                 list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example20.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example20.swift
@@ -17,7 +17,7 @@ private func main() async throws {
                 double: 1.1,
                 bool: True,
                 datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-                date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+                date: try! CalendarDate("2023-01-15"),
                 uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
                 base64: "SGVsbG8gd29ybGQh",
                 list: [
@@ -40,7 +40,7 @@ private func main() async throws {
                 double: 1.1,
                 bool: True,
                 datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-                date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+                date: try! CalendarDate("2023-01-15"),
                 uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
                 base64: "SGVsbG8gd29ybGQh",
                 list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example35.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example35.swift
@@ -7,7 +7,7 @@ private func main() async throws {
         token: "<token>"
     )
 
-    try await client.endpoints.primitive.getAndReturnDate(request: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601))
+    try await client.endpoints.primitive.getAndReturnDate(request: try! CalendarDate("2023-01-15"))
 }
 
 try await main()

--- a/seed/swift-sdk/exhaustive/Snippets/Example44.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example44.swift
@@ -17,7 +17,7 @@ private func main() async throws {
             double: 1.1,
             bool: True,
             datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-            date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+            date: try! CalendarDate("2023-01-15"),
             uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
             base64: "SGVsbG8gd29ybGQh",
             list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example45.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example45.swift
@@ -17,7 +17,7 @@ private func main() async throws {
             double: 1.1,
             bool: True,
             datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-            date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+            date: try! CalendarDate("2023-01-15"),
             uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
             base64: "SGVsbG8gd29ybGQh",
             list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example7.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example7.swift
@@ -14,7 +14,7 @@ private func main() async throws {
         double: 1.1,
         bool: True,
         datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
         base64: "SGVsbG8gd29ybGQh",
         list: [

--- a/seed/swift-sdk/exhaustive/Snippets/Example8.swift
+++ b/seed/swift-sdk/exhaustive/Snippets/Example8.swift
@@ -14,7 +14,7 @@ private func main() async throws {
         double: 1.1,
         bool: True,
         datetime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         uuid: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
         base64: "SGVsbG8gd29ybGQh",
         list: [

--- a/seed/swift-sdk/exhaustive/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/exhaustive/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Primitive/PrimitiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Primitive/PrimitiveClient.swift
@@ -67,13 +67,13 @@ public final class PrimitiveClient: Sendable {
         )
     }
 
-    public func getAndReturnDate(request: Date, requestOptions: RequestOptions? = nil) async throws -> Date {
+    public func getAndReturnDate(request: CalendarDate, requestOptions: RequestOptions? = nil) async throws -> CalendarDate {
         return try await httpClient.performRequest(
             method: .post,
             path: "/primitive/date",
             body: request,
             requestOptions: requestOptions,
-            responseType: Date.self
+            responseType: CalendarDate.self
         )
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Schemas/ObjectWithOptionalField.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Schemas/ObjectWithOptionalField.swift
@@ -8,7 +8,7 @@ public struct ObjectWithOptionalField: Codable, Hashable, Sendable {
     public let double: Double?
     public let bool: Bool?
     public let datetime: Date?
-    public let date: Date?
+    public let date: CalendarDate?
     public let uuid: UUID?
     public let base64: String?
     public let list: [String]?
@@ -25,7 +25,7 @@ public struct ObjectWithOptionalField: Codable, Hashable, Sendable {
         double: Double? = nil,
         bool: Bool? = nil,
         datetime: Date? = nil,
-        date: Date? = nil,
+        date: CalendarDate? = nil,
         uuid: UUID? = nil,
         base64: String? = nil,
         list: [String]? = nil,
@@ -58,7 +58,7 @@ public struct ObjectWithOptionalField: Codable, Hashable, Sendable {
         self.double = try container.decodeIfPresent(Double.self, forKey: .double)
         self.bool = try container.decodeIfPresent(Bool.self, forKey: .bool)
         self.datetime = try container.decodeIfPresent(Date.self, forKey: .datetime)
-        self.date = try container.decodeIfPresent(Date.self, forKey: .date)
+        self.date = try container.decodeIfPresent(CalendarDate.self, forKey: .date)
         self.uuid = try container.decodeIfPresent(UUID.self, forKey: .uuid)
         self.base64 = try container.decodeIfPresent(String.self, forKey: .base64)
         self.list = try container.decodeIfPresent([String].self, forKey: .list)

--- a/seed/swift-sdk/extends/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/extends/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/extends/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/extends/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/extends/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/extra-properties/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/extra-properties/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/file-download/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/file-download/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/file-upload/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/file-upload/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/folders/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/folders/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/folders/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/folders/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/folders/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/http-head/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/http-head/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/imdb/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/imdb/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/license/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/license/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/license/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/license/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/license/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/literal/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/literal/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/literal/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/literal/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/literal/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/mixed-case/Snippets/Example2.swift
+++ b/seed/swift-sdk/mixed-case/Snippets/Example2.swift
@@ -6,7 +6,7 @@ private func main() async throws {
 
     try await client.service.listResources(request: .init(
         pageLimit: 10,
-        beforeDate: try! Date("2023-01-01T00:00:00Z", strategy: .iso8601)
+        beforeDate: try! CalendarDate("2023-01-01")
     ))
 }
 

--- a/seed/swift-sdk/mixed-case/Snippets/Example3.swift
+++ b/seed/swift-sdk/mixed-case/Snippets/Example3.swift
@@ -6,7 +6,7 @@ private func main() async throws {
 
     try await client.service.listResources(request: .init(
         pageLimit: 1,
-        beforeDate: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601)
+        beforeDate: try! CalendarDate("2023-01-15")
     ))
 }
 

--- a/seed/swift-sdk/mixed-case/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/mixed-case/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/mixed-case/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Resources/Service/ServiceClient.swift
@@ -16,13 +16,13 @@ public final class ServiceClient: Sendable {
         )
     }
 
-    public func listResources(pageLimit: Int, beforeDate: Date, requestOptions: RequestOptions? = nil) async throws -> [Resource] {
+    public func listResources(pageLimit: Int, beforeDate: CalendarDate, requestOptions: RequestOptions? = nil) async throws -> [Resource] {
         return try await httpClient.performRequest(
             method: .get,
             path: "/resource",
             queryParams: [
                 "page_limit": .int(pageLimit), 
-                "beforeDate": .date(beforeDate)
+                "beforeDate": .calendarDate(beforeDate)
             ],
             requestOptions: requestOptions,
             responseType: [Resource].self

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/no-environment/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/no-environment/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/nullable-optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/nullable-optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/nullable/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/nullable/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/optional/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/optional/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/package-yml/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/package-yml/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/pagination-custom/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/pagination-custom/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/path-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/path-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/plain-text/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/plain-text/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/query-parameters/README.md
+++ b/seed/swift-sdk/query-parameters/README.md
@@ -38,7 +38,7 @@ private func main() async throws {
     try await client.user.getUsername(request: .init(
         limit: 1,
         id: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         deadline: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
         bytes: "SGVsbG8gd29ybGQh",
         user: User(

--- a/seed/swift-sdk/query-parameters/Snippets/Example0.swift
+++ b/seed/swift-sdk/query-parameters/Snippets/Example0.swift
@@ -7,7 +7,7 @@ private func main() async throws {
     try await client.user.getUsername(request: .init(
         limit: 1,
         id: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         deadline: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
         bytes: "SGVsbG8gd29ybGQh",
         user: User(

--- a/seed/swift-sdk/query-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/query-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/query-parameters/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Resources/User/UserClient.swift
@@ -7,14 +7,14 @@ public final class UserClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getUsername(limit: Int, id: UUID, date: Date, deadline: Date, bytes: String, user: User, userList: [User], optionalDeadline: Date? = nil, keyValue: [String: String], optionalString: String? = nil, nestedUser: NestedUser, optionalUser: User? = nil, excludeUser: User, filter: String, requestOptions: RequestOptions? = nil) async throws -> User {
+    public func getUsername(limit: Int, id: UUID, date: CalendarDate, deadline: Date, bytes: String, user: User, userList: [User], optionalDeadline: Date? = nil, keyValue: [String: String], optionalString: String? = nil, nestedUser: NestedUser, optionalUser: User? = nil, excludeUser: User, filter: String, requestOptions: RequestOptions? = nil) async throws -> User {
         return try await httpClient.performRequest(
             method: .get,
             path: "/user",
             queryParams: [
                 "limit": .int(limit), 
                 "id": .uuid(id), 
-                "date": .date(date), 
+                "date": .calendarDate(date), 
                 "deadline": .date(deadline), 
                 "bytes": .string(bytes), 
                 "user": .string(user.rawValue), 

--- a/seed/swift-sdk/request-parameters/Snippets/Example2.swift
+++ b/seed/swift-sdk/request-parameters/Snippets/Example2.swift
@@ -7,7 +7,7 @@ private func main() async throws {
     try await client.user.getUsername(request: .init(
         limit: 1,
         id: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
-        date: try! Date("2023-01-15T00:00:00Z", strategy: .iso8601),
+        date: try! CalendarDate("2023-01-15"),
         deadline: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
         bytes: "SGVsbG8gd29ybGQh",
         user: User(

--- a/seed/swift-sdk/request-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/request-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/request-parameters/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Resources/User/UserClient.swift
@@ -31,14 +31,14 @@ public final class UserClient: Sendable {
         )
     }
 
-    public func getUsername(limit: Int, id: UUID, date: Date, deadline: Date, bytes: String, user: User, userList: [User], optionalDeadline: Date? = nil, keyValue: [String: String], optionalString: String? = nil, nestedUser: NestedUser, optionalUser: User? = nil, excludeUser: User, filter: String, longParam: Int64, bigIntParam: String, requestOptions: RequestOptions? = nil) async throws -> User {
+    public func getUsername(limit: Int, id: UUID, date: CalendarDate, deadline: Date, bytes: String, user: User, userList: [User], optionalDeadline: Date? = nil, keyValue: [String: String], optionalString: String? = nil, nestedUser: NestedUser, optionalUser: User? = nil, excludeUser: User, filter: String, longParam: Int64, bigIntParam: String, requestOptions: RequestOptions? = nil) async throws -> User {
         return try await httpClient.performRequest(
             method: .get,
             path: "/user",
             queryParams: [
                 "limit": .int(limit), 
                 "id": .uuid(id), 
-                "date": .date(date), 
+                "date": .calendarDate(date), 
                 "deadline": .date(deadline), 
                 "bytes": .string(bytes), 
                 "user": .string(user.rawValue), 

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/response-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/response-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/server-sent-events/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/server-sent-events/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/simple-api/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/simple-api/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/simple-fhir/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/simple-fhir/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/streaming/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/streaming/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/trace/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/trace/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/trace/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/trace/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/trace/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/unions/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/unions/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/unions/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithOptionalTime.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithOptionalTime.swift
@@ -33,12 +33,12 @@ public enum UnionWithOptionalTime: Codable, Hashable, Sendable {
 
     public struct Date: Codable, Hashable, Sendable {
         public let type: String = "date"
-        public let value: Date?
+        public let value: CalendarDate?
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
-            value: Date? = nil,
+            value: CalendarDate? = nil,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.value = value
@@ -47,7 +47,7 @@ public enum UnionWithOptionalTime: Codable, Hashable, Sendable {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decodeIfPresent(Date.self, forKey: .value)
+            self.value = try container.decodeIfPresent(CalendarDate.self, forKey: .value)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithTime.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithTime.swift
@@ -72,12 +72,12 @@ public enum UnionWithTime: Codable, Hashable, Sendable {
 
     public struct Date: Codable, Hashable, Sendable {
         public let type: String = "date"
-        public let value: Date
+        public let value: CalendarDate
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
-            value: Date,
+            value: CalendarDate,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.value = value
@@ -86,7 +86,7 @@ public enum UnionWithTime: Codable, Hashable, Sendable {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(Date.self, forKey: .value)
+            self.value = try container.decode(CalendarDate.self, forKey: .value)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/unknown/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/unknown/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/validation/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/validation/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/validation/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/validation/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/validation/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/variables/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/variables/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/version-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/version-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/version/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/version/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/version/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/version/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/version/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/CalendarDate.swift
@@ -69,36 +69,21 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Private Helpers
 
-    /// Validates that the given year, month, and day form a valid calendar date.
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
     private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        guard year >= 1, year <= 9999,
-            month >= 1, month <= 12,
-            day >= 1
-        else {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
             return false
         }
 
-        let daysInMonth: [Int] = [
-            31,  // January
-            isLeapYear(year) ? 29 : 28,  // February
-            31,  // March
-            30,  // April
-            31,  // May
-            30,  // June
-            31,  // July
-            31,  // August
-            30,  // September
-            31,  // October
-            30,  // November
-            31,  // December
-        ]
-
-        return day <= daysInMonth[month - 1]
-    }
-
-    /// Determines if the given year is a leap year
-    private static func isLeapYear(_ year: Int) -> Bool {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
     }
 
     // MARK: - Error Types

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/CalendarDate.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        guard year >= 1, year <= 9999,
+            month >= 1, month <= 12,
+            day >= 1
+        else {
+            return false
+        }
+
+        let daysInMonth: [Int] = [
+            31,  // January
+            isLeapYear(year) ? 29 : 28,  // February
+            31,  // March
+            30,  // April
+            31,  // May
+            30,  // June
+            31,  // July
+            31,  // August
+            30,  // September
+            31,  // October
+            30,  // November
+            31,  // December
+        ]
+
+        return day <= daysInMonth[month - 1]
+    }
+
+    /// Determines if the given year is a leap year
+    private static func isLeapYear(_ year: Int) -> Bool {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):


### PR DESCRIPTION
## Description
Linear ticket: [FER-6387](https://linear.app/buildwithfern/issue/FER-6387/decode-date-and-datetime-values-differently)

<!-- Provide a clear and concise description of the changes made in this PR -->
Implements distinct handling of `date` vs `datetime` fields in the Swift SDK. `date` values are now decoded into a new `CalendarDate` type (RFC 3339 `YYYY-MM-DD`), while `datetime` continues to map to Foundation's `Date`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Implements `CalendarDate` "as is" type with RFC 3339 compliant `YYYY-MM-DD` format
- Updated `QueryParameter` "as is" type to handle `CalendarDate`
- Implemented generator changes to map `date` to `CalendarDate` and `datetime` to `Date`
- Updated dynamic snippets code/tests to use the new calendar date type
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
