### PR TITLE
fix(go): add back support for "downloadFiles" output mode to go-v2 projects

### DIFF
--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -3,6 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { BaseGoCustomConfigSchema, resolveRootImportPath } from "@fern-api/go-ast";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { OutputMode } from "@fern-fern/generator-exec-sdk/api";
 import { mkdir, readFile } from "fs/promises";
 import path from "path";
 import { AbstractGoGeneratorContext } from "../context/AbstractGoGeneratorContext";
@@ -117,7 +118,7 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
     }
 
     private getModuleConfig({ config }: { config: FernGeneratorExec.config.GeneratorConfig }): ModuleConfig {
-        const outputMode = config.output.mode;
+        const outputMode = config.output.mode as OutputMode;
         switch (outputMode.type) {
             case "github":
             case "downloadFiles":

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -3,7 +3,6 @@ import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { BaseGoCustomConfigSchema, resolveRootImportPath } from "@fern-api/go-ast";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { GithubOutputMode, OutputMode } from "@fern-fern/generator-exec-sdk/api";
 import { mkdir, readFile } from "fs/promises";
 import path from "path";
 import { AbstractGoGeneratorContext } from "../context/AbstractGoGeneratorContext";

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -54,9 +54,6 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
 
     public async writeGoMod(): Promise<void> {
         const moduleConfig = this.getModuleConfig({ config: this.context.config });
-        if (moduleConfig == null) {
-            return;
-        }
         // We write the go.mod file to disk upfront so that 'go fmt' can be run on the project.
         const moduleConfigWriter = new ModuleConfigWriter({ context: this.context, moduleConfig });
         await this.writeRawFile(moduleConfigWriter.generate());
@@ -120,39 +117,25 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
         });
     }
 
-    private getModuleConfig({
-        config
-    }: {
-        config: FernGeneratorExec.config.GeneratorConfig;
-    }): ModuleConfig | undefined {
-        const githubConfig = this.getGithubOutputMode({ outputMode: config.output.mode });
-        if (githubConfig == null && this.context.customConfig.module == null) {
-            return undefined;
-        }
-        if (githubConfig == null) {
-            return this.context.customConfig.module;
-        }
-        const modulePath = resolveRootImportPath({ config, customConfig: this.context.customConfig });
-        if (this.context.customConfig.module == null) {
-            return {
-                ...ModuleConfig.DEFAULT,
-                path: modulePath
-            };
-        }
-        return {
-            path: modulePath,
-            version: this.context.customConfig.module.version,
-            imports: this.context.customConfig.module.imports ?? ModuleConfig.DEFAULT.imports
-        };
-    }
-
-    private getGithubOutputMode({ outputMode }: { outputMode: OutputMode }): GithubOutputMode | undefined {
+    private getModuleConfig({ config }: { config: FernGeneratorExec.config.GeneratorConfig }): ModuleConfig {
+        const outputMode = config.output.mode;
         switch (outputMode.type) {
             case "github":
-                return outputMode;
-            case "publish":
             case "downloadFiles":
-                return undefined;
+            case "publish": {
+                const modulePath = resolveRootImportPath({ config, customConfig: this.context.customConfig });
+                if (this.context.customConfig.module == null) {
+                    return {
+                        ...ModuleConfig.DEFAULT,
+                        path: modulePath
+                    };
+                }
+                return {
+                    path: this.context.customConfig.module.path,
+                    version: this.context.customConfig.module.version ?? ModuleConfig.DEFAULT.version,
+                    imports: this.context.customConfig.module.imports ?? ModuleConfig.DEFAULT.imports
+                };
+            }
             default:
                 assertNever(outputMode);
         }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.8.1
+  changelogEntry:
+    - summary: |
+        Add back support for local filesystem output mode.
+      type: feat
+  createdAt: "2025-09-10"
+  irVersion: 59
+
 - version: 1.8.0
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Add back support for local filesystem output mode.
-      type: feat
+      type: fix
   createdAt: "2025-09-10"
   irVersion: 59
 


### PR DESCRIPTION
## Description
Linear tickets:
1. [FER-6041](https://linear.app/buildwithfern/issue/FER-6041/go-go-generator-version-154-seems-to-fail-when-output-mode-is-local)
2. [FER-6259](https://linear.app/buildwithfern/issue/FER-6259/go-go-generator-hangs-if-both-configoutput-and-configgithub-arent)

For the golang generator output mode of "downloadFiles" (equivalent to "local-file-system") was [suppported in the v1 generator](https://github.com/fern-api/fern/blob/9c241c93086693a45d14c74006c7ff7bc7b151b5/generators/go/internal/cmd/cmd.go#L390) but support was not ported over to the v2 generator. This fix adds back in support which is as simple as respecting the existing `importPath` or `customConfig.module` flags and then proceeding with the files download.

## Testing
1. I tested this using [FROND](https://github.com/fern-api/frond) to prove that local-file-system mode works using:
```
pnpm frond generator go-sdk 2.0.0
pnpm frond generate auth0 --group go-sdk --generator-local
``` 
