### PR TITLE
feat(cli): enable google log in

### DIFF
--- a/packages/cli/auth/src/index.ts
+++ b/packages/cli/auth/src/index.ts
@@ -2,6 +2,7 @@ export { type FernOrganizationToken, type FernToken, type FernUserToken } from "
 export { createOrganizationIfDoesNotExist } from "./orgs/createOrganizationIfDoesNotExist";
 export { getOrganizationNameValidationError } from "./orgs/getOrganizationNameValidationError";
 export { getAccessToken, getToken, getUserToken } from "./persistence/getToken";
+export { removeToken } from "./persistence/removeToken";
 export { storeToken } from "./persistence/storeToken";
 export { getCurrentUser } from "./users/getCurrentUser";
 export { getUserIdFromToken } from "./verify/getPropertiesFromJwtToken";

--- a/packages/cli/auth/src/persistence/removeToken.ts
+++ b/packages/cli/auth/src/persistence/removeToken.ts
@@ -1,0 +1,14 @@
+import { unlink } from "fs/promises";
+import { getPathToTokenFile } from "./getPathToTokenFile";
+
+export async function removeToken(): Promise<void> {
+    const pathToTokenFile = getPathToTokenFile();
+    try {
+        await unlink(pathToTokenFile);
+    } catch (error) {
+        // If the file doesn't exist, that's fine - the user is already logged out
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+        }
+    }
+}

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -13,7 +13,7 @@ import { ContainerRunner, haveSameNullishness, undefinedIfNullish, undefinedIfSo
 import { AbsoluteFilePath, cwd, doesPathExist, isURL, resolve } from "@fern-api/fs-utils";
 import { initializeAPI, initializeDocs, initializeWithMintlify, initializeWithReadme } from "@fern-api/init";
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
-import { askToLogin, login } from "@fern-api/login";
+import { askToLogin, login, logout } from "@fern-api/login";
 import { protocGenFern } from "@fern-api/protoc-gen-fern";
 import { FernCliError, LoggableFernCliError } from "@fern-api/task-context";
 import getPort from "get-port";
@@ -175,6 +175,7 @@ async function tryRunCli(cliContext: CliContext) {
     addRegisterCommand(cli, cliContext);
     addRegisterV2Command(cli, cliContext);
     addLoginCommand(cli, cliContext);
+    addLogoutCommand(cli, cliContext);
     addFormatCommand(cli, cliContext);
     addWriteDefinitionCommand(cli, cliContext);
     addDocsCommand(cli, cliContext);
@@ -1042,6 +1043,22 @@ function addLoginCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     command: "fern login"
                 });
                 await login(context, { useDeviceCodeFlow: argv.deviceCode });
+            });
+        }
+    );
+}
+
+function addLogoutCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+    cli.command(
+        "logout",
+        "Log out of Fern",
+        (yargs) => yargs,
+        async () => {
+            await cliContext.runTask(async (context) => {
+                await cliContext.instrumentPostHogEvent({
+                    command: "fern logout"
+                });
+                await logout(context);
             });
         }
     );

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add google sign in, and logout command
+      type: fix
+  irVersion: 59
+  createdAt: "2025-09-10"
+  version: 0.75.2
+
+- changelogEntry:
+    - summary: |
         Availability is now inherited by children when set in the `docs.yml` navigation.
       type: fix
   irVersion: 59

--- a/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
@@ -129,5 +129,5 @@ function constructAuth0Url({
         audience
     });
     const url = `https://${auth0Domain}/authorize?${queryParams.toString()}`;
-    return url
+    return url;
 }

