### PR TITLE
feat(typescript): try retry-after and x-ratelimit-reset before exponential backoff

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.10.3
+  changelogEntry:
+    - summary: Retries now check `Retry-After` and `X-RateLimit-Reset` before defaulting to exponential backoff.
+      type: feat
+  createdAt: "2025-09-09"
+  irVersion: 59
+
 - version: 2.10.2
   changelogEntry:
     - summary: Allow `null` values in headers in addition to `undefined` to explicitly unset a header.

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for retry-after header first (RFC 7231)
+    const retryAfter = response.headers.get("retry-after");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard x-ratelimit-reset header
+    const rateLimitReset = response.headers.get("x-ratelimit-reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
@@ -10,8 +10,8 @@ function addJitter(delay: number): number {
 }
 
 function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
-    // Check for retry-after header first (RFC 7231)
-    const retryAfter = response.headers.get("retry-after");
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
     if (retryAfter) {
         // Parse as number of seconds...
         const retryAfterSeconds = parseInt(retryAfter, 10);
@@ -28,8 +28,8 @@ function getRetryDelayFromHeaders(response: Response, retryAttempt: number): num
         }
     }
 
-    // Then check for industry-standard x-ratelimit-reset header
-    const rateLimitReset = response.headers.get("x-ratelimit-reset");
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
     if (rateLimitReset) {
         const resetTime = parseInt(rateLimitReset, 10);
         if (!isNaN(resetTime)) {

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,4 +1,4 @@
-import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import { requestWithRetries } from "../../../../../src/management/core/fetcher/requestWithRetries.js";
 
 describe("requestWithRetries", () => {
     let mockFetch: jest.Mock;
@@ -128,5 +128,108 @@ describe("requestWithRetries", () => {
 
         expect(response1.status).toBe(200);
         expect(response2.status).toBe(200);
+    });
+
+    it("should respect retry-after header with seconds value", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "retry-after": "5" })
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000); // 5 seconds = 5000ms
+        expect(response.status).toBe(200);
+    });
+
+    it("should respect retry-after header with HTTP date value", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        const futureDate = new Date(Date.now() + 3000); // 3 seconds from now
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "retry-after": futureDate.toUTCString() })
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        // Should use the date-based delay (approximately 3000ms, but with jitter)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+        const actualDelay = setTimeoutSpy.mock.calls[0][1];
+        expect(actualDelay).toBeGreaterThan(2000);
+        expect(actualDelay).toBeLessThan(4000);
+        expect(response.status).toBe(200);
+    });
+
+    it("should respect x-ratelimit-reset header", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        const resetTime = Math.floor((Date.now() + 4000) / 1000); // 4 seconds from now in Unix timestamp
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "x-ratelimit-reset": resetTime.toString() })
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+        const actualDelay = setTimeoutSpy.mock.calls[0][1];
+        expect(actualDelay).toBeGreaterThan(3000);
+        expect(actualDelay).toBeLessThan(5000);
+        expect(response.status).toBe(200);
+    });
+
+    it("should cap delay at MAX_RETRY_DELAY for large header values", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "retry-after": "120" }) // 120 seconds = 120000ms > MAX_RETRY_DELAY (60000ms)
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        // Should be capped at MAX_RETRY_DELAY (60000ms) with jitter applied
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000); // Exactly MAX_RETRY_DELAY since jitter with 0.5 random keeps it at 60000
+        expect(response.status).toBe(200);
     });
 });

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,4 +1,4 @@
-import { requestWithRetries } from "../../../../../src/management/core/fetcher/requestWithRetries.js";
+import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
     let mockFetch: jest.Mock;

