### PR TITLE
fix(swift): add required system deps to Dockerfile

### DIFF
--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:22.12-alpine3.20 AS node
 
 RUN apk --no-cache add bash curl git zip
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 COPY generators/swift/sdk/features.yml /assets/features.yml
 COPY generators/swift/sdk/dist /dist

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22.12-alpine3.20 AS node
 
+RUN apk --no-cache add bash curl git zip
+
 COPY generators/swift/sdk/features.yml /assets/features.yml
 COPY generators/swift/sdk/dist /dist
 

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.12.4
+  createdAt: "2025-09-09"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Added missing system dependencies (bash, curl, git, zip) to Swift generator Docker image to fix README generation.
+  irVersion: 59
+
 - version: 0.12.2
   createdAt: "2025-09-05"
   changelogEntry:

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.12.4
+- version: 0.12.3
   createdAt: "2025-09-09"
   changelogEntry:
     - type: fix


### PR DESCRIPTION
## Description
Linear ticket: [FER-6480](https://linear.app/buildwithfern/issue/FER-6480/chrt-readme-gen-failing-in-ci)

<!-- Provide a clear and concise description of the changes made in this PR -->
Adds `bash`, `curl`, `git`, and `zip` to the Swift generator Docker container. This mirrors the setup of the C# generator and resolves CI errors in README generation caused by missing `git`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated Swift SDK generator Dockerfile to install new packages

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