--- a/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
@@ -124,10 +124,10 @@ function constructAuth0Url({
     const queryParams = new URLSearchParams({
         client_id: auth0ClientId,
         response_type: "code",
-        connection: "github",
         scope: "openid profile email offline_access",
         redirect_uri: origin,
         audience
     });
-    return `https://${auth0Domain}/authorize?${queryParams.toString()}`;
+    const url = `https://${auth0Domain}/authorize?${queryParams.toString()}`;
+    return url
 }

--- a/packages/cli/login/src/constants.ts
+++ b/packages/cli/login/src/constants.ts
@@ -1,0 +1,3 @@
+export const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN ?? "fern-prod.us.auth0.com";
+export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID ?? "syaWnk6SjNoo5xBf1omfvziU3q7085lh";
+export const VENUS_AUDIENCE = process.env.VENUS_AUDIENCE ?? "venus-prod";

--- a/packages/cli/login/src/index.ts
+++ b/packages/cli/login/src/index.ts
@@ -1,2 +1,3 @@
 export { askToLogin } from "./askToLogin";
 export { login } from "./login";
+export { logout } from "./logout";

--- a/packages/cli/login/src/login.ts
+++ b/packages/cli/login/src/login.ts
@@ -5,11 +5,7 @@ import chalk from "chalk";
 
 import { doAuth0DeviceAuthorizationFlow } from "./auth0-login/doAuth0DeviceAuthorizationFlow";
 import { doAuth0LoginFlow } from "./auth0-login/doAuth0LoginFlow";
-
-// these are client-side safe values
-const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN ?? "fern-prod.us.auth0.com";
-const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID ?? "syaWnk6SjNoo5xBf1omfvziU3q7085lh";
-const VENUS_AUDIENCE = process.env.VENUS_AUDIENCE ?? "venus-prod";
+import { AUTH0_CLIENT_ID, AUTH0_DOMAIN, VENUS_AUDIENCE } from "./constants";
 
 export async function login(
     context: TaskContext,

--- a/packages/cli/login/src/logout.ts
+++ b/packages/cli/login/src/logout.ts
@@ -2,7 +2,7 @@ import { isLoggedIn, removeToken } from "@fern-api/auth";
 import { TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import open from "open";
-import { AUTH0_CLIENT_ID } from "./constants";
+import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from "./constants";
 
 export async function logout(context: TaskContext): Promise<void> {
     await context.instrumentPostHogEvent({

--- a/packages/cli/login/src/logout.ts
+++ b/packages/cli/login/src/logout.ts
@@ -1,0 +1,51 @@
+import { isLoggedIn, removeToken } from "@fern-api/auth";
+import { TaskContext } from "@fern-api/task-context";
+import chalk from "chalk";
+import open from "open";
+import { AUTH0_CLIENT_ID } from "./constants";
+
+export async function logout(context: TaskContext): Promise<void> {
+    await context.instrumentPostHogEvent({
+        command: "Logout initiated"
+    });
+
+    const wasLoggedIn = await isLoggedIn();
+
+    if (!wasLoggedIn) {
+        context.logger.info(chalk.yellow("You are not currently logged in."));
+        return;
+    }
+
+    // Remove the local token first
+    await removeToken();
+
+    // Open the Auth0 logout URL to clear the Auth0 session
+    const logoutUrl = constructAuth0LogoutUrl();
+
+    context.logger.info(chalk.blue("Opening browser to complete logout..."));
+
+    try {
+        await open(logoutUrl);
+        context.logger.info(chalk.green("Successfully logged out! You can close the browser window."));
+    } catch (error) {
+        context.logger.warn(
+            chalk.yellow(
+                "Could not open browser automatically. Please visit this URL to complete logout:\n" + logoutUrl
+            )
+        );
+    }
+
+    await context.instrumentPostHogEvent({
+        command: "Logout successful"
+    });
+}
+
+function constructAuth0LogoutUrl(): string {
+    // We don't specify a returnTo URL since we don't have a web app to return to
+    // The user will see Auth0's default logout confirmation page
+    const queryParams = new URLSearchParams({
+        client_id: AUTH0_CLIENT_ID
+    });
+
+    return `https://${AUTH0_DOMAIN}/v2/logout?${queryParams.toString()}`;
+}


### PR DESCRIPTION
## Description

CLI users can now optionally login with google instead of github.

## Changes Made

The `connection` URL query  parameter is no longer hard-coded to `github`, which will give users the option to login with either github or google.

<img width="878" height="782" alt="image" src="https://github.com/user-attachments/assets/b5dc6fdd-f4b9-4eda-a20e-12c8e9a222ac" />


## Testing

Tested locally using `pnpm fern-local:build` and 
```
FERN_NO_VERSION_REDIRECTION=true node --enable-source-maps ./packages/cli/cli/dist/local/cli.cjs login
```