--- a/seed/ts-sdk/accept-header/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/alias/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/any-auth/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/any-auth/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/auth-environment-variables/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/wire/basicAuth.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/wire/basicAuth.test.ts
@@ -22,7 +22,7 @@ describe("BasicAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("getWithBasicAuth (135b91bb)", async () => {
+    test("getWithBasicAuth (93582a4e)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedBasicAuthEnvironmentVariablesClient({
             username: "test",
@@ -66,7 +66,7 @@ describe("BasicAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithBasicAuth (8264039e)", async () => {
+    test("postWithBasicAuth (97a6b3dd)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedBasicAuthEnvironmentVariablesClient({
             username: "test",

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/basic-auth/tests/wire/basicAuth.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/wire/basicAuth.test.ts
@@ -18,7 +18,7 @@ describe("BasicAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("getWithBasicAuth (135b91bb)", async () => {
+    test("getWithBasicAuth (93582a4e)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedBasicAuthClient({ username: "test", password: "test", environment: server.baseUrl });
 
@@ -54,7 +54,7 @@ describe("BasicAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithBasicAuth (8264039e)", async () => {
+    test("postWithBasicAuth (97a6b3dd)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedBasicAuthClient({ username: "test", password: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/circular-references/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/client-side-params/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/client-side-params/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/content-type/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/cross-package-type-names/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/custom-auth/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/custom-auth/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/custom-auth/tests/wire/customAuth.test.ts
+++ b/seed/ts-sdk/custom-auth/tests/wire/customAuth.test.ts
@@ -18,7 +18,7 @@ describe("CustomAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("getWithCustomAuth (135b91bb)", async () => {
+    test("getWithCustomAuth (93582a4e)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedCustomAuthClient({ customAuthScheme: "test", environment: server.baseUrl });
 
@@ -54,7 +54,7 @@ describe("CustomAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithCustomAuth (8264039e)", async () => {
+    test("postWithCustomAuth (97a6b3dd)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedCustomAuthClient({ customAuthScheme: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/empty-clients/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/empty-clients/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/enum/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/enum/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/error-property/union-utils/tests/wire/propertyBasedError.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/wire/propertyBasedError.test.ts
@@ -24,7 +24,7 @@ describe("PropertyBasedError", () => {
         expect(response).toEqual("string");
     });
 
-    test("ThrowError (3382c84f)", async () => {
+    test("ThrowError (8baa99fe)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorPropertyClient({ environment: server.baseUrl });
 

--- a/seed/ts-sdk/errors/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/errors/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/errors/tests/wire/simple.test.ts
+++ b/seed/ts-sdk/errors/tests/wire/simple.test.ts
@@ -7,7 +7,7 @@ import { SeedErrorsClient } from "../../src/Client";
 import * as SeedErrors from "../../src/api/index";
 
 describe("Simple", () => {
-    test("fooWithoutEndpointError (38e631f7)", async () => {
+    test("fooWithoutEndpointError (2410f9ff)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -29,7 +29,7 @@ describe("Simple", () => {
         });
     });
 
-    test("fooWithoutEndpointError (894c9afe)", async () => {
+    test("fooWithoutEndpointError (91e10777)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -55,7 +55,7 @@ describe("Simple", () => {
         );
     });
 
-    test("fooWithoutEndpointError (22cbdac)", async () => {
+    test("fooWithoutEndpointError (fb1f6bc1)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -81,7 +81,7 @@ describe("Simple", () => {
         );
     });
 
-    test("fooWithoutEndpointError (f542a668)", async () => {
+    test("fooWithoutEndpointError (d5eb8f1d)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -107,7 +107,7 @@ describe("Simple", () => {
         );
     });
 
-    test("foo (38e631f7)", async () => {
+    test("foo (2410f9ff)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -129,7 +129,7 @@ describe("Simple", () => {
         });
     });
 
-    test("foo (c3630df8)", async () => {
+    test("foo (b3c4361f)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -155,7 +155,7 @@ describe("Simple", () => {
         );
     });
 
-    test("foo (34253fa0)", async () => {
+    test("foo (85e7d2ef)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -181,7 +181,7 @@ describe("Simple", () => {
         );
     });
 
-    test("foo (894c9afe)", async () => {
+    test("foo (91e10777)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -207,7 +207,7 @@ describe("Simple", () => {
         );
     });
 
-    test("foo (22cbdac)", async () => {
+    test("foo (fb1f6bc1)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };
@@ -233,7 +233,7 @@ describe("Simple", () => {
         );
     });
 
-    test("foo (f542a668)", async () => {
+    test("foo (d5eb8f1d)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedErrorsClient({ environment: server.baseUrl });
         const rawRequestBody = { bar: "bar" };

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/jsr/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/jsr/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/requestWithRetries.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/requestWithRetries.js
@@ -19,13 +19,45 @@ function addJitter(delay) {
     const jitterMultiplier = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
     return delay * jitterMultiplier;
 }
+function getRetryDelayFromHeaders(response, retryAttempt) {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
 function requestWithRetries(requestFn_1) {
     return __awaiter(this, arguments, void 0, function* (requestFn, maxRetries = DEFAULT_MAX_RETRIES) {
         let response = yield requestFn();
         for (let i = 0; i < maxRetries; ++i) {
             if ([408, 429].includes(response.status) || response.status >= 500) {
-                // Calculate base delay using exponential backoff (in milliseconds)
-                const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+                // Get delay from headers or fall back to exponential backoff
+                const baseDelay = getRetryDelayFromHeaders(response, i);
                 // Add jitter to the delay
                 const delayWithJitter = addJitter(baseDelay);
                 yield new Promise((resolve) => setTimeout(resolve, delayWithJitter));

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/requestWithRetries.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/requestWithRetries.mjs
@@ -16,13 +16,45 @@ function addJitter(delay) {
     const jitterMultiplier = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
     return delay * jitterMultiplier;
 }
+function getRetryDelayFromHeaders(response, retryAttempt) {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
 export function requestWithRetries(requestFn_1) {
     return __awaiter(this, arguments, void 0, function* (requestFn, maxRetries = DEFAULT_MAX_RETRIES) {
         let response = yield requestFn();
         for (let i = 0; i < maxRetries; ++i) {
             if ([408, 429].includes(response.status) || response.status >= 500) {
-                // Calculate base delay using exponential backoff (in milliseconds)
-                const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+                // Get delay from headers or fall back to exponential backoff
+                const baseDelay = getRetryDelayFromHeaders(response, i);
                 // Add jitter to the delay
                 const delayWithJitter = addJitter(baseDelay);
                 yield new Promise((resolve) => setTimeout(resolve, delayWithJitter));

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../Client.js";
 import * as SeedExhaustive from "../../api/index.js";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/use-pnpm/pnpm-lock.yaml
+++ b/seed/ts-sdk/exhaustive/use-pnpm/pnpm-lock.yaml
@@ -1259,10 +1259,10 @@ packages:
             }
         engines: { node: ">= 0.4" }
 
-    electron-to-chromium@1.5.214:
+    electron-to-chromium@1.5.215:
         resolution:
             {
-                integrity: sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==,
+                integrity: sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==,
             }
 
     emittery@0.13.1:
@@ -3797,7 +3797,7 @@ snapshots:
     browserslist@4.25.4:
         dependencies:
             caniuse-lite: 1.0.30001741
-            electron-to-chromium: 1.5.214
+            electron-to-chromium: 1.5.215
             node-releases: 2.0.20
             update-browserslist-db: 1.1.3(browserslist@4.25.4)
 
@@ -3928,7 +3928,7 @@ snapshots:
             es-errors: 1.3.0
             gopd: 1.2.0
 
-    electron-to-chromium@1.5.214: {}
+    electron-to-chromium@1.5.215: {}
 
     emittery@0.13.1: {}
 

--- a/seed/ts-sdk/exhaustive/use-pnpm/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/use-pnpm/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/use-pnpm/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/use-pnpm/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/use-pnpm/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/use-pnpm/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/inlinedRequests.test.ts
@@ -7,7 +7,7 @@ import { SeedExhaustiveClient } from "../../src/Client";
 import * as SeedExhaustive from "../../src/api/index";
 
 describe("InlinedRequests", () => {
-    test("postWithObjectBodyandResponse (5a1d0f30)", async () => {
+    test("postWithObjectBodyandResponse (36a333c6)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {
@@ -93,7 +93,7 @@ describe("InlinedRequests", () => {
         });
     });
 
-    test("postWithObjectBodyandResponse (c70fbba8)", async () => {
+    test("postWithObjectBodyandResponse (7586df6c)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/noAuth.test.ts
@@ -27,7 +27,7 @@ describe("NoAuth", () => {
         expect(response).toEqual(true);
     });
 
-    test("postWithNoAuth (4ca6cb0d)", async () => {
+    test("postWithNoAuth (7faa8b08)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedExhaustiveClient({ token: "test", environment: server.baseUrl });
         const rawRequestBody = { key: "value" };

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/extends/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-download/stream/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-download/stream/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-download/wrapper/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-download/wrapper/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/folders/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/http-head/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/wire/imdb.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/wire/imdb.test.ts
@@ -28,7 +28,7 @@ describe("Imdb", () => {
         expect(response).toEqual(SeedApi.MovieId("string"));
     });
 
-    test("getMovie (76cc5edf)", async () => {
+    test("getMovie (cedc5a8a)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedApiClient({ token: "test", environment: server.baseUrl });
 

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/imdb/no-custom-config/tests/wire/imdb.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/wire/imdb.test.ts
@@ -28,7 +28,7 @@ describe("Imdb", () => {
         expect(response).toEqual("string");
     });
 
-    test("getMovie (76cc5edf)", async () => {
+    test("getMovie (cedc5a8a)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedApiClient({ token: "test", environment: server.baseUrl });
 

--- a/seed/ts-sdk/imdb/noScripts/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/requestWithRetries.test.ts
@@ -129,4 +129,107 @@ describe("requestWithRetries", () => {
         expect(response1.status).toBe(200);
         expect(response2.status).toBe(200);
     });
+
+    it("should respect retry-after header with seconds value", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "retry-after": "5" })
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000); // 5 seconds = 5000ms
+        expect(response.status).toBe(200);
+    });
+
+    it("should respect retry-after header with HTTP date value", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        const futureDate = new Date(Date.now() + 3000); // 3 seconds from now
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "retry-after": futureDate.toUTCString() })
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        // Should use the date-based delay (approximately 3000ms, but with jitter)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+        const actualDelay = setTimeoutSpy.mock.calls[0][1];
+        expect(actualDelay).toBeGreaterThan(2000);
+        expect(actualDelay).toBeLessThan(4000);
+        expect(response.status).toBe(200);
+    });
+
+    it("should respect x-ratelimit-reset header", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        const resetTime = Math.floor((Date.now() + 4000) / 1000); // 4 seconds from now in Unix timestamp
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "x-ratelimit-reset": resetTime.toString() })
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+        const actualDelay = setTimeoutSpy.mock.calls[0][1];
+        expect(actualDelay).toBeGreaterThan(3000);
+        expect(actualDelay).toBeLessThan(5000);
+        expect(response.status).toBe(200);
+    });
+
+    it("should cap delay at MAX_RETRY_DELAY for large header values", async () => {
+        setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((callback: (args: void) => void) => {
+            process.nextTick(callback);
+            return null as any;
+        });
+
+        mockFetch
+            .mockResolvedValueOnce(
+                new Response("", {
+                    status: 429,
+                    headers: new Headers({ "retry-after": "120" }) // 120 seconds = 120000ms > MAX_RETRY_DELAY (60000ms)
+                })
+            )
+            .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+        const responsePromise = requestWithRetries(() => mockFetch(), 1);
+        await jest.runAllTimersAsync();
+        const response = await responsePromise;
+
+        // Should be capped at MAX_RETRY_DELAY (60000ms) with jitter applied
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000); // Exactly MAX_RETRY_DELAY since jitter with 0.5 random keeps it at 60000
+        expect(response.status).toBe(200);
+    });
 });

--- a/seed/ts-sdk/imdb/noScripts/tests/wire/imdb.test.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/wire/imdb.test.ts
@@ -31,7 +31,7 @@ describe("Imdb", () => {
                 
     });
           
-    test("getMovie (76cc5edf)", async () => {
+    test("getMovie (cedc5a8a)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedApiClient({ "token" : "test" , "environment" : server.baseUrl });
         

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/imdb/omit-undefined/tests/wire/imdb.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/wire/imdb.test.ts
@@ -28,7 +28,7 @@ describe("Imdb", () => {
         expect(response).toEqual("string");
     });
 
-    test("getMovie (76cc5edf)", async () => {
+    test("getMovie (cedc5a8a)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedApiClient({ token: "test", environment: server.baseUrl });
 

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/license/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/literal/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/literals-unions/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/literals-unions/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/no-environment/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/nullable-optional/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/nullable/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/object/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/optional/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/package-yml/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/pagination/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/pagination/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/path-parameters/default/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/path-parameters/default/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/plain-text/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/public-object/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/query-parameters-openapi/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/query-parameters-openapi/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/response-property/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/simple-api/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/simple-api/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/trace/no-custom-config/tests/wire/playlist.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/wire/playlist.test.ts
@@ -75,7 +75,7 @@ describe("Playlist", () => {
         ]);
     });
 
-    test("getPlaylist (11bcd5f5)", async () => {
+    test("getPlaylist (c5db3399)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedTraceClient({ token: "test", xRandomHeader: "test", environment: server.baseUrl });
 
@@ -136,7 +136,7 @@ describe("Playlist", () => {
         }).rejects.toThrow(new SeedTrace.UnauthorizedError());
     });
 
-    test("updatePlaylist (44610b90)", async () => {
+    test("updatePlaylist (56f82548)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedTraceClient({ token: "test", xRandomHeader: "test", environment: server.baseUrl });
         const rawRequestBody = { name: "name", problems: ["problems", "problems"] };
@@ -167,7 +167,7 @@ describe("Playlist", () => {
         });
     });
 
-    test("updatePlaylist (7681d277)", async () => {
+    test("updatePlaylist (368df093)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedTraceClient({ token: "test", xRandomHeader: "test", environment: server.baseUrl });
         const rawRequestBody = { name: "name", problems: ["problems", "problems"] };

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/trace/serde-trace/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/trace/serde-trace/tests/wire/playlist.test.ts
+++ b/seed/ts-sdk/trace/serde-trace/tests/wire/playlist.test.ts
@@ -75,7 +75,7 @@ describe("Playlist", () => {
         ]);
     });
 
-    test("getPlaylist (11bcd5f5)", async () => {
+    test("getPlaylist (c5db3399)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedTraceClient({ token: "test", xRandomHeader: "test", environment: server.baseUrl });
 
@@ -136,7 +136,7 @@ describe("Playlist", () => {
         }).rejects.toThrow(new SeedTrace.UnauthorizedError());
     });
 
-    test("updatePlaylist (44610b90)", async () => {
+    test("updatePlaylist (56f82548)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedTraceClient({ token: "test", xRandomHeader: "test", environment: server.baseUrl });
         const rawRequestBody = { name: "name", problems: ["problems", "problems"] };
@@ -167,7 +167,7 @@ describe("Playlist", () => {
         });
     });
 
-    test("updatePlaylist (7681d277)", async () => {
+    test("updatePlaylist (368df093)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedTraceClient({ token: "test", xRandomHeader: "test", environment: server.baseUrl });
         const rawRequestBody = { name: "name", problems: ["problems", "problems"] };

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/ts-express-casing/tests/wire/imdb.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/wire/imdb.test.ts
@@ -29,7 +29,7 @@ describe("Imdb", () => {
         expect(response).toEqual("string");
     });
 
-    test("get_movie (32ec616d)", async () => {
+    test("get_movie (b5fb3500)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedApiClient({ token: "test", environment: server.baseUrl });
 

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/unions/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/unions/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/validation/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/variables/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/version/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/requestWithRetries.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/requestWithRetries.ts
@@ -9,6 +9,42 @@ function addJitter(delay: number): number {
     return delay * jitterMultiplier;
 }
 
+function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
+    // Check for Retry-After header first (RFC 7231)
+    const retryAfter = response.headers.get("Retry-After");
+    if (retryAfter) {
+        // Parse as number of seconds...
+        const retryAfterSeconds = parseInt(retryAfter, 10);
+        if (!isNaN(retryAfterSeconds)) {
+            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+            return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
+        }
+
+        // ...or as an HTTP date; both are valid
+        const retryAfterDate = new Date(retryAfter);
+        if (!isNaN(retryAfterDate.getTime())) {
+            const delay = retryAfterDate.getTime() - Date.now();
+            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+        }
+    }
+
+    // Then check for industry-standard X-RateLimit-Reset header
+    const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+    if (rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10);
+        if (!isNaN(resetTime)) {
+            // Assume Unix timestamp in epoch seconds
+            const delay = resetTime * 1000 - Date.now();
+            if (delay > 0) {
+                return Math.min(delay, MAX_RETRY_DELAY);
+            }
+        }
+    }
+
+    // Fall back to exponential backoff
+    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+}
+
 export async function requestWithRetries(
     requestFn: () => Promise<Response>,
     maxRetries: number = DEFAULT_MAX_RETRIES,
@@ -17,8 +53,8 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Calculate base delay using exponential backoff (in milliseconds)
-            const baseDelay = Math.min(INITIAL_RETRY_DELAY * Math.pow(2, i), MAX_RETRY_DELAY);
+            // Get delay from headers or fall back to exponential backoff
+            const baseDelay = getRetryDelayFromHeaders(response, i);
 
             // Add jitter to the delay
             const delayWithJitter = addJitter(baseDelay);


### PR DESCRIPTION
## Description
Linear ticket:
https://linear.app/buildwithfern/issue/FER-6416/auth0-use-ready-after-etc-instead-of-starting-with-exponential-backoff

Retries for requests now try to use the value in `retry-after` (RFC 7231) or otherwise in `x-ratelimit-reset` (standard practice) before defaulting to exponential backoff.

## Changes Made
Changes to as-is utilities in the TypeScript generator.

## Testing
Four new tests to `requestWithRetries.test.ts`.
- [X] Unit tests added/updated
