### PR TITLE
feat(java)!: enable forward-compatible enums by default

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
@@ -32,7 +32,7 @@ public interface ICustomConfig {
     @Value.Default
     @JsonProperty("enable-forward-compatible-enums")
     default Boolean enableForwardCompatibleEnum() {
-        return true;
+        return false;
     }
 
     @Value.Default

--- a/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
@@ -32,7 +32,7 @@ public interface ICustomConfig {
     @Value.Default
     @JsonProperty("enable-forward-compatible-enums")
     default Boolean enableForwardCompatibleEnum() {
-        return false;
+        return true;
     }
 
     @Value.Default

--- a/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
@@ -29,6 +29,13 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableJavaSdkCustomConfig.class)
 public interface JavaSdkCustomConfig extends ICustomConfig {
 
+    @Override
+    @Value.Default
+    @JsonProperty("enable-forward-compatible-enums")
+    default Boolean enableForwardCompatibleEnum() {
+        return true;
+    }
+
     @JsonProperty("client-class-name")
     Optional<String> clientClassName();
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,32 @@
+- version: 3.0.0
+  changelogEntry:
+    - summary: |
+        The SDK generator now defaults to forward-compatible enums, providing resilience against new enum variants 
+        added on the backend. This is a breaking change that affects the structure of generated enum types.
+
+        To revert to the previous behavior with traditional Java enums, add the following configuration to your 
+        `generators.yml` file:
+        ```yaml
+        generators:
+          - name: fernapi/fern-java-sdk
+            config:
+              enable-forward-compatible-enums: false
+        ```
+      type: break
+    - summary: |
+        Forward-compatible enums are now enabled by default. Generated SDKs will no longer throw errors when 
+        encountering unknown enum variants, instead handling them gracefully with an UNKNOWN value. This is 
+        particularly important for:
+        - Mobile applications that cannot be easily updated
+        - Maintaining backward compatibility when backend adds new enum values
+        - Arrays of enum values where new variants previously caused client failures
+
+        With forward-compatible enums, the generated code changes from traditional Java enums to class-based 
+        enums that support unknown values through a visitor pattern.
+      type: feat
+  createdAt: "2025-09-09"
+  irVersion: 59
+
 - version: 2.43.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/resources/ast/types/PrimitiveValue.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/resources/ast/types/PrimitiveValue.java
@@ -3,22 +3,81 @@
  */
 package com.seed.api.resources.ast.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum PrimitiveValue {
-    STRING("STRING"),
+public final class PrimitiveValue {
+    public static final PrimitiveValue NUMBER = new PrimitiveValue(Value.NUMBER, "NUMBER");
 
-    NUMBER("NUMBER");
+    public static final PrimitiveValue STRING = new PrimitiveValue(Value.STRING, "STRING");
 
-    private final String value;
+    private final Value value;
 
-    PrimitiveValue(String value) {
+    private final String string;
+
+    PrimitiveValue(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof PrimitiveValue && this.string.equals(((PrimitiveValue) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case NUMBER:
+                return visitor.visitNumber();
+            case STRING:
+                return visitor.visitString();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static PrimitiveValue valueOf(String value) {
+        switch (value) {
+            case "NUMBER":
+                return NUMBER;
+            case "STRING":
+                return STRING;
+            default:
+                return new PrimitiveValue(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        STRING,
+
+        NUMBER,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitString();
+
+        T visitNumber();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/circular-references/src/main/java/com/seed/api/resources/ast/types/PrimitiveValue.java
+++ b/seed/java-sdk/circular-references/src/main/java/com/seed/api/resources/ast/types/PrimitiveValue.java
@@ -3,22 +3,81 @@
  */
 package com.seed.api.resources.ast.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum PrimitiveValue {
-    STRING("STRING"),
+public final class PrimitiveValue {
+    public static final PrimitiveValue NUMBER = new PrimitiveValue(Value.NUMBER, "NUMBER");
 
-    NUMBER("NUMBER");
+    public static final PrimitiveValue STRING = new PrimitiveValue(Value.STRING, "STRING");
 
-    private final String value;
+    private final Value value;
 
-    PrimitiveValue(String value) {
+    private final String string;
+
+    PrimitiveValue(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof PrimitiveValue && this.string.equals(((PrimitiveValue) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case NUMBER:
+                return visitor.visitNumber();
+            case STRING:
+                return visitor.visitString();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static PrimitiveValue valueOf(String value) {
+        switch (value) {
+            case "NUMBER":
+                return NUMBER;
+            case "STRING":
+                return STRING;
+            default:
+                return new PrimitiveValue(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        STRING,
+
+        NUMBER,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitString();
+
+        T visitNumber();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/unknown/types/Status.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/unknown/types/Status.java
@@ -3,22 +3,80 @@
  */
 package com.seed._enum.resources.unknown.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Status {
-    KNOWN("Known"),
+public final class Status {
+    public static final Status UNKNOWN = new Status(Value.UNKNOWN, "Unknown");
 
-    UNKNOWN("Unknown");
+    public static final Status KNOWN = new Status(Value.KNOWN, "Known");
 
-    private final String value;
+    private final Value value;
 
-    Status(String value) {
+    private final String string;
+
+    Status(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Status && this.string.equals(((Status) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case KNOWN:
+                return visitor.visitKnown();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Status valueOf(String value) {
+        switch (value) {
+            case "Unknown":
+                return UNKNOWN;
+            case "Known":
+                return KNOWN;
+            default:
+                return new Status(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        KNOWN,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitKnown();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/Color.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/Color.java
@@ -3,22 +3,80 @@
  */
 package com.seed._enum.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Color {
-    RED("red"),
+public final class Color {
+    public static final Color RED = new Color(Value.RED, "red");
 
-    BLUE("blue");
+    public static final Color BLUE = new Color(Value.BLUE, "blue");
 
-    private final String value;
+    private final Value value;
 
-    Color(String value) {
+    private final String string;
+
+    Color(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Color && this.string.equals(((Color) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case RED:
+                return visitor.visitRed();
+            case BLUE:
+                return visitor.visitBlue();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Color valueOf(String value) {
+        switch (value) {
+            case "red":
+                return RED;
+            case "blue":
+                return BLUE;
+            default:
+                return new Color(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        RED,
+
+        BLUE,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRed();
+
+        T visitBlue();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/EnumWithCustom.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/EnumWithCustom.java
@@ -3,22 +3,81 @@
  */
 package com.seed._enum.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum EnumWithCustom {
-    SAFE("safe"),
+public final class EnumWithCustom {
+    public static final EnumWithCustom SAFE = new EnumWithCustom(Value.SAFE, "safe");
 
-    CUSTOM("Custom");
+    public static final EnumWithCustom CUSTOM = new EnumWithCustom(Value.CUSTOM, "Custom");
 
-    private final String value;
+    private final Value value;
 
-    EnumWithCustom(String value) {
+    private final String string;
+
+    EnumWithCustom(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof EnumWithCustom && this.string.equals(((EnumWithCustom) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SAFE:
+                return visitor.visitSafe();
+            case CUSTOM:
+                return visitor.visitCustom();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EnumWithCustom valueOf(String value) {
+        switch (value) {
+            case "safe":
+                return SAFE;
+            case "Custom":
+                return CUSTOM;
+            default:
+                return new EnumWithCustom(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SAFE,
+
+        CUSTOM,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSafe();
+
+        T visitCustom();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/EnumWithSpecialCharacters.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/EnumWithSpecialCharacters.java
@@ -3,22 +3,82 @@
  */
 package com.seed._enum.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum EnumWithSpecialCharacters {
-    BLA("\\$bla"),
+public final class EnumWithSpecialCharacters {
+    public static final EnumWithSpecialCharacters YO = new EnumWithSpecialCharacters(Value.YO, "\\$yo");
 
-    YO("\\$yo");
+    public static final EnumWithSpecialCharacters BLA = new EnumWithSpecialCharacters(Value.BLA, "\\$bla");
 
-    private final String value;
+    private final Value value;
 
-    EnumWithSpecialCharacters(String value) {
+    private final String string;
+
+    EnumWithSpecialCharacters(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof EnumWithSpecialCharacters
+                        && this.string.equals(((EnumWithSpecialCharacters) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case YO:
+                return visitor.visitYo();
+            case BLA:
+                return visitor.visitBla();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EnumWithSpecialCharacters valueOf(String value) {
+        switch (value) {
+            case "\\$yo":
+                return YO;
+            case "\\$bla":
+                return BLA;
+            default:
+                return new EnumWithSpecialCharacters(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        BLA,
+
+        YO,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitBla();
+
+        T visitYo();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/Operand.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/Operand.java
@@ -3,24 +3,90 @@
  */
 package com.seed._enum.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Operand {
-    GREATER_THAN(">"),
+public final class Operand {
+    public static final Operand LESS_THAN = new Operand(Value.LESS_THAN, "less_than");
 
-    EQUAL_TO("="),
+    public static final Operand EQUAL_TO = new Operand(Value.EQUAL_TO, "=");
 
-    LESS_THAN("less_than");
+    public static final Operand GREATER_THAN = new Operand(Value.GREATER_THAN, ">");
 
-    private final String value;
+    private final Value value;
 
-    Operand(String value) {
+    private final String string;
+
+    Operand(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Operand && this.string.equals(((Operand) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LESS_THAN:
+                return visitor.visitLessThan();
+            case EQUAL_TO:
+                return visitor.visitEqualTo();
+            case GREATER_THAN:
+                return visitor.visitGreaterThan();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Operand valueOf(String value) {
+        switch (value) {
+            case "less_than":
+                return LESS_THAN;
+            case "=":
+                return EQUAL_TO;
+            case ">":
+                return GREATER_THAN;
+            default:
+                return new Operand(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        GREATER_THAN,
+
+        EQUAL_TO,
+
+        LESS_THAN,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitGreaterThan();
+
+        T visitEqualTo();
+
+        T visitLessThan();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/SpecialEnum.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/types/SpecialEnum.java
@@ -3,82 +3,383 @@
  */
 package com.seed._enum.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum SpecialEnum {
-    A(""),
+public final class SpecialEnum {
+    public static final SpecialEnum Q = new SpecialEnum(Value.Q, "Hello\\u007FWorld");
 
-    B("Hello \\\"World\\\""),
+    public static final SpecialEnum BB = new SpecialEnum(Value.BB, "C:\\\\Users\\\\John\\\\Documents\\\\file.txt");
 
-    C("Hello 'World'"),
+    public static final SpecialEnum CC = new SpecialEnum(Value.CC, "/usr/local/bin/app");
 
-    D("Hello\\\\World"),
+    public static final SpecialEnum Z =
+            new SpecialEnum(Value.Z, "{\"name\": \"John\", \"age\": 30, \"city\": \"New York\"}");
 
-    E("Hello\\nWorld"),
+    public static final SpecialEnum D = new SpecialEnum(Value.D, "Hello\\\\World");
 
-    F("Hello\\rWorld"),
+    public static final SpecialEnum I = new SpecialEnum(Value.I, "Hello\\fWorld");
 
-    H("Hello\\tWorld"),
+    public static final SpecialEnum H = new SpecialEnum(Value.H, "Hello\\tWorld");
 
-    I("Hello\\fWorld"),
+    public static final SpecialEnum L = new SpecialEnum(Value.L, "Hello\\x00World");
 
-    J("Hello\\u0008World"),
+    public static final SpecialEnum E = new SpecialEnum(Value.E, "Hello\\nWorld");
 
-    K("Hello\\vWorld"),
+    public static final SpecialEnum N = new SpecialEnum(Value.N, "Hello\\u0001World");
 
-    L("Hello\\x00World"),
+    public static final SpecialEnum X = new SpecialEnum(Value.X, "\\\\n");
 
-    M("Hello\\u0007World"),
+    public static final SpecialEnum AA =
+            new SpecialEnum(Value.AA, "SELECT * FROM users WHERE name = 'John O\\\\'Reilly'");
 
-    N("Hello\\u0001World"),
+    public static final SpecialEnum M = new SpecialEnum(Value.M, "Hello\\u0007World");
 
-    O("Hello\\u0002World"),
+    public static final SpecialEnum O = new SpecialEnum(Value.O, "Hello\\u0002World");
 
-    P("Hello\\u001FWorld"),
+    public static final SpecialEnum F = new SpecialEnum(Value.F, "Hello\\rWorld");
 
-    Q("Hello\\u007FWorld"),
+    public static final SpecialEnum FF = new SpecialEnum(Value.FF, "transcript[transcriptType=\"final\"]");
 
-    R("Hello\\u009FWorld"),
+    public static final SpecialEnum DD = new SpecialEnum(Value.DD, "\\\\d{3}-\\\\d{2}-\\\\d{4}");
 
-    S("Line 1\\n\"Quote\"\\tTab\\\\Backslash\\r\\nLine 2\\0Null"),
+    public static final SpecialEnum K = new SpecialEnum(Value.K, "Hello\\vWorld");
 
-    T("\\n\\r\\t\\x00\\u0008\\f\\v\\u0007"),
+    public static final SpecialEnum V = new SpecialEnum(Value.V, "café");
 
-    U("Hello 世界"),
+    public static final SpecialEnum J = new SpecialEnum(Value.J, "Hello\\u0008World");
 
-    V("café"),
+    public static final SpecialEnum W = new SpecialEnum(Value.W, "🚀");
 
-    W("🚀"),
+    public static final SpecialEnum GG = new SpecialEnum(Value.GG, "transcript[transcriptType='final']");
 
-    X("\\\\n"),
+    public static final SpecialEnum U = new SpecialEnum(Value.U, "Hello 世界");
 
-    Y("\\\\"),
+    public static final SpecialEnum P = new SpecialEnum(Value.P, "Hello\\u001FWorld");
 
-    Z("{\"name\": \"John\", \"age\": 30, \"city\": \"New York\"}"),
+    public static final SpecialEnum B = new SpecialEnum(Value.B, "Hello \\\"World\\\"");
 
-    AA("SELECT * FROM users WHERE name = 'John O\\\\'Reilly'"),
+    public static final SpecialEnum C = new SpecialEnum(Value.C, "Hello 'World'");
 
-    BB("C:\\\\Users\\\\John\\\\Documents\\\\file.txt"),
+    public static final SpecialEnum R = new SpecialEnum(Value.R, "Hello\\u009FWorld");
 
-    CC("/usr/local/bin/app"),
+    public static final SpecialEnum A = new SpecialEnum(Value.A, "");
 
-    DD("\\\\d{3}-\\\\d{2}-\\\\d{4}"),
+    public static final SpecialEnum Y = new SpecialEnum(Value.Y, "\\\\");
 
-    EE("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}"),
+    public static final SpecialEnum EE = new SpecialEnum(Value.EE, "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}");
 
-    FF("transcript[transcriptType=\"final\"]"),
+    public static final SpecialEnum S =
+            new SpecialEnum(Value.S, "Line 1\\n\"Quote\"\\tTab\\\\Backslash\\r\\nLine 2\\0Null");
 
-    GG("transcript[transcriptType='final']");
+    public static final SpecialEnum T = new SpecialEnum(Value.T, "\\n\\r\\t\\x00\\u0008\\f\\v\\u0007");
 
-    private final String value;
+    private final Value value;
 
-    SpecialEnum(String value) {
+    private final String string;
+
+    SpecialEnum(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof SpecialEnum && this.string.equals(((SpecialEnum) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case Q:
+                return visitor.visitQ();
+            case BB:
+                return visitor.visitBb();
+            case CC:
+                return visitor.visitCc();
+            case Z:
+                return visitor.visitZ();
+            case D:
+                return visitor.visitD();
+            case I:
+                return visitor.visitI();
+            case H:
+                return visitor.visitH();
+            case L:
+                return visitor.visitL();
+            case E:
+                return visitor.visitE();
+            case N:
+                return visitor.visitN();
+            case X:
+                return visitor.visitX();
+            case AA:
+                return visitor.visitAa();
+            case M:
+                return visitor.visitM();
+            case O:
+                return visitor.visitO();
+            case F:
+                return visitor.visitF();
+            case FF:
+                return visitor.visitFf();
+            case DD:
+                return visitor.visitDd();
+            case K:
+                return visitor.visitK();
+            case V:
+                return visitor.visitV();
+            case J:
+                return visitor.visitJ();
+            case W:
+                return visitor.visitW();
+            case GG:
+                return visitor.visitGg();
+            case U:
+                return visitor.visitU();
+            case P:
+                return visitor.visitP();
+            case B:
+                return visitor.visitB();
+            case C:
+                return visitor.visitC();
+            case R:
+                return visitor.visitR();
+            case A:
+                return visitor.visitA();
+            case Y:
+                return visitor.visitY();
+            case EE:
+                return visitor.visitEe();
+            case S:
+                return visitor.visitS();
+            case T:
+                return visitor.visitT();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SpecialEnum valueOf(String value) {
+        switch (value) {
+            case "Hello\\u007FWorld":
+                return Q;
+            case "C:\\\\Users\\\\John\\\\Documents\\\\file.txt":
+                return BB;
+            case "/usr/local/bin/app":
+                return CC;
+            case "{\"name\": \"John\", \"age\": 30, \"city\": \"New York\"}":
+                return Z;
+            case "Hello\\\\World":
+                return D;
+            case "Hello\\fWorld":
+                return I;
+            case "Hello\\tWorld":
+                return H;
+            case "Hello\\x00World":
+                return L;
+            case "Hello\\nWorld":
+                return E;
+            case "Hello\\u0001World":
+                return N;
+            case "\\\\n":
+                return X;
+            case "SELECT * FROM users WHERE name = 'John O\\\\'Reilly'":
+                return AA;
+            case "Hello\\u0007World":
+                return M;
+            case "Hello\\u0002World":
+                return O;
+            case "Hello\\rWorld":
+                return F;
+            case "transcript[transcriptType=\"final\"]":
+                return FF;
+            case "\\\\d{3}-\\\\d{2}-\\\\d{4}":
+                return DD;
+            case "Hello\\vWorld":
+                return K;
+            case "café":
+                return V;
+            case "Hello\\u0008World":
+                return J;
+            case "🚀":
+                return W;
+            case "transcript[transcriptType='final']":
+                return GG;
+            case "Hello 世界":
+                return U;
+            case "Hello\\u001FWorld":
+                return P;
+            case "Hello \\\"World\\\"":
+                return B;
+            case "Hello 'World'":
+                return C;
+            case "Hello\\u009FWorld":
+                return R;
+            case "":
+                return A;
+            case "\\\\":
+                return Y;
+            case "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}":
+                return EE;
+            case "Line 1\\n\"Quote\"\\tTab\\\\Backslash\\r\\nLine 2\\0Null":
+                return S;
+            case "\\n\\r\\t\\x00\\u0008\\f\\v\\u0007":
+                return T;
+            default:
+                return new SpecialEnum(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        A,
+
+        B,
+
+        C,
+
+        D,
+
+        E,
+
+        F,
+
+        H,
+
+        I,
+
+        J,
+
+        K,
+
+        L,
+
+        M,
+
+        N,
+
+        O,
+
+        P,
+
+        Q,
+
+        R,
+
+        S,
+
+        T,
+
+        U,
+
+        V,
+
+        W,
+
+        X,
+
+        Y,
+
+        Z,
+
+        AA,
+
+        BB,
+
+        CC,
+
+        DD,
+
+        EE,
+
+        FF,
+
+        GG,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitA();
+
+        T visitB();
+
+        T visitC();
+
+        T visitD();
+
+        T visitE();
+
+        T visitF();
+
+        T visitH();
+
+        T visitI();
+
+        T visitJ();
+
+        T visitK();
+
+        T visitL();
+
+        T visitM();
+
+        T visitN();
+
+        T visitO();
+
+        T visitP();
+
+        T visitQ();
+
+        T visitR();
+
+        T visitS();
+
+        T visitT();
+
+        T visitU();
+
+        T visitV();
+
+        T visitW();
+
+        T visitX();
+
+        T visitY();
+
+        T visitZ();
+
+        T visitAa();
+
+        T visitBb();
+
+        T visitCc();
+
+        T visitDd();
+
+        T visitEe();
+
+        T visitFf();
+
+        T visitGg();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
@@ -3,24 +3,91 @@
  */
 package com.seed.examples.resources.types.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MigrationStatus {
-    RUNNING("RUNNING"),
+public final class MigrationStatus {
+    public static final MigrationStatus RUNNING = new MigrationStatus(Value.RUNNING, "RUNNING");
 
-    FAILED("FAILED"),
+    public static final MigrationStatus FAILED = new MigrationStatus(Value.FAILED, "FAILED");
 
-    FINISHED("FINISHED");
+    public static final MigrationStatus FINISHED = new MigrationStatus(Value.FINISHED, "FINISHED");
 
-    private final String value;
+    private final Value value;
 
-    MigrationStatus(String value) {
+    private final String string;
+
+    MigrationStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof MigrationStatus && this.string.equals(((MigrationStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case RUNNING:
+                return visitor.visitRunning();
+            case FAILED:
+                return visitor.visitFailed();
+            case FINISHED:
+                return visitor.visitFinished();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static MigrationStatus valueOf(String value) {
+        switch (value) {
+            case "RUNNING":
+                return RUNNING;
+            case "FAILED":
+                return FAILED;
+            case "FINISHED":
+                return FINISHED;
+            default:
+                return new MigrationStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        RUNNING,
+
+        FAILED,
+
+        FINISHED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRunning();
+
+        T visitFailed();
+
+        T visitFinished();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/types/BasicType.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/types/BasicType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.examples.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum BasicType {
-    PRIMITIVE("primitive"),
+public final class BasicType {
+    public static final BasicType LITERAL = new BasicType(Value.LITERAL, "literal");
 
-    LITERAL("literal");
+    public static final BasicType PRIMITIVE = new BasicType(Value.PRIMITIVE, "primitive");
 
-    private final String value;
+    private final Value value;
 
-    BasicType(String value) {
+    private final String string;
+
+    BasicType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof BasicType && this.string.equals(((BasicType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LITERAL:
+                return visitor.visitLiteral();
+            case PRIMITIVE:
+                return visitor.visitPrimitive();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static BasicType valueOf(String value) {
+        switch (value) {
+            case "literal":
+                return LITERAL;
+            case "primitive":
+                return PRIMITIVE;
+            default:
+                return new BasicType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        PRIMITIVE,
+
+        LITERAL,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitPrimitive();
+
+        T visitLiteral();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
@@ -3,24 +3,91 @@
  */
 package com.seed.examples.resources.types.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MigrationStatus {
-    RUNNING("RUNNING"),
+public final class MigrationStatus {
+    public static final MigrationStatus RUNNING = new MigrationStatus(Value.RUNNING, "RUNNING");
 
-    FAILED("FAILED"),
+    public static final MigrationStatus FAILED = new MigrationStatus(Value.FAILED, "FAILED");
 
-    FINISHED("FINISHED");
+    public static final MigrationStatus FINISHED = new MigrationStatus(Value.FINISHED, "FINISHED");
 
-    private final String value;
+    private final Value value;
 
-    MigrationStatus(String value) {
+    private final String string;
+
+    MigrationStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof MigrationStatus && this.string.equals(((MigrationStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case RUNNING:
+                return visitor.visitRunning();
+            case FAILED:
+                return visitor.visitFailed();
+            case FINISHED:
+                return visitor.visitFinished();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static MigrationStatus valueOf(String value) {
+        switch (value) {
+            case "RUNNING":
+                return RUNNING;
+            case "FAILED":
+                return FAILED;
+            case "FINISHED":
+                return FINISHED;
+            default:
+                return new MigrationStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        RUNNING,
+
+        FAILED,
+
+        FINISHED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRunning();
+
+        T visitFailed();
+
+        T visitFinished();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/types/BasicType.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/types/BasicType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.examples.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum BasicType {
-    PRIMITIVE("primitive"),
+public final class BasicType {
+    public static final BasicType LITERAL = new BasicType(Value.LITERAL, "literal");
 
-    LITERAL("literal");
+    public static final BasicType PRIMITIVE = new BasicType(Value.PRIMITIVE, "primitive");
 
-    private final String value;
+    private final Value value;
 
-    BasicType(String value) {
+    private final String string;
+
+    BasicType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof BasicType && this.string.equals(((BasicType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LITERAL:
+                return visitor.visitLiteral();
+            case PRIMITIVE:
+                return visitor.visitPrimitive();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static BasicType valueOf(String value) {
+        switch (value) {
+            case "literal":
+                return LITERAL;
+            case "primitive":
+                return PRIMITIVE;
+            default:
+                return new BasicType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        PRIMITIVE,
+
+        LITERAL,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitPrimitive();
+
+        T visitLiteral();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
@@ -3,24 +3,91 @@
  */
 package com.seed.examples.resources.types.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MigrationStatus {
-    RUNNING("RUNNING"),
+public final class MigrationStatus {
+    public static final MigrationStatus RUNNING = new MigrationStatus(Value.RUNNING, "RUNNING");
 
-    FAILED("FAILED"),
+    public static final MigrationStatus FAILED = new MigrationStatus(Value.FAILED, "FAILED");
 
-    FINISHED("FINISHED");
+    public static final MigrationStatus FINISHED = new MigrationStatus(Value.FINISHED, "FINISHED");
 
-    private final String value;
+    private final Value value;
 
-    MigrationStatus(String value) {
+    private final String string;
+
+    MigrationStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof MigrationStatus && this.string.equals(((MigrationStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case RUNNING:
+                return visitor.visitRunning();
+            case FAILED:
+                return visitor.visitFailed();
+            case FINISHED:
+                return visitor.visitFinished();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static MigrationStatus valueOf(String value) {
+        switch (value) {
+            case "RUNNING":
+                return RUNNING;
+            case "FAILED":
+                return FAILED;
+            case "FINISHED":
+                return FINISHED;
+            default:
+                return new MigrationStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        RUNNING,
+
+        FAILED,
+
+        FINISHED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRunning();
+
+        T visitFailed();
+
+        T visitFinished();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/types/BasicType.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/types/BasicType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.examples.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum BasicType {
-    PRIMITIVE("primitive"),
+public final class BasicType {
+    public static final BasicType LITERAL = new BasicType(Value.LITERAL, "literal");
 
-    LITERAL("literal");
+    public static final BasicType PRIMITIVE = new BasicType(Value.PRIMITIVE, "primitive");
 
-    private final String value;
+    private final Value value;
 
-    BasicType(String value) {
+    private final String string;
+
+    BasicType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof BasicType && this.string.equals(((BasicType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LITERAL:
+                return visitor.visitLiteral();
+            case PRIMITIVE:
+                return visitor.visitPrimitive();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static BasicType valueOf(String value) {
+        switch (value) {
+            case "literal":
+                return LITERAL;
+            case "primitive":
+                return PRIMITIVE;
+            default:
+                return new BasicType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        PRIMITIVE,
+
+        LITERAL,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitPrimitive();
+
+        T visitLiteral();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
+++ b/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/MigrationStatus.java
@@ -3,24 +3,91 @@
  */
 package com.seed.examples.resources.types.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MigrationStatus {
-    RUNNING("RUNNING"),
+public final class MigrationStatus {
+    public static final MigrationStatus RUNNING = new MigrationStatus(Value.RUNNING, "RUNNING");
 
-    FAILED("FAILED"),
+    public static final MigrationStatus FAILED = new MigrationStatus(Value.FAILED, "FAILED");
 
-    FINISHED("FINISHED");
+    public static final MigrationStatus FINISHED = new MigrationStatus(Value.FINISHED, "FINISHED");
 
-    private final String value;
+    private final Value value;
 
-    MigrationStatus(String value) {
+    private final String string;
+
+    MigrationStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof MigrationStatus && this.string.equals(((MigrationStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case RUNNING:
+                return visitor.visitRunning();
+            case FAILED:
+                return visitor.visitFailed();
+            case FINISHED:
+                return visitor.visitFinished();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static MigrationStatus valueOf(String value) {
+        switch (value) {
+            case "RUNNING":
+                return RUNNING;
+            case "FAILED":
+                return FAILED;
+            case "FINISHED":
+                return FINISHED;
+            default:
+                return new MigrationStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        RUNNING,
+
+        FAILED,
+
+        FINISHED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRunning();
+
+        T visitFailed();
+
+        T visitFinished();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/types/BasicType.java
+++ b/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/types/BasicType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.examples.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum BasicType {
-    PRIMITIVE("primitive"),
+public final class BasicType {
+    public static final BasicType LITERAL = new BasicType(Value.LITERAL, "literal");
 
-    LITERAL("literal");
+    public static final BasicType PRIMITIVE = new BasicType(Value.PRIMITIVE, "primitive");
 
-    private final String value;
+    private final Value value;
 
-    BasicType(String value) {
+    private final String string;
+
+    BasicType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof BasicType && this.string.equals(((BasicType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LITERAL:
+                return visitor.visitLiteral();
+            case PRIMITIVE:
+                return visitor.visitPrimitive();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static BasicType valueOf(String value) {
+        switch (value) {
+            case "literal":
+                return LITERAL;
+            case "primitive":
+                return PRIMITIVE;
+            default:
+                return new BasicType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        PRIMITIVE,
+
+        LITERAL,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitPrimitive();
+
+        T visitLiteral();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.endpoints.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.endpoints.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.types.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/local-files/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/local-files/resources/endpoints/put/types/ErrorCategory.java
@@ -4,25 +4,95 @@
 
 package com.fern.sdk.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.lang.Object;
 import java.lang.String;
 
-public enum ErrorCategory {
-  API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+  public static final ErrorCategory INVALID_REQUEST_ERROR = new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-  AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+  public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-  INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+  public static final ErrorCategory AUTHENTICATION_ERROR = new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-  private final String value;
+  private final Value value;
 
-  ErrorCategory(String value) {
+  private final String string;
+
+  ErrorCategory(Value value, String string) {
     this.value = value;
+    this.string = string;
   }
 
-  @JsonValue
+  public Value getEnumValue() {
+    return value;
+  }
+
   @java.lang.Override
+  @JsonValue
   public String toString() {
-    return this.value;
+    return this.string;
+  }
+
+  @java.lang.Override
+  public boolean equals(Object other) {
+    return (this == other) 
+      || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    return this.string.hashCode();
+  }
+
+  public <T> T visit(Visitor<T> visitor) {
+    switch (value) {
+      case INVALID_REQUEST_ERROR:
+        return visitor.visitInvalidRequestError();
+      case API_ERROR:
+        return visitor.visitApiError();
+      case AUTHENTICATION_ERROR:
+        return visitor.visitAuthenticationError();
+      case UNKNOWN:
+      default:
+        return visitor.visitUnknown(string);
+    }
+  }
+
+  @JsonCreator(
+      mode = JsonCreator.Mode.DELEGATING
+  )
+  public static ErrorCategory valueOf(String value) {
+    switch (value) {
+      case "INVALID_REQUEST_ERROR":
+        return INVALID_REQUEST_ERROR;
+      case "API_ERROR":
+        return API_ERROR;
+      case "AUTHENTICATION_ERROR":
+        return AUTHENTICATION_ERROR;
+      default:
+        return new ErrorCategory(Value.UNKNOWN, value);
+    }
+  }
+
+  public enum Value {
+    API_ERROR,
+
+    AUTHENTICATION_ERROR,
+
+    INVALID_REQUEST_ERROR,
+
+    UNKNOWN
+  }
+
+  public interface Visitor<T> {
+    T visitApiError();
+
+    T visitAuthenticationError();
+
+    T visitInvalidRequestError();
+
+    T visitUnknown(String unknownType);
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/local-files/resources/endpoints/put/types/ErrorCode.java
@@ -4,41 +4,175 @@
 
 package com.fern.sdk.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.lang.Object;
 import java.lang.String;
 
-public enum ErrorCode {
-  INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+  public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-  UNAUTHORIZED("UNAUTHORIZED"),
+  public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-  FORBIDDEN("FORBIDDEN"),
+  public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-  BAD_REQUEST("BAD_REQUEST"),
+  public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-  CONFLICT("CONFLICT"),
+  public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-  GONE("GONE"),
+  public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-  UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+  public static final ErrorCode UNPROCESSABLE_ENTITY = new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-  NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+  public static final ErrorCode INTERNAL_SERVER_ERROR = new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-  BAD_GATEWAY("BAD_GATEWAY"),
+  public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-  SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+  public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-  UNKNOWN("Unknown");
+  public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-  private final String value;
+  private final Value value;
 
-  ErrorCode(String value) {
+  private final String string;
+
+  ErrorCode(Value value, String string) {
     this.value = value;
+    this.string = string;
   }
 
-  @JsonValue
+  public Value getEnumValue() {
+    return value;
+  }
+
   @java.lang.Override
+  @JsonValue
   public String toString() {
-    return this.value;
+    return this.string;
+  }
+
+  @java.lang.Override
+  public boolean equals(Object other) {
+    return (this == other) 
+      || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    return this.string.hashCode();
+  }
+
+  public <T> T visit(Visitor<T> visitor) {
+    switch (value) {
+      case GONE:
+        return visitor.visitGone();
+      case CONFLICT:
+        return visitor.visitConflict();
+      case UNKNOWN:
+        return visitor.visitUnknown();
+      case NOT_IMPLEMENTED:
+        return visitor.visitNotImplemented();
+      case UNAUTHORIZED:
+        return visitor.visitUnauthorized();
+      case BAD_REQUEST:
+        return visitor.visitBadRequest();
+      case UNPROCESSABLE_ENTITY:
+        return visitor.visitUnprocessableEntity();
+      case INTERNAL_SERVER_ERROR:
+        return visitor.visitInternalServerError();
+      case BAD_GATEWAY:
+        return visitor.visitBadGateway();
+      case SERVICE_UNAVAILABLE:
+        return visitor.visitServiceUnavailable();
+      case FORBIDDEN:
+        return visitor.visitForbidden();
+      case _UNKNOWN:
+      default:
+        return visitor.visitUnknown(string);
+    }
+  }
+
+  @JsonCreator(
+      mode = JsonCreator.Mode.DELEGATING
+  )
+  public static ErrorCode valueOf(String value) {
+    switch (value) {
+      case "GONE":
+        return GONE;
+      case "CONFLICT":
+        return CONFLICT;
+      case "Unknown":
+        return UNKNOWN;
+      case "NOT_IMPLEMENTED":
+        return NOT_IMPLEMENTED;
+      case "UNAUTHORIZED":
+        return UNAUTHORIZED;
+      case "BAD_REQUEST":
+        return BAD_REQUEST;
+      case "UNPROCESSABLE_ENTITY":
+        return UNPROCESSABLE_ENTITY;
+      case "INTERNAL_SERVER_ERROR":
+        return INTERNAL_SERVER_ERROR;
+      case "BAD_GATEWAY":
+        return BAD_GATEWAY;
+      case "SERVICE_UNAVAILABLE":
+        return SERVICE_UNAVAILABLE;
+      case "FORBIDDEN":
+        return FORBIDDEN;
+      default:
+        return new ErrorCode(Value._UNKNOWN, value);
+    }
+  }
+
+  public enum Value {
+    INTERNAL_SERVER_ERROR,
+
+    UNAUTHORIZED,
+
+    FORBIDDEN,
+
+    BAD_REQUEST,
+
+    CONFLICT,
+
+    GONE,
+
+    UNPROCESSABLE_ENTITY,
+
+    NOT_IMPLEMENTED,
+
+    BAD_GATEWAY,
+
+    SERVICE_UNAVAILABLE,
+
+    UNKNOWN,
+
+    _UNKNOWN
+  }
+
+  public interface Visitor<T> {
+    T visitInternalServerError();
+
+    T visitUnauthorized();
+
+    T visitForbidden();
+
+    T visitBadRequest();
+
+    T visitConflict();
+
+    T visitGone();
+
+    T visitUnprocessableEntity();
+
+    T visitNotImplemented();
+
+    T visitBadGateway();
+
+    T visitServiceUnavailable();
+
+    T visitUnknown();
+
+    T visitUnknown(String unknownType);
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/local-files/resources/types/enum_/types/WeatherReport.java
@@ -4,27 +4,105 @@
 
 package com.fern.sdk.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.lang.Object;
 import java.lang.String;
 
-public enum WeatherReport {
-  SUNNY("SUNNY"),
+public final class WeatherReport {
+  public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-  CLOUDY("CLOUDY"),
+  public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-  RAINING("RAINING"),
+  public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-  SNOWING("SNOWING");
+  public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-  private final String value;
+  private final Value value;
 
-  WeatherReport(String value) {
+  private final String string;
+
+  WeatherReport(Value value, String string) {
     this.value = value;
+    this.string = string;
   }
 
-  @JsonValue
+  public Value getEnumValue() {
+    return value;
+  }
+
   @java.lang.Override
+  @JsonValue
   public String toString() {
-    return this.value;
+    return this.string;
+  }
+
+  @java.lang.Override
+  public boolean equals(Object other) {
+    return (this == other) 
+      || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    return this.string.hashCode();
+  }
+
+  public <T> T visit(Visitor<T> visitor) {
+    switch (value) {
+      case SUNNY:
+        return visitor.visitSunny();
+      case RAINING:
+        return visitor.visitRaining();
+      case SNOWING:
+        return visitor.visitSnowing();
+      case CLOUDY:
+        return visitor.visitCloudy();
+      case UNKNOWN:
+      default:
+        return visitor.visitUnknown(string);
+    }
+  }
+
+  @JsonCreator(
+      mode = JsonCreator.Mode.DELEGATING
+  )
+  public static WeatherReport valueOf(String value) {
+    switch (value) {
+      case "SUNNY":
+        return SUNNY;
+      case "RAINING":
+        return RAINING;
+      case "SNOWING":
+        return SNOWING;
+      case "CLOUDY":
+        return CLOUDY;
+      default:
+        return new WeatherReport(Value.UNKNOWN, value);
+    }
+  }
+
+  public enum Value {
+    SUNNY,
+
+    CLOUDY,
+
+    RAINING,
+
+    SNOWING,
+
+    UNKNOWN
+  }
+
+  public interface Visitor<T> {
+    T visitSunny();
+
+    T visitCloudy();
+
+    T visitRaining();
+
+    T visitSnowing();
+
+    T visitUnknown(String unknownType);
   }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCategory.java
@@ -3,24 +3,93 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCategory {
-    API_ERROR("API_ERROR"),
+public final class ErrorCategory {
+    public static final ErrorCategory INVALID_REQUEST_ERROR =
+            new ErrorCategory(Value.INVALID_REQUEST_ERROR, "INVALID_REQUEST_ERROR");
 
-    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR"),
+    public static final ErrorCategory API_ERROR = new ErrorCategory(Value.API_ERROR, "API_ERROR");
 
-    INVALID_REQUEST_ERROR("INVALID_REQUEST_ERROR");
+    public static final ErrorCategory AUTHENTICATION_ERROR =
+            new ErrorCategory(Value.AUTHENTICATION_ERROR, "AUTHENTICATION_ERROR");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCategory(String value) {
+    private final String string;
+
+    ErrorCategory(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ErrorCategory && this.string.equals(((ErrorCategory) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case INVALID_REQUEST_ERROR:
+                return visitor.visitInvalidRequestError();
+            case API_ERROR:
+                return visitor.visitApiError();
+            case AUTHENTICATION_ERROR:
+                return visitor.visitAuthenticationError();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCategory valueOf(String value) {
+        switch (value) {
+            case "INVALID_REQUEST_ERROR":
+                return INVALID_REQUEST_ERROR;
+            case "API_ERROR":
+                return API_ERROR;
+            case "AUTHENTICATION_ERROR":
+                return AUTHENTICATION_ERROR;
+            default:
+                return new ErrorCategory(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        API_ERROR,
+
+        AUTHENTICATION_ERROR,
+
+        INVALID_REQUEST_ERROR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitApiError();
+
+        T visitAuthenticationError();
+
+        T visitInvalidRequestError();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/ErrorCode.java
@@ -3,40 +3,172 @@
  */
 package com.seed.exhaustive.resources.endpoints.put.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ErrorCode {
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR"),
+public final class ErrorCode {
+    public static final ErrorCode GONE = new ErrorCode(Value.GONE, "GONE");
 
-    UNAUTHORIZED("UNAUTHORIZED"),
+    public static final ErrorCode CONFLICT = new ErrorCode(Value.CONFLICT, "CONFLICT");
 
-    FORBIDDEN("FORBIDDEN"),
+    public static final ErrorCode UNKNOWN = new ErrorCode(Value.UNKNOWN, "Unknown");
 
-    BAD_REQUEST("BAD_REQUEST"),
+    public static final ErrorCode NOT_IMPLEMENTED = new ErrorCode(Value.NOT_IMPLEMENTED, "NOT_IMPLEMENTED");
 
-    CONFLICT("CONFLICT"),
+    public static final ErrorCode UNAUTHORIZED = new ErrorCode(Value.UNAUTHORIZED, "UNAUTHORIZED");
 
-    GONE("GONE"),
+    public static final ErrorCode BAD_REQUEST = new ErrorCode(Value.BAD_REQUEST, "BAD_REQUEST");
 
-    UNPROCESSABLE_ENTITY("UNPROCESSABLE_ENTITY"),
+    public static final ErrorCode UNPROCESSABLE_ENTITY =
+            new ErrorCode(Value.UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY");
 
-    NOT_IMPLEMENTED("NOT_IMPLEMENTED"),
+    public static final ErrorCode INTERNAL_SERVER_ERROR =
+            new ErrorCode(Value.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
 
-    BAD_GATEWAY("BAD_GATEWAY"),
+    public static final ErrorCode BAD_GATEWAY = new ErrorCode(Value.BAD_GATEWAY, "BAD_GATEWAY");
 
-    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE"),
+    public static final ErrorCode SERVICE_UNAVAILABLE = new ErrorCode(Value.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE");
 
-    UNKNOWN("Unknown");
+    public static final ErrorCode FORBIDDEN = new ErrorCode(Value.FORBIDDEN, "FORBIDDEN");
 
-    private final String value;
+    private final Value value;
 
-    ErrorCode(String value) {
+    private final String string;
+
+    ErrorCode(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ErrorCode && this.string.equals(((ErrorCode) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GONE:
+                return visitor.visitGone();
+            case CONFLICT:
+                return visitor.visitConflict();
+            case UNKNOWN:
+                return visitor.visitUnknown();
+            case NOT_IMPLEMENTED:
+                return visitor.visitNotImplemented();
+            case UNAUTHORIZED:
+                return visitor.visitUnauthorized();
+            case BAD_REQUEST:
+                return visitor.visitBadRequest();
+            case UNPROCESSABLE_ENTITY:
+                return visitor.visitUnprocessableEntity();
+            case INTERNAL_SERVER_ERROR:
+                return visitor.visitInternalServerError();
+            case BAD_GATEWAY:
+                return visitor.visitBadGateway();
+            case SERVICE_UNAVAILABLE:
+                return visitor.visitServiceUnavailable();
+            case FORBIDDEN:
+                return visitor.visitForbidden();
+            case _UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ErrorCode valueOf(String value) {
+        switch (value) {
+            case "GONE":
+                return GONE;
+            case "CONFLICT":
+                return CONFLICT;
+            case "Unknown":
+                return UNKNOWN;
+            case "NOT_IMPLEMENTED":
+                return NOT_IMPLEMENTED;
+            case "UNAUTHORIZED":
+                return UNAUTHORIZED;
+            case "BAD_REQUEST":
+                return BAD_REQUEST;
+            case "UNPROCESSABLE_ENTITY":
+                return UNPROCESSABLE_ENTITY;
+            case "INTERNAL_SERVER_ERROR":
+                return INTERNAL_SERVER_ERROR;
+            case "BAD_GATEWAY":
+                return BAD_GATEWAY;
+            case "SERVICE_UNAVAILABLE":
+                return SERVICE_UNAVAILABLE;
+            case "FORBIDDEN":
+                return FORBIDDEN;
+            default:
+                return new ErrorCode(Value._UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        INTERNAL_SERVER_ERROR,
+
+        UNAUTHORIZED,
+
+        FORBIDDEN,
+
+        BAD_REQUEST,
+
+        CONFLICT,
+
+        GONE,
+
+        UNPROCESSABLE_ENTITY,
+
+        NOT_IMPLEMENTED,
+
+        BAD_GATEWAY,
+
+        SERVICE_UNAVAILABLE,
+
+        UNKNOWN,
+
+        _UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitInternalServerError();
+
+        T visitUnauthorized();
+
+        T visitForbidden();
+
+        T visitBadRequest();
+
+        T visitConflict();
+
+        T visitGone();
+
+        T visitUnprocessableEntity();
+
+        T visitNotImplemented();
+
+        T visitBadGateway();
+
+        T visitServiceUnavailable();
+
+        T visitUnknown();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/enum_/types/WeatherReport.java
@@ -3,26 +3,101 @@
  */
 package com.seed.exhaustive.resources.types.enum_.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum WeatherReport {
-    SUNNY("SUNNY"),
+public final class WeatherReport {
+    public static final WeatherReport SUNNY = new WeatherReport(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final WeatherReport RAINING = new WeatherReport(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final WeatherReport SNOWING = new WeatherReport(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final WeatherReport CLOUDY = new WeatherReport(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    WeatherReport(String value) {
+    private final String string;
+
+    WeatherReport(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof WeatherReport && this.string.equals(((WeatherReport) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherReport valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new WeatherReport(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/types/ObjectType.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/types/ObjectType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.fileUpload.resources.service.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ObjectType {
-    FOO("FOO"),
+public final class ObjectType {
+    public static final ObjectType FOO = new ObjectType(Value.FOO, "FOO");
 
-    BAR("BAR");
+    public static final ObjectType BAR = new ObjectType(Value.BAR, "BAR");
 
-    private final String value;
+    private final Value value;
 
-    ObjectType(String value) {
+    private final String string;
+
+    ObjectType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ObjectType && this.string.equals(((ObjectType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case FOO:
+                return visitor.visitFoo();
+            case BAR:
+                return visitor.visitBar();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ObjectType valueOf(String value) {
+        switch (value) {
+            case "FOO":
+                return FOO;
+            case "BAR":
+                return BAR;
+            default:
+                return new ObjectType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        FOO,
+
+        BAR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitFoo();
+
+        T visitBar();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/types/ObjectType.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/types/ObjectType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.fileUpload.resources.service.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ObjectType {
-    FOO("FOO"),
+public final class ObjectType {
+    public static final ObjectType FOO = new ObjectType(Value.FOO, "FOO");
 
-    BAR("BAR");
+    public static final ObjectType BAR = new ObjectType(Value.BAR, "BAR");
 
-    private final String value;
+    private final Value value;
 
-    ObjectType(String value) {
+    private final String string;
+
+    ObjectType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ObjectType && this.string.equals(((ObjectType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case FOO:
+                return visitor.visitFoo();
+            case BAR:
+                return visitor.visitBar();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ObjectType valueOf(String value) {
+        switch (value) {
+            case "FOO":
+                return FOO;
+            case "BAR":
+                return BAR;
+            default:
+                return new ObjectType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        FOO,
+
+        BAR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitFoo();
+
+        T visitBar();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/types/ObjectType.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/types/ObjectType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.fileUpload.resources.service.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ObjectType {
-    FOO("FOO"),
+public final class ObjectType {
+    public static final ObjectType FOO = new ObjectType(Value.FOO, "FOO");
 
-    BAR("BAR");
+    public static final ObjectType BAR = new ObjectType(Value.BAR, "BAR");
 
-    private final String value;
+    private final Value value;
 
-    ObjectType(String value) {
+    private final String string;
+
+    ObjectType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ObjectType && this.string.equals(((ObjectType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case FOO:
+                return visitor.visitFoo();
+            case BAR:
+                return visitor.visitBar();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ObjectType valueOf(String value) {
+        switch (value) {
+            case "FOO":
+                return FOO;
+            case "BAR":
+                return BAR;
+            default:
+                return new ObjectType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        FOO,
+
+        BAR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitFoo();
+
+        T visitBar();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/idempotency-headers/src/main/java/com/seed/idempotencyHeaders/resources/payment/types/Currency.java
+++ b/seed/java-sdk/idempotency-headers/src/main/java/com/seed/idempotencyHeaders/resources/payment/types/Currency.java
@@ -3,22 +3,80 @@
  */
 package com.seed.idempotencyHeaders.resources.payment.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Currency {
-    USD("USD"),
+public final class Currency {
+    public static final Currency YEN = new Currency(Value.YEN, "YEN");
 
-    YEN("YEN");
+    public static final Currency USD = new Currency(Value.USD, "USD");
 
-    private final String value;
+    private final Value value;
 
-    Currency(String value) {
+    private final String string;
+
+    Currency(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Currency && this.string.equals(((Currency) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case YEN:
+                return visitor.visitYen();
+            case USD:
+                return visitor.visitUsd();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Currency valueOf(String value) {
+        switch (value) {
+            case "YEN":
+                return YEN;
+            case "USD":
+                return USD;
+            default:
+                return new Currency(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        USD,
+
+        YEN,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitUsd();
+
+        T visitYen();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/requests/GetUndiscriminatedUnionRequest.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/requests/GetUndiscriminatedUnionRequest.java
@@ -1398,25 +1398,99 @@ public final class GetUndiscriminatedUnionRequest {
             }
         }
 
-        public enum InlineEnum1 {
-            SUNNY("SUNNY"),
+        public static final class InlineEnum1 {
+            public static final InlineEnum1 SUNNY = new InlineEnum1(Value.SUNNY, "SUNNY");
 
-            CLOUDY("CLOUDY"),
+            public static final InlineEnum1 RAINING = new InlineEnum1(Value.RAINING, "RAINING");
 
-            RAINING("RAINING"),
+            public static final InlineEnum1 SNOWING = new InlineEnum1(Value.SNOWING, "SNOWING");
 
-            SNOWING("SNOWING");
+            public static final InlineEnum1 CLOUDY = new InlineEnum1(Value.CLOUDY, "CLOUDY");
 
-            private final String value;
+            private final Value value;
 
-            InlineEnum1(String value) {
+            private final String string;
+
+            InlineEnum1(Value value, String string) {
                 this.value = value;
+                this.string = string;
             }
 
-            @JsonValue
+            public Value getEnumValue() {
+                return value;
+            }
+
             @java.lang.Override
+            @JsonValue
             public String toString() {
-                return this.value;
+                return this.string;
+            }
+
+            @java.lang.Override
+            public boolean equals(Object other) {
+                return (this == other)
+                        || (other instanceof InlineEnum1 && this.string.equals(((InlineEnum1) other).string));
+            }
+
+            @java.lang.Override
+            public int hashCode() {
+                return this.string.hashCode();
+            }
+
+            public <T> T visit(Visitor<T> visitor) {
+                switch (value) {
+                    case SUNNY:
+                        return visitor.visitSunny();
+                    case RAINING:
+                        return visitor.visitRaining();
+                    case SNOWING:
+                        return visitor.visitSnowing();
+                    case CLOUDY:
+                        return visitor.visitCloudy();
+                    case UNKNOWN:
+                    default:
+                        return visitor.visitUnknown(string);
+                }
+            }
+
+            @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+            public static InlineEnum1 valueOf(String value) {
+                switch (value) {
+                    case "SUNNY":
+                        return SUNNY;
+                    case "RAINING":
+                        return RAINING;
+                    case "SNOWING":
+                        return SNOWING;
+                    case "CLOUDY":
+                        return CLOUDY;
+                    default:
+                        return new InlineEnum1(Value.UNKNOWN, value);
+                }
+            }
+
+            public enum Value {
+                SUNNY,
+
+                CLOUDY,
+
+                RAINING,
+
+                SNOWING,
+
+                UNKNOWN
+            }
+
+            public interface Visitor<T> {
+                T visitSunny();
+
+                T visitCloudy();
+
+                T visitRaining();
+
+                T visitSnowing();
+
+                T visitUnknown(String unknownType);
             }
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/RootType1.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/RootType1.java
@@ -5,6 +5,7 @@ package com.seed.object.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -856,25 +857,98 @@ public final class RootType1 {
                 }
             }
 
-            public enum MyEnum {
-                SUNNY("SUNNY"),
+            public static final class MyEnum {
+                public static final MyEnum SUNNY = new MyEnum(Value.SUNNY, "SUNNY");
 
-                CLOUDY("CLOUDY"),
+                public static final MyEnum RAINING = new MyEnum(Value.RAINING, "RAINING");
 
-                RAINING("RAINING"),
+                public static final MyEnum SNOWING = new MyEnum(Value.SNOWING, "SNOWING");
 
-                SNOWING("SNOWING");
+                public static final MyEnum CLOUDY = new MyEnum(Value.CLOUDY, "CLOUDY");
 
-                private final String value;
+                private final Value value;
 
-                MyEnum(String value) {
+                private final String string;
+
+                MyEnum(Value value, String string) {
                     this.value = value;
+                    this.string = string;
                 }
 
-                @JsonValue
+                public Value getEnumValue() {
+                    return value;
+                }
+
                 @java.lang.Override
+                @JsonValue
                 public String toString() {
-                    return this.value;
+                    return this.string;
+                }
+
+                @java.lang.Override
+                public boolean equals(Object other) {
+                    return (this == other) || (other instanceof MyEnum && this.string.equals(((MyEnum) other).string));
+                }
+
+                @java.lang.Override
+                public int hashCode() {
+                    return this.string.hashCode();
+                }
+
+                public <T> T visit(Visitor<T> visitor) {
+                    switch (value) {
+                        case SUNNY:
+                            return visitor.visitSunny();
+                        case RAINING:
+                            return visitor.visitRaining();
+                        case SNOWING:
+                            return visitor.visitSnowing();
+                        case CLOUDY:
+                            return visitor.visitCloudy();
+                        case UNKNOWN:
+                        default:
+                            return visitor.visitUnknown(string);
+                    }
+                }
+
+                @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+                public static MyEnum valueOf(String value) {
+                    switch (value) {
+                        case "SUNNY":
+                            return SUNNY;
+                        case "RAINING":
+                            return RAINING;
+                        case "SNOWING":
+                            return SNOWING;
+                        case "CLOUDY":
+                            return CLOUDY;
+                        default:
+                            return new MyEnum(Value.UNKNOWN, value);
+                    }
+                }
+
+                public enum Value {
+                    SUNNY,
+
+                    CLOUDY,
+
+                    RAINING,
+
+                    SNOWING,
+
+                    UNKNOWN
+                }
+
+                public interface Visitor<T> {
+                    T visitSunny();
+
+                    T visitCloudy();
+
+                    T visitRaining();
+
+                    T visitSnowing();
+
+                    T visitUnknown(String unknownType);
                 }
             }
         }

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/InlineEnum1.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/InlineEnum1.java
@@ -3,26 +3,100 @@
  */
 package com.seed.object.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum InlineEnum1 {
-    SUNNY("SUNNY"),
+public final class InlineEnum1 {
+    public static final InlineEnum1 SUNNY = new InlineEnum1(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final InlineEnum1 RAINING = new InlineEnum1(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final InlineEnum1 SNOWING = new InlineEnum1(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final InlineEnum1 CLOUDY = new InlineEnum1(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    InlineEnum1(String value) {
+    private final String string;
+
+    InlineEnum1(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof InlineEnum1 && this.string.equals(((InlineEnum1) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static InlineEnum1 valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new InlineEnum1(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/UndiscriminatedUnion1InlineEnum1.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/UndiscriminatedUnion1InlineEnum1.java
@@ -3,26 +3,106 @@
  */
 package com.seed.object.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum UndiscriminatedUnion1InlineEnum1 {
-    SUNNY("SUNNY"),
+public final class UndiscriminatedUnion1InlineEnum1 {
+    public static final UndiscriminatedUnion1InlineEnum1 SUNNY =
+            new UndiscriminatedUnion1InlineEnum1(Value.SUNNY, "SUNNY");
 
-    CLOUDY("CLOUDY"),
+    public static final UndiscriminatedUnion1InlineEnum1 RAINING =
+            new UndiscriminatedUnion1InlineEnum1(Value.RAINING, "RAINING");
 
-    RAINING("RAINING"),
+    public static final UndiscriminatedUnion1InlineEnum1 SNOWING =
+            new UndiscriminatedUnion1InlineEnum1(Value.SNOWING, "SNOWING");
 
-    SNOWING("SNOWING");
+    public static final UndiscriminatedUnion1InlineEnum1 CLOUDY =
+            new UndiscriminatedUnion1InlineEnum1(Value.CLOUDY, "CLOUDY");
 
-    private final String value;
+    private final Value value;
 
-    UndiscriminatedUnion1InlineEnum1(String value) {
+    private final String string;
+
+    UndiscriminatedUnion1InlineEnum1(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof UndiscriminatedUnion1InlineEnum1
+                        && this.string.equals(((UndiscriminatedUnion1InlineEnum1) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case SUNNY:
+                return visitor.visitSunny();
+            case RAINING:
+                return visitor.visitRaining();
+            case SNOWING:
+                return visitor.visitSnowing();
+            case CLOUDY:
+                return visitor.visitCloudy();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static UndiscriminatedUnion1InlineEnum1 valueOf(String value) {
+        switch (value) {
+            case "SUNNY":
+                return SUNNY;
+            case "RAINING":
+                return RAINING;
+            case "SNOWING":
+                return SNOWING;
+            case "CLOUDY":
+                return CLOUDY;
+            default:
+                return new UndiscriminatedUnion1InlineEnum1(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SUNNY,
+
+        CLOUDY,
+
+        RAINING,
+
+        SNOWING,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSunny();
+
+        T visitCloudy();
+
+        T visitRaining();
+
+        T visitSnowing();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/requests/GetUndiscriminatedUnionRequest.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/requests/GetUndiscriminatedUnionRequest.java
@@ -1397,25 +1397,99 @@ public final class GetUndiscriminatedUnionRequest {
             }
         }
 
-        public enum InlineEnum1 {
-            SUNNY("SUNNY"),
+        public static final class InlineEnum1 {
+            public static final InlineEnum1 SUNNY = new InlineEnum1(Value.SUNNY, "SUNNY");
 
-            CLOUDY("CLOUDY"),
+            public static final InlineEnum1 RAINING = new InlineEnum1(Value.RAINING, "RAINING");
 
-            RAINING("RAINING"),
+            public static final InlineEnum1 SNOWING = new InlineEnum1(Value.SNOWING, "SNOWING");
 
-            SNOWING("SNOWING");
+            public static final InlineEnum1 CLOUDY = new InlineEnum1(Value.CLOUDY, "CLOUDY");
 
-            private final String value;
+            private final Value value;
 
-            InlineEnum1(String value) {
+            private final String string;
+
+            InlineEnum1(Value value, String string) {
                 this.value = value;
+                this.string = string;
             }
 
-            @JsonValue
+            public Value getEnumValue() {
+                return value;
+            }
+
             @java.lang.Override
+            @JsonValue
             public String toString() {
-                return this.value;
+                return this.string;
+            }
+
+            @java.lang.Override
+            public boolean equals(Object other) {
+                return (this == other)
+                        || (other instanceof InlineEnum1 && this.string.equals(((InlineEnum1) other).string));
+            }
+
+            @java.lang.Override
+            public int hashCode() {
+                return this.string.hashCode();
+            }
+
+            public <T> T visit(Visitor<T> visitor) {
+                switch (value) {
+                    case SUNNY:
+                        return visitor.visitSunny();
+                    case RAINING:
+                        return visitor.visitRaining();
+                    case SNOWING:
+                        return visitor.visitSnowing();
+                    case CLOUDY:
+                        return visitor.visitCloudy();
+                    case UNKNOWN:
+                    default:
+                        return visitor.visitUnknown(string);
+                }
+            }
+
+            @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+            public static InlineEnum1 valueOf(String value) {
+                switch (value) {
+                    case "SUNNY":
+                        return SUNNY;
+                    case "RAINING":
+                        return RAINING;
+                    case "SNOWING":
+                        return SNOWING;
+                    case "CLOUDY":
+                        return CLOUDY;
+                    default:
+                        return new InlineEnum1(Value.UNKNOWN, value);
+                }
+            }
+
+            public enum Value {
+                SUNNY,
+
+                CLOUDY,
+
+                RAINING,
+
+                SNOWING,
+
+                UNKNOWN
+            }
+
+            public interface Visitor<T> {
+                T visitSunny();
+
+                T visitCloudy();
+
+                T visitRaining();
+
+                T visitSnowing();
+
+                T visitUnknown(String unknownType);
             }
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/RootType1.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/RootType1.java
@@ -5,6 +5,7 @@ package com.seed.object.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -856,25 +857,98 @@ public final class RootType1 {
                 }
             }
 
-            public enum MyEnum {
-                SUNNY("SUNNY"),
+            public static final class MyEnum {
+                public static final MyEnum SUNNY = new MyEnum(Value.SUNNY, "SUNNY");
 
-                CLOUDY("CLOUDY"),
+                public static final MyEnum RAINING = new MyEnum(Value.RAINING, "RAINING");
 
-                RAINING("RAINING"),
+                public static final MyEnum SNOWING = new MyEnum(Value.SNOWING, "SNOWING");
 
-                SNOWING("SNOWING");
+                public static final MyEnum CLOUDY = new MyEnum(Value.CLOUDY, "CLOUDY");
 
-                private final String value;
+                private final Value value;
 
-                MyEnum(String value) {
+                private final String string;
+
+                MyEnum(Value value, String string) {
                     this.value = value;
+                    this.string = string;
                 }
 
-                @JsonValue
+                public Value getEnumValue() {
+                    return value;
+                }
+
                 @java.lang.Override
+                @JsonValue
                 public String toString() {
-                    return this.value;
+                    return this.string;
+                }
+
+                @java.lang.Override
+                public boolean equals(Object other) {
+                    return (this == other) || (other instanceof MyEnum && this.string.equals(((MyEnum) other).string));
+                }
+
+                @java.lang.Override
+                public int hashCode() {
+                    return this.string.hashCode();
+                }
+
+                public <T> T visit(Visitor<T> visitor) {
+                    switch (value) {
+                        case SUNNY:
+                            return visitor.visitSunny();
+                        case RAINING:
+                            return visitor.visitRaining();
+                        case SNOWING:
+                            return visitor.visitSnowing();
+                        case CLOUDY:
+                            return visitor.visitCloudy();
+                        case UNKNOWN:
+                        default:
+                            return visitor.visitUnknown(string);
+                    }
+                }
+
+                @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+                public static MyEnum valueOf(String value) {
+                    switch (value) {
+                        case "SUNNY":
+                            return SUNNY;
+                        case "RAINING":
+                            return RAINING;
+                        case "SNOWING":
+                            return SNOWING;
+                        case "CLOUDY":
+                            return CLOUDY;
+                        default:
+                            return new MyEnum(Value.UNKNOWN, value);
+                    }
+                }
+
+                public enum Value {
+                    SUNNY,
+
+                    CLOUDY,
+
+                    RAINING,
+
+                    SNOWING,
+
+                    UNKNOWN
+                }
+
+                public interface Visitor<T> {
+                    T visitSunny();
+
+                    T visitCloudy();
+
+                    T visitRaining();
+
+                    T visitSnowing();
+
+                    T visitUnknown(String unknownType);
                 }
             }
         }

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/resources/service/types/ResourceStatus.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/resources/service/types/ResourceStatus.java
@@ -3,22 +3,81 @@
  */
 package com.seed.mixedCase.resources.service.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ResourceStatus {
-    ACTIVE("ACTIVE"),
+public final class ResourceStatus {
+    public static final ResourceStatus ACTIVE = new ResourceStatus(Value.ACTIVE, "ACTIVE");
 
-    INACTIVE("INACTIVE");
+    public static final ResourceStatus INACTIVE = new ResourceStatus(Value.INACTIVE, "INACTIVE");
 
-    private final String value;
+    private final Value value;
 
-    ResourceStatus(String value) {
+    private final String string;
+
+    ResourceStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ResourceStatus && this.string.equals(((ResourceStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case ACTIVE:
+                return visitor.visitActive();
+            case INACTIVE:
+                return visitor.visitInactive();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ResourceStatus valueOf(String value) {
+        switch (value) {
+            case "ACTIVE":
+                return ACTIVE;
+            case "INACTIVE":
+                return INACTIVE;
+            default:
+                return new ResourceStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        ACTIVE,
+
+        INACTIVE,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitActive();
+
+        T visitInactive();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/types/Operand.java
+++ b/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/types/Operand.java
@@ -3,24 +3,90 @@
  */
 package com.seed.multiLineDocs.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Operand {
-    GREATER_THAN(">"),
+public final class Operand {
+    public static final Operand LESS_THAN = new Operand(Value.LESS_THAN, "less_than");
 
-    EQUAL_TO("="),
+    public static final Operand EQUAL_TO = new Operand(Value.EQUAL_TO, "=");
 
-    LESS_THAN("less_than");
+    public static final Operand GREATER_THAN = new Operand(Value.GREATER_THAN, ">");
 
-    private final String value;
+    private final Value value;
 
-    Operand(String value) {
+    private final String string;
+
+    Operand(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Operand && this.string.equals(((Operand) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LESS_THAN:
+                return visitor.visitLessThan();
+            case EQUAL_TO:
+                return visitor.visitEqualTo();
+            case GREATER_THAN:
+                return visitor.visitGreaterThan();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Operand valueOf(String value) {
+        switch (value) {
+            case "less_than":
+                return LESS_THAN;
+            case "=":
+                return EQUAL_TO;
+            case ">":
+                return GREATER_THAN;
+            default:
+                return new Operand(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        GREATER_THAN,
+
+        EQUAL_TO,
+
+        LESS_THAN,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitGreaterThan();
+
+        T visitEqualTo();
+
+        T visitLessThan();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserRole.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserRole.java
@@ -3,26 +3,100 @@
  */
 package com.seed.nullableOptional.resources.nullableoptional.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum UserRole {
-    ADMIN("ADMIN"),
+public final class UserRole {
+    public static final UserRole MODERATOR = new UserRole(Value.MODERATOR, "MODERATOR");
 
-    USER("USER"),
+    public static final UserRole USER = new UserRole(Value.USER, "USER");
 
-    GUEST("GUEST"),
+    public static final UserRole GUEST = new UserRole(Value.GUEST, "GUEST");
 
-    MODERATOR("MODERATOR");
+    public static final UserRole ADMIN = new UserRole(Value.ADMIN, "ADMIN");
 
-    private final String value;
+    private final Value value;
 
-    UserRole(String value) {
+    private final String string;
+
+    UserRole(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof UserRole && this.string.equals(((UserRole) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case MODERATOR:
+                return visitor.visitModerator();
+            case USER:
+                return visitor.visitUser();
+            case GUEST:
+                return visitor.visitGuest();
+            case ADMIN:
+                return visitor.visitAdmin();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static UserRole valueOf(String value) {
+        switch (value) {
+            case "MODERATOR":
+                return MODERATOR;
+            case "USER":
+                return USER;
+            case "GUEST":
+                return GUEST;
+            case "ADMIN":
+                return ADMIN;
+            default:
+                return new UserRole(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        ADMIN,
+
+        USER,
+
+        GUEST,
+
+        MODERATOR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitAdmin();
+
+        T visitUser();
+
+        T visitGuest();
+
+        T visitModerator();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserStatus.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserStatus.java
@@ -3,26 +3,100 @@
  */
 package com.seed.nullableOptional.resources.nullableoptional.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum UserStatus {
-    ACTIVE("active"),
+public final class UserStatus {
+    public static final UserStatus ACTIVE = new UserStatus(Value.ACTIVE, "active");
 
-    INACTIVE("inactive"),
+    public static final UserStatus INACTIVE = new UserStatus(Value.INACTIVE, "inactive");
 
-    SUSPENDED("suspended"),
+    public static final UserStatus DELETED = new UserStatus(Value.DELETED, "deleted");
 
-    DELETED("deleted");
+    public static final UserStatus SUSPENDED = new UserStatus(Value.SUSPENDED, "suspended");
 
-    private final String value;
+    private final Value value;
 
-    UserStatus(String value) {
+    private final String string;
+
+    UserStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof UserStatus && this.string.equals(((UserStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case ACTIVE:
+                return visitor.visitActive();
+            case INACTIVE:
+                return visitor.visitInactive();
+            case DELETED:
+                return visitor.visitDeleted();
+            case SUSPENDED:
+                return visitor.visitSuspended();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static UserStatus valueOf(String value) {
+        switch (value) {
+            case "active":
+                return ACTIVE;
+            case "inactive":
+                return INACTIVE;
+            case "deleted":
+                return DELETED;
+            case "suspended":
+                return SUSPENDED;
+            default:
+                return new UserStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        ACTIVE,
+
+        INACTIVE,
+
+        SUSPENDED,
+
+        DELETED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitActive();
+
+        T visitInactive();
+
+        T visitSuspended();
+
+        T visitDeleted();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserRole.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserRole.java
@@ -3,26 +3,100 @@
  */
 package com.seed.nullableOptional.resources.nullableoptional.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum UserRole {
-    ADMIN("ADMIN"),
+public final class UserRole {
+    public static final UserRole MODERATOR = new UserRole(Value.MODERATOR, "MODERATOR");
 
-    USER("USER"),
+    public static final UserRole USER = new UserRole(Value.USER, "USER");
 
-    GUEST("GUEST"),
+    public static final UserRole GUEST = new UserRole(Value.GUEST, "GUEST");
 
-    MODERATOR("MODERATOR");
+    public static final UserRole ADMIN = new UserRole(Value.ADMIN, "ADMIN");
 
-    private final String value;
+    private final Value value;
 
-    UserRole(String value) {
+    private final String string;
+
+    UserRole(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof UserRole && this.string.equals(((UserRole) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case MODERATOR:
+                return visitor.visitModerator();
+            case USER:
+                return visitor.visitUser();
+            case GUEST:
+                return visitor.visitGuest();
+            case ADMIN:
+                return visitor.visitAdmin();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static UserRole valueOf(String value) {
+        switch (value) {
+            case "MODERATOR":
+                return MODERATOR;
+            case "USER":
+                return USER;
+            case "GUEST":
+                return GUEST;
+            case "ADMIN":
+                return ADMIN;
+            default:
+                return new UserRole(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        ADMIN,
+
+        USER,
+
+        GUEST,
+
+        MODERATOR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitAdmin();
+
+        T visitUser();
+
+        T visitGuest();
+
+        T visitModerator();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserStatus.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserStatus.java
@@ -3,26 +3,100 @@
  */
 package com.seed.nullableOptional.resources.nullableoptional.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum UserStatus {
-    ACTIVE("active"),
+public final class UserStatus {
+    public static final UserStatus ACTIVE = new UserStatus(Value.ACTIVE, "active");
 
-    INACTIVE("inactive"),
+    public static final UserStatus INACTIVE = new UserStatus(Value.INACTIVE, "inactive");
 
-    SUSPENDED("suspended"),
+    public static final UserStatus DELETED = new UserStatus(Value.DELETED, "deleted");
 
-    DELETED("deleted");
+    public static final UserStatus SUSPENDED = new UserStatus(Value.SUSPENDED, "suspended");
 
-    private final String value;
+    private final Value value;
 
-    UserStatus(String value) {
+    private final String string;
+
+    UserStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof UserStatus && this.string.equals(((UserStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case ACTIVE:
+                return visitor.visitActive();
+            case INACTIVE:
+                return visitor.visitInactive();
+            case DELETED:
+                return visitor.visitDeleted();
+            case SUSPENDED:
+                return visitor.visitSuspended();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static UserStatus valueOf(String value) {
+        switch (value) {
+            case "active":
+                return ACTIVE;
+            case "inactive":
+                return INACTIVE;
+            case "deleted":
+                return DELETED;
+            case "suspended":
+                return SUSPENDED;
+            default:
+                return new UserStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        ACTIVE,
+
+        INACTIVE,
+
+        SUSPENDED,
+
+        DELETED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitActive();
+
+        T visitInactive();
+
+        T visitSuspended();
+
+        T visitDeleted();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/resources/file/types/FileInfo.java
+++ b/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/resources/file/types/FileInfo.java
@@ -3,22 +3,80 @@
  */
 package com.seed.objectsWithImports.resources.file.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum FileInfo {
-    REGULAR("REGULAR"),
+public final class FileInfo {
+    public static final FileInfo REGULAR = new FileInfo(Value.REGULAR, "REGULAR");
 
-    DIRECTORY("DIRECTORY");
+    public static final FileInfo DIRECTORY = new FileInfo(Value.DIRECTORY, "DIRECTORY");
 
-    private final String value;
+    private final Value value;
 
-    FileInfo(String value) {
+    private final String string;
+
+    FileInfo(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof FileInfo && this.string.equals(((FileInfo) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case REGULAR:
+                return visitor.visitRegular();
+            case DIRECTORY:
+                return visitor.visitDirectory();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static FileInfo valueOf(String value) {
+        switch (value) {
+            case "REGULAR":
+                return REGULAR;
+            case "DIRECTORY":
+                return DIRECTORY;
+            default:
+                return new FileInfo(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        REGULAR,
+
+        DIRECTORY,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRegular();
+
+        T visitDirectory();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/pagination/src/main/java/com/seed/pagination/resources/complex/types/MultipleFilterSearchRequestOperator.java
+++ b/seed/java-sdk/pagination/src/main/java/com/seed/pagination/resources/complex/types/MultipleFilterSearchRequestOperator.java
@@ -3,22 +3,84 @@
  */
 package com.seed.pagination.resources.complex.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MultipleFilterSearchRequestOperator {
-    AND("AND"),
+public final class MultipleFilterSearchRequestOperator {
+    public static final MultipleFilterSearchRequestOperator AND =
+            new MultipleFilterSearchRequestOperator(Value.AND, "AND");
 
-    OR("OR");
+    public static final MultipleFilterSearchRequestOperator OR =
+            new MultipleFilterSearchRequestOperator(Value.OR, "OR");
 
-    private final String value;
+    private final Value value;
 
-    MultipleFilterSearchRequestOperator(String value) {
+    private final String string;
+
+    MultipleFilterSearchRequestOperator(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof MultipleFilterSearchRequestOperator
+                        && this.string.equals(((MultipleFilterSearchRequestOperator) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case AND:
+                return visitor.visitAnd();
+            case OR:
+                return visitor.visitOr();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static MultipleFilterSearchRequestOperator valueOf(String value) {
+        switch (value) {
+            case "AND":
+                return AND;
+            case "OR":
+                return OR;
+            default:
+                return new MultipleFilterSearchRequestOperator(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        AND,
+
+        OR,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitAnd();
+
+        T visitOr();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/pagination/src/main/java/com/seed/pagination/resources/complex/types/SingleFilterSearchRequestOperator.java
+++ b/seed/java-sdk/pagination/src/main/java/com/seed/pagination/resources/complex/types/SingleFilterSearchRequestOperator.java
@@ -3,38 +3,171 @@
  */
 package com.seed.pagination.resources.complex.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum SingleFilterSearchRequestOperator {
-    EQUALS("="),
+public final class SingleFilterSearchRequestOperator {
+    public static final SingleFilterSearchRequestOperator GREATER_THAN =
+            new SingleFilterSearchRequestOperator(Value.GREATER_THAN, ">");
 
-    NOT_EQUALS("!="),
+    public static final SingleFilterSearchRequestOperator DOES_NOT_CONTAIN =
+            new SingleFilterSearchRequestOperator(Value.DOES_NOT_CONTAIN, "!~");
 
-    IN("IN"),
+    public static final SingleFilterSearchRequestOperator IN = new SingleFilterSearchRequestOperator(Value.IN, "IN");
 
-    NOT_IN("NIN"),
+    public static final SingleFilterSearchRequestOperator CONTAINS =
+            new SingleFilterSearchRequestOperator(Value.CONTAINS, "~");
 
-    LESS_THAN("<"),
+    public static final SingleFilterSearchRequestOperator LESS_THAN =
+            new SingleFilterSearchRequestOperator(Value.LESS_THAN, "<");
 
-    GREATER_THAN(">"),
+    public static final SingleFilterSearchRequestOperator EQUALS =
+            new SingleFilterSearchRequestOperator(Value.EQUALS, "=");
 
-    CONTAINS("~"),
+    public static final SingleFilterSearchRequestOperator NOT_EQUALS =
+            new SingleFilterSearchRequestOperator(Value.NOT_EQUALS, "!=");
 
-    DOES_NOT_CONTAIN("!~"),
+    public static final SingleFilterSearchRequestOperator ENDS_WITH =
+            new SingleFilterSearchRequestOperator(Value.ENDS_WITH, "$");
 
-    STARTS_WITH("^"),
+    public static final SingleFilterSearchRequestOperator STARTS_WITH =
+            new SingleFilterSearchRequestOperator(Value.STARTS_WITH, "^");
 
-    ENDS_WITH("$");
+    public static final SingleFilterSearchRequestOperator NOT_IN =
+            new SingleFilterSearchRequestOperator(Value.NOT_IN, "NIN");
 
-    private final String value;
+    private final Value value;
 
-    SingleFilterSearchRequestOperator(String value) {
+    private final String string;
+
+    SingleFilterSearchRequestOperator(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof SingleFilterSearchRequestOperator
+                        && this.string.equals(((SingleFilterSearchRequestOperator) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case GREATER_THAN:
+                return visitor.visitGreaterThan();
+            case DOES_NOT_CONTAIN:
+                return visitor.visitDoesNotContain();
+            case IN:
+                return visitor.visitIn();
+            case CONTAINS:
+                return visitor.visitContains();
+            case LESS_THAN:
+                return visitor.visitLessThan();
+            case EQUALS:
+                return visitor.visitEquals();
+            case NOT_EQUALS:
+                return visitor.visitNotEquals();
+            case ENDS_WITH:
+                return visitor.visitEndsWith();
+            case STARTS_WITH:
+                return visitor.visitStartsWith();
+            case NOT_IN:
+                return visitor.visitNotIn();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SingleFilterSearchRequestOperator valueOf(String value) {
+        switch (value) {
+            case ">":
+                return GREATER_THAN;
+            case "!~":
+                return DOES_NOT_CONTAIN;
+            case "IN":
+                return IN;
+            case "~":
+                return CONTAINS;
+            case "<":
+                return LESS_THAN;
+            case "=":
+                return EQUALS;
+            case "!=":
+                return NOT_EQUALS;
+            case "$":
+                return ENDS_WITH;
+            case "^":
+                return STARTS_WITH;
+            case "NIN":
+                return NOT_IN;
+            default:
+                return new SingleFilterSearchRequestOperator(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        EQUALS,
+
+        NOT_EQUALS,
+
+        IN,
+
+        NOT_IN,
+
+        LESS_THAN,
+
+        GREATER_THAN,
+
+        CONTAINS,
+
+        DOES_NOT_CONTAIN,
+
+        STARTS_WITH,
+
+        ENDS_WITH,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitEquals();
+
+        T visitNotEquals();
+
+        T visitIn();
+
+        T visitNotIn();
+
+        T visitLessThan();
+
+        T visitGreaterThan();
+
+        T visitContains();
+
+        T visitDoesNotContain();
+
+        T visitStartsWith();
+
+        T visitEndsWith();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/pagination/src/main/java/com/seed/pagination/resources/users/types/Order.java
+++ b/seed/java-sdk/pagination/src/main/java/com/seed/pagination/resources/users/types/Order.java
@@ -3,22 +3,80 @@
  */
 package com.seed.pagination.resources.users.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Order {
-    ASC("asc"),
+public final class Order {
+    public static final Order ASC = new Order(Value.ASC, "asc");
 
-    DESC("desc");
+    public static final Order DESC = new Order(Value.DESC, "desc");
 
-    private final String value;
+    private final Value value;
 
-    Order(String value) {
+    private final String string;
+
+    Order(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Order && this.string.equals(((Order) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case ASC:
+                return visitor.visitAsc();
+            case DESC:
+                return visitor.visitDesc();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Order valueOf(String value) {
+        switch (value) {
+            case "asc":
+                return ASC;
+            case "desc":
+                return DESC;
+            default:
+                return new Order(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        ASC,
+
+        DESC,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitAsc();
+
+        T visitDesc();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/Language.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/Language.java
@@ -3,24 +3,90 @@
  */
 package com.seed.trace.resources.commons.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Language {
-    JAVA("JAVA"),
+public final class Language {
+    public static final Language JAVASCRIPT = new Language(Value.JAVASCRIPT, "JAVASCRIPT");
 
-    JAVASCRIPT("JAVASCRIPT"),
+    public static final Language PYTHON = new Language(Value.PYTHON, "PYTHON");
 
-    PYTHON("PYTHON");
+    public static final Language JAVA = new Language(Value.JAVA, "JAVA");
 
-    private final String value;
+    private final Value value;
 
-    Language(String value) {
+    private final String string;
+
+    Language(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Language && this.string.equals(((Language) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case JAVASCRIPT:
+                return visitor.visitJavascript();
+            case PYTHON:
+                return visitor.visitPython();
+            case JAVA:
+                return visitor.visitJava();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Language valueOf(String value) {
+        switch (value) {
+            case "JAVASCRIPT":
+                return JAVASCRIPT;
+            case "PYTHON":
+                return PYTHON;
+            case "JAVA":
+                return JAVA;
+            default:
+                return new Language(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        JAVA,
+
+        JAVASCRIPT,
+
+        PYTHON,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitJava();
+
+        T visitJavascript();
+
+        T visitPython();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/migration/types/MigrationStatus.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/migration/types/MigrationStatus.java
@@ -3,24 +3,91 @@
  */
 package com.seed.trace.resources.migration.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MigrationStatus {
-    RUNNING("RUNNING"),
+public final class MigrationStatus {
+    public static final MigrationStatus FAILED = new MigrationStatus(Value.FAILED, "FAILED");
 
-    FAILED("FAILED"),
+    public static final MigrationStatus FINISHED = new MigrationStatus(Value.FINISHED, "FINISHED");
 
-    FINISHED("FINISHED");
+    public static final MigrationStatus RUNNING = new MigrationStatus(Value.RUNNING, "RUNNING");
 
-    private final String value;
+    private final Value value;
 
-    MigrationStatus(String value) {
+    private final String string;
+
+    MigrationStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof MigrationStatus && this.string.equals(((MigrationStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case FAILED:
+                return visitor.visitFailed();
+            case FINISHED:
+                return visitor.visitFinished();
+            case RUNNING:
+                return visitor.visitRunning();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static MigrationStatus valueOf(String value) {
+        switch (value) {
+            case "FAILED":
+                return FAILED;
+            case "FINISHED":
+                return FINISHED;
+            case "RUNNING":
+                return RUNNING;
+            default:
+                return new MigrationStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        RUNNING,
+
+        FAILED,
+
+        FINISHED,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitRunning();
+
+        T visitFailed();
+
+        T visitFinished();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/ReservedKeywordEnum.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/ReservedKeywordEnum.java
@@ -3,22 +3,81 @@
  */
 package com.seed.trace.resources.playlist.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ReservedKeywordEnum {
-    IS("is"),
+public final class ReservedKeywordEnum {
+    public static final ReservedKeywordEnum IS = new ReservedKeywordEnum(Value.IS, "is");
 
-    AS("as");
+    public static final ReservedKeywordEnum AS = new ReservedKeywordEnum(Value.AS, "as");
 
-    private final String value;
+    private final Value value;
 
-    ReservedKeywordEnum(String value) {
+    private final String string;
+
+    ReservedKeywordEnum(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ReservedKeywordEnum && this.string.equals(((ReservedKeywordEnum) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case IS:
+                return visitor.visitIs();
+            case AS:
+                return visitor.visitAs();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ReservedKeywordEnum valueOf(String value) {
+        switch (value) {
+            case "is":
+                return IS;
+            case "as":
+                return AS;
+            default:
+                return new ReservedKeywordEnum(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        IS,
+
+        AS,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitIs();
+
+        T visitAs();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/ExecutionSessionStatus.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/ExecutionSessionStatus.java
@@ -3,30 +3,128 @@
  */
 package com.seed.trace.resources.submission.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ExecutionSessionStatus {
-    CREATING_CONTAINER("CREATING_CONTAINER"),
+public final class ExecutionSessionStatus {
+    public static final ExecutionSessionStatus LIVE_CONTAINER =
+            new ExecutionSessionStatus(Value.LIVE_CONTAINER, "LIVE_CONTAINER");
 
-    PROVISIONING_CONTAINER("PROVISIONING_CONTAINER"),
+    public static final ExecutionSessionStatus PENDING_CONTAINER =
+            new ExecutionSessionStatus(Value.PENDING_CONTAINER, "PENDING_CONTAINER");
 
-    PENDING_CONTAINER("PENDING_CONTAINER"),
+    public static final ExecutionSessionStatus CREATING_CONTAINER =
+            new ExecutionSessionStatus(Value.CREATING_CONTAINER, "CREATING_CONTAINER");
 
-    RUNNING_CONTAINER("RUNNING_CONTAINER"),
+    public static final ExecutionSessionStatus PROVISIONING_CONTAINER =
+            new ExecutionSessionStatus(Value.PROVISIONING_CONTAINER, "PROVISIONING_CONTAINER");
 
-    LIVE_CONTAINER("LIVE_CONTAINER"),
+    public static final ExecutionSessionStatus RUNNING_CONTAINER =
+            new ExecutionSessionStatus(Value.RUNNING_CONTAINER, "RUNNING_CONTAINER");
 
-    FAILED_TO_LAUNCH("FAILED_TO_LAUNCH");
+    public static final ExecutionSessionStatus FAILED_TO_LAUNCH =
+            new ExecutionSessionStatus(Value.FAILED_TO_LAUNCH, "FAILED_TO_LAUNCH");
 
-    private final String value;
+    private final Value value;
 
-    ExecutionSessionStatus(String value) {
+    private final String string;
+
+    ExecutionSessionStatus(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof ExecutionSessionStatus
+                        && this.string.equals(((ExecutionSessionStatus) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LIVE_CONTAINER:
+                return visitor.visitLiveContainer();
+            case PENDING_CONTAINER:
+                return visitor.visitPendingContainer();
+            case CREATING_CONTAINER:
+                return visitor.visitCreatingContainer();
+            case PROVISIONING_CONTAINER:
+                return visitor.visitProvisioningContainer();
+            case RUNNING_CONTAINER:
+                return visitor.visitRunningContainer();
+            case FAILED_TO_LAUNCH:
+                return visitor.visitFailedToLaunch();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ExecutionSessionStatus valueOf(String value) {
+        switch (value) {
+            case "LIVE_CONTAINER":
+                return LIVE_CONTAINER;
+            case "PENDING_CONTAINER":
+                return PENDING_CONTAINER;
+            case "CREATING_CONTAINER":
+                return CREATING_CONTAINER;
+            case "PROVISIONING_CONTAINER":
+                return PROVISIONING_CONTAINER;
+            case "RUNNING_CONTAINER":
+                return RUNNING_CONTAINER;
+            case "FAILED_TO_LAUNCH":
+                return FAILED_TO_LAUNCH;
+            default:
+                return new ExecutionSessionStatus(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        CREATING_CONTAINER,
+
+        PROVISIONING_CONTAINER,
+
+        PENDING_CONTAINER,
+
+        RUNNING_CONTAINER,
+
+        LIVE_CONTAINER,
+
+        FAILED_TO_LAUNCH,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitCreatingContainer();
+
+        T visitProvisioningContainer();
+
+        T visitPendingContainer();
+
+        T visitRunningContainer();
+
+        T visitLiveContainer();
+
+        T visitFailedToLaunch();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/RunningSubmissionState.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/RunningSubmissionState.java
@@ -3,28 +3,117 @@
  */
 package com.seed.trace.resources.submission.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum RunningSubmissionState {
-    QUEUEING_SUBMISSION("QUEUEING_SUBMISSION"),
+public final class RunningSubmissionState {
+    public static final RunningSubmissionState RUNNING_SUBMISSION =
+            new RunningSubmissionState(Value.RUNNING_SUBMISSION, "RUNNING_SUBMISSION");
 
-    KILLING_HISTORICAL_SUBMISSIONS("KILLING_HISTORICAL_SUBMISSIONS"),
+    public static final RunningSubmissionState KILLING_HISTORICAL_SUBMISSIONS =
+            new RunningSubmissionState(Value.KILLING_HISTORICAL_SUBMISSIONS, "KILLING_HISTORICAL_SUBMISSIONS");
 
-    WRITING_SUBMISSION_TO_FILE("WRITING_SUBMISSION_TO_FILE"),
+    public static final RunningSubmissionState COMPILING_SUBMISSION =
+            new RunningSubmissionState(Value.COMPILING_SUBMISSION, "COMPILING_SUBMISSION");
 
-    COMPILING_SUBMISSION("COMPILING_SUBMISSION"),
+    public static final RunningSubmissionState QUEUEING_SUBMISSION =
+            new RunningSubmissionState(Value.QUEUEING_SUBMISSION, "QUEUEING_SUBMISSION");
 
-    RUNNING_SUBMISSION("RUNNING_SUBMISSION");
+    public static final RunningSubmissionState WRITING_SUBMISSION_TO_FILE =
+            new RunningSubmissionState(Value.WRITING_SUBMISSION_TO_FILE, "WRITING_SUBMISSION_TO_FILE");
 
-    private final String value;
+    private final Value value;
 
-    RunningSubmissionState(String value) {
+    private final String string;
+
+    RunningSubmissionState(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof RunningSubmissionState
+                        && this.string.equals(((RunningSubmissionState) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case RUNNING_SUBMISSION:
+                return visitor.visitRunningSubmission();
+            case KILLING_HISTORICAL_SUBMISSIONS:
+                return visitor.visitKillingHistoricalSubmissions();
+            case COMPILING_SUBMISSION:
+                return visitor.visitCompilingSubmission();
+            case QUEUEING_SUBMISSION:
+                return visitor.visitQueueingSubmission();
+            case WRITING_SUBMISSION_TO_FILE:
+                return visitor.visitWritingSubmissionToFile();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static RunningSubmissionState valueOf(String value) {
+        switch (value) {
+            case "RUNNING_SUBMISSION":
+                return RUNNING_SUBMISSION;
+            case "KILLING_HISTORICAL_SUBMISSIONS":
+                return KILLING_HISTORICAL_SUBMISSIONS;
+            case "COMPILING_SUBMISSION":
+                return COMPILING_SUBMISSION;
+            case "QUEUEING_SUBMISSION":
+                return QUEUEING_SUBMISSION;
+            case "WRITING_SUBMISSION_TO_FILE":
+                return WRITING_SUBMISSION_TO_FILE;
+            default:
+                return new RunningSubmissionState(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        QUEUEING_SUBMISSION,
+
+        KILLING_HISTORICAL_SUBMISSIONS,
+
+        WRITING_SUBMISSION_TO_FILE,
+
+        COMPILING_SUBMISSION,
+
+        RUNNING_SUBMISSION,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitQueueingSubmission();
+
+        T visitKillingHistoricalSubmissions();
+
+        T visitWritingSubmissionToFile();
+
+        T visitCompilingSubmission();
+
+        T visitRunningSubmission();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/SubmissionTypeEnum.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/SubmissionTypeEnum.java
@@ -3,20 +3,71 @@
  */
 package com.seed.trace.resources.submission.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum SubmissionTypeEnum {
-    TEST("TEST");
+public final class SubmissionTypeEnum {
+    public static final SubmissionTypeEnum TEST = new SubmissionTypeEnum(Value.TEST, "TEST");
 
-    private final String value;
+    private final Value value;
 
-    SubmissionTypeEnum(String value) {
+    private final String string;
+
+    SubmissionTypeEnum(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other)
+                || (other instanceof SubmissionTypeEnum && this.string.equals(((SubmissionTypeEnum) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case TEST:
+                return visitor.visitTest();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SubmissionTypeEnum valueOf(String value) {
+        switch (value) {
+            case "TEST":
+                return TEST;
+            default:
+                return new SubmissionTypeEnum(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        TEST,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitTest();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/resources/union/types/KeyType.java
+++ b/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/resources/union/types/KeyType.java
@@ -3,22 +3,80 @@
  */
 package com.seed.undiscriminatedUnions.resources.union.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum KeyType {
-    NAME("name"),
+public final class KeyType {
+    public static final KeyType NAME = new KeyType(Value.NAME, "name");
 
-    VALUE("value");
+    public static final KeyType VALUE = new KeyType(Value.VALUE, "value");
 
-    private final String value;
+    private final Value value;
 
-    KeyType(String value) {
+    private final String string;
+
+    KeyType(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof KeyType && this.string.equals(((KeyType) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case NAME:
+                return visitor.visitName();
+            case VALUE:
+                return visitor.visitValue();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static KeyType valueOf(String value) {
+        switch (value) {
+            case "name":
+                return NAME;
+            case "value":
+                return VALUE;
+            default:
+                return new KeyType(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        NAME,
+
+        VALUE,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitName();
+
+        T visitValue();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/validation/src/main/java/com/seed/validation/types/Shape.java
+++ b/seed/java-sdk/validation/src/main/java/com/seed/validation/types/Shape.java
@@ -3,24 +3,90 @@
  */
 package com.seed.validation.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Shape {
-    SQUARE("SQUARE"),
+public final class Shape {
+    public static final Shape TRIANGLE = new Shape(Value.TRIANGLE, "TRIANGLE");
 
-    CIRCLE("CIRCLE"),
+    public static final Shape CIRCLE = new Shape(Value.CIRCLE, "CIRCLE");
 
-    TRIANGLE("TRIANGLE");
+    public static final Shape SQUARE = new Shape(Value.SQUARE, "SQUARE");
 
-    private final String value;
+    private final Value value;
 
-    Shape(String value) {
+    private final String string;
+
+    Shape(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof Shape && this.string.equals(((Shape) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case TRIANGLE:
+                return visitor.visitTriangle();
+            case CIRCLE:
+                return visitor.visitCircle();
+            case SQUARE:
+                return visitor.visitSquare();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Shape valueOf(String value) {
+        switch (value) {
+            case "TRIANGLE":
+                return TRIANGLE;
+            case "CIRCLE":
+                return CIRCLE;
+            case "SQUARE":
+                return SQUARE;
+            default:
+                return new Shape(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        SQUARE,
+
+        CIRCLE,
+
+        TRIANGLE,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitSquare();
+
+        T visitCircle();
+
+        T visitTriangle();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ApiVersion.java
+++ b/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ApiVersion.java
@@ -3,24 +3,90 @@
  */
 package com.seed.version.core;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ApiVersion {
-    _1_0_0("1.0.0"),
+public final class ApiVersion {
+    public static final ApiVersion _1_0_0 = new ApiVersion(Value._1_0_0, "1.0.0");
 
-    _2_0_0("2.0.0"),
+    public static final ApiVersion LATEST = new ApiVersion(Value.LATEST, "latest");
 
-    LATEST("latest");
+    public static final ApiVersion _2_0_0 = new ApiVersion(Value._2_0_0, "2.0.0");
 
-    private final String value;
+    private final Value value;
 
-    ApiVersion(String value) {
+    private final String string;
+
+    ApiVersion(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ApiVersion && this.string.equals(((ApiVersion) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case _1_0_0:
+                return visitor.visit_100();
+            case LATEST:
+                return visitor.visitLatest();
+            case _2_0_0:
+                return visitor.visit_200();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ApiVersion valueOf(String value) {
+        switch (value) {
+            case "1.0.0":
+                return _1_0_0;
+            case "latest":
+                return LATEST;
+            case "2.0.0":
+                return _2_0_0;
+            default:
+                return new ApiVersion(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        _1_0_0,
+
+        _2_0_0,
+
+        LATEST,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visit_100();
+
+        T visit_200();
+
+        T visitLatest();
+
+        T visitUnknown(String unknownType);
     }
 }

--- a/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ApiVersion.java
+++ b/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ApiVersion.java
@@ -3,24 +3,90 @@
  */
 package com.seed.version.core;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ApiVersion {
-    V_1("1.0.0"),
+public final class ApiVersion {
+    public static final ApiVersion LATEST = new ApiVersion(Value.LATEST, "latest");
 
-    V_2("2.0.0"),
+    public static final ApiVersion V_1 = new ApiVersion(Value.V_1, "1.0.0");
 
-    LATEST("latest");
+    public static final ApiVersion V_2 = new ApiVersion(Value.V_2, "2.0.0");
 
-    private final String value;
+    private final Value value;
 
-    ApiVersion(String value) {
+    private final String string;
+
+    ApiVersion(Value value, String string) {
         this.value = value;
+        this.string = string;
     }
 
-    @JsonValue
+    public Value getEnumValue() {
+        return value;
+    }
+
     @java.lang.Override
+    @JsonValue
     public String toString() {
-        return this.value;
+        return this.string;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        return (this == other) || (other instanceof ApiVersion && this.string.equals(((ApiVersion) other).string));
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        switch (value) {
+            case LATEST:
+                return visitor.visitLatest();
+            case V_1:
+                return visitor.visitV1();
+            case V_2:
+                return visitor.visitV2();
+            case UNKNOWN:
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ApiVersion valueOf(String value) {
+        switch (value) {
+            case "latest":
+                return LATEST;
+            case "1.0.0":
+                return V_1;
+            case "2.0.0":
+                return V_2;
+            default:
+                return new ApiVersion(Value.UNKNOWN, value);
+        }
+    }
+
+    public enum Value {
+        V_1,
+
+        V_2,
+
+        LATEST,
+
+        UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitV1();
+
+        T visitV2();
+
+        T visitLatest();
+
+        T visitUnknown(String unknownType);
     }
 }


### PR DESCRIPTION
## Description
Linear ticket:https://linear.app/buildwithfern/issue/FER-6475/major-version-release-to-made-to-enable-forward-compatible-enums-by

**BREAKING CHANGE**: Forward-compatible enums are now enabled by default in the Java SDK generator.

This changes the structure of generated enum types from traditional Java enums to class-based enums that gracefully handle unknown variants.

## Changes

- Set `enable-forward-compatible-enums` default to `true` in `JavaSdkCustomConfig.java`
- Bump version to 3.0.0 to signal breaking change
- Generated SDKs will no longer throw errors for unknown enum values