### PR TITLE
fix(ci): Ignore package manager files for seed comparison checks

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -91,6 +91,7 @@ runs:
       id: validate
       shell: bash
       run: |
+        # Validate results
         # Split the input string into an array
         IFS=',' read -ra FOLDERS <<< "${{ inputs.validation-exclude-paths }}"
 
@@ -107,7 +108,9 @@ runs:
         # Remove trailing space
         EXCLUDE_STRING=$(echo "$EXCLUDE_STRING" | sed 's/[[:space:]]*$//')
 
-        echo "Built git diff exclude string as: $EXCLUDE_STRING"
+        echo "exclude_string=$EXCLUDE_STRING" >> $GITHUB_OUTPUT
+        echo "Built git diff exclude string as: "
+        echo "$EXCLUDE_STRING"
 
         if git --no-pager diff --exit-code -- $EXCLUDE_STRING; then
           echo "Results are valid, saving to cache if not already."

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: "Whether to skip caching and always regenerate"
     required: false
     default: "true"
+  validation-exclude-paths:
+    description: "Comma separated list of paths to exclude from validation step, typically package manager/lock files"
+    required: false
+    default: "seed/*/.mock/*"
 
 runs:
   using: "composite"
@@ -90,7 +94,25 @@ runs:
       id: validate
       shell: bash
       run: |
-        if git --no-pager diff --exit-code -- ":(exclude)seed/*/.mock/*"; then
+        # Split the input string into an array
+        IFS=',' read -ra FOLDERS <<< "${{ inputs.validation-exclude-paths }}"
+
+        # Build the exclude string
+        EXCLUDE_STRING=""
+        for folder in "${FOLDERS[@]}"; do
+          # Trim whitespace
+          folder=$(echo "$folder" | xargs)
+          if [ -n "$folder" ]; then
+            EXCLUDE_STRING="$EXCLUDE_STRING\":(exclude)$folder\" "
+          fi
+        done
+
+        # Remove trailing space
+        EXCLUDE_STRING=$(echo "$EXCLUDE_STRING" | sed 's/[[:space:]]*$//')
+
+        echo "Built git diff exclude string as: $EXCLUDE_STRING"
+
+        if git --no-pager diff --exit-code -- $EXCLUDE_STRING; then
           echo "Results are valid, saving to cache if not already."
           echo "valid=true" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -87,10 +87,7 @@ runs:
           ${{ inputs.allow-unexpected-failures == 'true' && '--allow-unexpected-failures' || '' }}
 
     - name: Validate results
-      # Note: generators added here are currently generating non-deterministic results.
-      # To get us to a passing state in CI, add them as exceptions here. This is not
-      # a long-term solution.
-      if: inputs.validate-git-diff == 'true' && !(inputs.generator-name == 'go-sdk' || inputs.generator-name == 'typescript-sdk' || inputs.generator-name == 'ruby-sdk-v2')
+      if: inputs.validate-git-diff == 'true'
       id: validate
       shell: bash
       run: |

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -152,7 +152,6 @@ jobs:
         with:
           generator-name: ruby-sdk-v2
           generator-path: generators/ruby-v2
-          validate-git-diff: true
           validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
 
   pydantic-model:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -152,6 +152,8 @@ jobs:
         with:
           generator-name: ruby-sdk-v2
           generator-path: generators/ruby-v2
+          validate-git-diff: true
+          validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
 
   pydantic-model:
     runs-on: Seed

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -389,6 +389,9 @@ jobs:
         with:
           generator-name: go-sdk
           generator-path: generators/go generators/go-v2
+          # TODO FER-6487: package.go is not a lockfile, but it is a generated file that is not deterministic
+          # Once that file is made deterministic, we can remove this exclude path
+          exclude-paths: "seed/*/.mock/*,seed/go-sdk/reserved-keywords/package.go"
 
   csharp-model:
     runs-on: Seed

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -189,6 +189,7 @@ jobs:
         with:
           generator-name: python-sdk
           generator-path: generators/python
+          exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
 
   fastapi:
     runs-on: Seed

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -189,7 +189,7 @@ jobs:
         with:
           generator-name: python-sdk
           generator-path: generators/python
-          exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
+          validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
 
   fastapi:
     runs-on: Seed
@@ -391,7 +391,7 @@ jobs:
           generator-path: generators/go generators/go-v2
           # TODO FER-6487: package.go is not a lockfile, but it is a generated file that is not deterministic
           # Once that file is made deterministic, we can remove this exclude path
-          exclude-paths: "seed/*/.mock/*,seed/go-sdk/reserved-keywords/package.go"
+          validation-exclude-paths: "seed/*/.mock/*,seed/go-sdk/reserved-keywords/package.go"
 
   csharp-model:
     runs-on: Seed

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -204,6 +204,7 @@ jobs:
           generator-path: generators/ruby-v2
           validate-git-diff: false
           allow-unexpected-failures: true
+          validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
 
       - name: Create Pull Request
         id: cpr

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -204,7 +204,6 @@ jobs:
           generator-path: generators/ruby-v2
           validate-git-diff: false
           allow-unexpected-failures: true
-          validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
 
       - name: Create Pull Request
         id: cpr

--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -44,4 +44,5 @@ allowedFailures:
   - enum
   - file-upload
   - http-head
+  - query-parameters-openapi-as-objects
   - version

--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -41,6 +41,7 @@ allowedFailures:
   - circular-references
   - circular-references-advanced
   # unknown
+  - alias
   - enum
   - file-upload
   - http-head

--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -44,3 +44,4 @@ allowedFailures:
   - enum
   - file-upload
   - http-head
+  - version

--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -46,3 +46,4 @@ allowedFailures:
   - http-head
   - query-parameters-openapi-as-objects
   - version
+  - version-no-default

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -411,4 +411,16 @@ allowedFailures:
   - examples:retain-original-casing
 
   # unknown
+  - file-upload:no-custom-config
+  - file-upload:inline
+  - file-upload:serde
+  - file-upload:wrapper
+  - file-upload:form-data-node16
+  - http-head
+  - idempotency-headers
+  - imdb:no-custom-config
+  - imdb:omit-undefined
+  - imdb:noScripts
+  - imdb:branded-string-aliases
+  - license
   - ts-inline-types:inline

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -423,4 +423,5 @@ allowedFailures:
   - imdb:noScripts
   - imdb:branded-string-aliases
   - license
+  - oauth-client-credentials:no-custom-config
   - ts-inline-types:inline

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -381,12 +381,14 @@ allowedFailures:
   - error-property
   - error-property:union-utils
   - errors
+  - exhaustive:bundle
   - exhaustive:custom-package-json
   - exhaustive:dev-dependencies
   - exhaustive:never-throw-errors
   - extends
   - file-download:file-download-response-headers
   - file-download:no-custom-config
+  - file-download:stream
   - file-download:wrapper
   - literal
   - mixed-case:no-custom-config


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6476/ci-ignore-package-manager-files-for-seed-comparison-check
Adding new failures to allowed list
Creating a path to input non-deterministic files to the cached-seed action file so that it can ignore those files for the validation step (typically for lock files)

## Changes Made
- ts-sdk seed.yml updates for new allowed failures
- php-model seed.yml updates for new allowed failures
- cached-seed.yml added new input for files to skip at validation step
- workflows/seed.yml and workflows/update-seed.yml updated to pass nondeterministic files

## Testing
Testing on CI here: https://github.com/fern-api/fern/pull/9280 then cleaned up and made this PR
