### PR TITLE
fix(python): never duplicate params

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.28.3
+  changelogEntry:
+    - summary: |
+        Never duplicate parameters in client constructors
+      type: fix
+  createdAt: "2025-09-10"
+  irVersion: 59
+
 - version: 4.28.2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/publisher.py
+++ b/generators/python/src/fern_python/cli/publisher.py
@@ -25,7 +25,7 @@ class Publisher:
 
     def run_ruff_check_fix(self, path: Optional[str] = None, *, cwd: Optional[str] = None) -> None:
         if self._should_fix:
-            command = ["poetry", "run", "ruff", "check", "--fix", "--no-cache"]
+            command = ["poetry", "run", "ruff", "check", "--fix", "--no-cache", "--ignore", "E741"]
             if path is not None:
                 command.append(path)
             self._run_command(

--- a/generators/python/src/fern_python/codegen/ast/nodes/declarations/function/function_signature.py
+++ b/generators/python/src/fern_python/codegen/ast/nodes/declarations/function/function_signature.py
@@ -38,8 +38,11 @@ class FunctionSignature(AstNode):
     def write(self, writer: NodeWriter, should_write_as_snippet: Optional[bool] = None) -> None:
         writer.write("(")
         just_wrote_parameter = False
-
+        written_params = set()
         for parameter in self.parameters:
+            if parameter.name in written_params:
+                continue
+            written_params.add(parameter.name)
             if just_wrote_parameter:
                 writer.write(", ")
             writer.write_node(parameter)
@@ -58,6 +61,9 @@ class FunctionSignature(AstNode):
             just_wrote_parameter = True
 
         for named_parameter in self.named_parameters:
+            if named_parameter.name in written_params:
+                continue
+            written_params.add(named_parameter.name)
             if just_wrote_parameter:
                 writer.write(", ")
             writer.write_node(named_parameter)

--- a/generators/python/src/fern_python/codegen/ast/nodes/expressions/callable_invocation/callable_invocation.py
+++ b/generators/python/src/fern_python/codegen/ast/nodes/expressions/callable_invocation/callable_invocation.py
@@ -35,7 +35,11 @@ class CallableInvocation(AstNode):
                 writer.write(", ")
             arg.write(writer=writer, should_write_as_snippet=should_write_as_snippet)
             just_wrote_argument = True
+        written_params = set()
         for i, (name, value) in enumerate(self.kwargs):
+            if name in written_params:
+                continue
+            written_params.add(name)
             if just_wrote_argument:
                 writer.write(", ")
             writer.write(f"{name}=")

--- a/generators/python/src/fern_python/generators/sdk/client_generator/client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/client_generator.py
@@ -98,10 +98,15 @@ class ClientGenerator(BaseWrappedClientGenerator[ConstructorParameter]):
 
     def _get_write_constructor_body(self, *, is_async: bool) -> CodeWriterFunction:
         def _write_constructor_body(writer: AST.NodeWriter) -> None:
-            kwargs = [
-                (param.constructor_parameter_name, AST.Expression(param.constructor_parameter_name))
-                for param in self._get_constructor_parameters(is_async=is_async)
-            ]
+            # Avoid repeating parameters by tracking names
+            seen_param_names = set()
+            kwargs = []
+            for param in self._get_constructor_parameters(is_async=is_async):
+                if param.constructor_parameter_name not in seen_param_names:
+                    kwargs.append(
+                        (param.constructor_parameter_name, AST.Expression(param.constructor_parameter_name))
+                    )
+                    seen_param_names.add(param.constructor_parameter_name)
 
             # Initialize the raw client with the client_wrapper
             writer.write_node(

--- a/generators/python/src/fern_python/generators/sdk/client_generator/client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/client_generator.py
@@ -103,9 +103,7 @@ class ClientGenerator(BaseWrappedClientGenerator[ConstructorParameter]):
             kwargs = []
             for param in self._get_constructor_parameters(is_async=is_async):
                 if param.constructor_parameter_name not in seen_param_names:
-                    kwargs.append(
-                        (param.constructor_parameter_name, AST.Expression(param.constructor_parameter_name))
-                    )
+                    kwargs.append((param.constructor_parameter_name, AST.Expression(param.constructor_parameter_name)))
                     seen_param_names.add(param.constructor_parameter_name)
 
             # Initialize the raw client with the client_wrapper

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -302,9 +302,7 @@ class ClientWrapperGenerator:
             param_assignments = []
             for param in constructor_parameters:
                 if param.constructor_parameter_name not in seen_param_names:
-                    param_assignments.append(
-                        f"{param.constructor_parameter_name}={param.constructor_parameter_name}"
-                    )
+                    param_assignments.append(f"{param.constructor_parameter_name}={param.constructor_parameter_name}")
                     seen_param_names.add(param.constructor_parameter_name)
             writer.write_line(
                 "super().__init__("

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -297,13 +297,19 @@ class ClientWrapperGenerator:
         has_base_url = get_client_wrapper_url_type(ir=self._context.ir) == ClientWrapperUrlStorage.URL
 
         def _write_derived_client_wrapper_constructor_body(writer: AST.NodeWriter) -> None:
+            # Avoid repeating parameters by tracking names
+            seen_param_names = set()
+            param_assignments = []
+            for param in constructor_parameters:
+                if param.constructor_parameter_name not in seen_param_names:
+                    param_assignments.append(
+                        f"{param.constructor_parameter_name}={param.constructor_parameter_name}"
+                    )
+                    seen_param_names.add(param.constructor_parameter_name)
             writer.write_line(
                 "super().__init__("
                 + ", ".join(
-                    [
-                        f"{param.constructor_parameter_name}={param.constructor_parameter_name}"
-                        for param in constructor_parameters
-                    ]
+                    param_assignments
                     + [
                         f"{literal_header.constructor_parameter_name}={literal_header.constructor_parameter_name}"
                         for literal_header in literal_headers

--- a/generators/python/tests/sdk/test_custom_config.py
+++ b/generators/python/tests/sdk/test_custom_config.py
@@ -16,27 +16,37 @@ def test_parse_obj_override() -> None:
 
     top_level_custom_config = SDKCustomConfig.parse_obj(top_level_payload)
     pydantic_config_custom_config = SDKCustomConfig.parse_obj(pydantic_config_level_payload)
-    
+
     assert top_level_custom_config.use_typeddict_requests is True
     assert pydantic_config_custom_config.pydantic_config.use_typeddict_requests is True
 
-    assert top_level_custom_config.use_typeddict_requests == top_level_custom_config.pydantic_config.use_typeddict_requests
-    
-    assert pydantic_config_custom_config.use_typeddict_requests == pydantic_config_custom_config.pydantic_config.use_typeddict_requests
+    assert (
+        top_level_custom_config.use_typeddict_requests == top_level_custom_config.pydantic_config.use_typeddict_requests
+    )
+
+    assert (
+        pydantic_config_custom_config.use_typeddict_requests
+        == pydantic_config_custom_config.pydantic_config.use_typeddict_requests
+    )
 
     assert top_level_custom_config.use_typeddict_requests == pydantic_config_custom_config.use_typeddict_requests
-    assert top_level_custom_config.pydantic_config.use_typeddict_requests == pydantic_config_custom_config.pydantic_config.use_typeddict_requests
+    assert (
+        top_level_custom_config.pydantic_config.use_typeddict_requests
+        == pydantic_config_custom_config.pydantic_config.use_typeddict_requests
+    )
 
 
 def test_parse_wrapped_aliases() -> None:
     v1 = {
-         "pydantic_config": {
+        "pydantic_config": {
             "version": "v1",
             "wrapped_aliases": True,
         },
     }
     sdk_custom_config = SDKCustomConfig.parse_obj(v1)
-    assert sdk_custom_config.pydantic_config.version == "v1" and sdk_custom_config.pydantic_config.wrapped_aliases is True
+    assert (
+        sdk_custom_config.pydantic_config.version == "v1" and sdk_custom_config.pydantic_config.wrapped_aliases is True
+    )
 
     v2 = {
         "pydantic_config": {
@@ -46,7 +56,8 @@ def test_parse_wrapped_aliases() -> None:
     }
     sdk_custom_config_v2 = SDKCustomConfig.parse_obj(v2)
     assert (
-        sdk_custom_config_v2.pydantic_config.version == "v2" and sdk_custom_config_v2.pydantic_config.wrapped_aliases is True
+        sdk_custom_config_v2.pydantic_config.version == "v2"
+        and sdk_custom_config_v2.pydantic_config.wrapped_aliases is True
     )
     both = {
         "pydantic_config": {
@@ -54,5 +65,8 @@ def test_parse_wrapped_aliases() -> None:
             "wrapped_aliases": True,
         },
     }
-    with pytest.raises(pydantic.ValidationError, match="Wrapped aliases are only supported in Pydantic V1, V1_ON_V2, or V2, please update your `version` field appropriately to continue using wrapped aliases."):
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Wrapped aliases are only supported in Pydantic V1, V1_ON_V2, or V2, please update your `version` field appropriately to continue using wrapped aliases.",
+    ):
         SDKCustomConfig.parse_obj(both)

--- a/generators/python/tests/utils/example_models/types/core/datetime_utils.py
+++ b/generators/python/tests/utils/example_models/types/core/datetime_utils.py
@@ -13,9 +13,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(
-            None
-        ):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/generators/python/tests/utils/example_models/types/core/pydantic_utilities.py
+++ b/generators/python/tests/utils/example_models/types/core/pydantic_utilities.py
@@ -133,9 +133,7 @@ class UniversalBaseModel(pydantic.BaseModel):
                     # If the default values are non-null act like they've been set
                     # This effectively allows exclude_unset to work like exclude_none where
                     # the latter passes through intentionally set none values.
-                    if default is not None or (
-                        "exclude_unset" in kwargs and not kwargs["exclude_unset"]
-                    ):
+                    if default is not None or ("exclude_unset" in kwargs and not kwargs["exclude_unset"]):
                         _fields_set.add(name)
 
                         if default is not None:
@@ -175,9 +173,9 @@ else:
 
 
 def encode_by_type(o: typing.Any) -> typing.Any:
-    encoders_by_class_tuples: typing.Dict[
-        typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]
-    ] = defaultdict(tuple)
+    encoders_by_class_tuples: typing.Dict[typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]] = (
+        defaultdict(tuple)
+    )
     for type_, encoder in encoders_by_type.items():
         encoders_by_class_tuples[encoder] += (type_,)
 
@@ -211,14 +209,10 @@ def universal_root_validator(
     return decorator
 
 
-def universal_field_validator(
-    field_name: str, pre: bool = False
-) -> typing.Callable[[AnyCallable], AnyCallable]:
+def universal_field_validator(field_name: str, pre: bool = False) -> typing.Callable[[AnyCallable], AnyCallable]:
     def decorator(func: AnyCallable) -> AnyCallable:
         if IS_PYDANTIC_V2:
-            return pydantic.field_validator(
-                field_name, mode="before" if pre else "after"
-            )(func)  # type: ignore # Pydantic v2
+            return pydantic.field_validator(field_name, mode="before" if pre else "after")(func)  # type: ignore # Pydantic v2
         else:
             return pydantic.validator(field_name, pre=pre)(func)  # type: ignore # Pydantic v1
 

--- a/generators/python/tests/utils/example_models/types/core/serialization.py
+++ b/generators/python/tests/utils/example_models/types/core/serialization.py
@@ -68,9 +68,7 @@ def convert_and_respect_annotation_metadata(
     ):
         return _convert_mapping(object_, clean_type, direction)
     # TypedDicts
-    if typing_extensions.is_typeddict(clean_type) and isinstance(
-        object_, typing.Mapping
-    ):
+    if typing_extensions.is_typeddict(clean_type) and isinstance(object_, typing.Mapping):
         return _convert_mapping(object_, clean_type, direction)
 
     if (
@@ -183,10 +181,8 @@ def _convert_mapping(
                 object_=value, annotation=type_, direction=direction
             )
         else:
-            converted_object[
-                _alias_key(key, type_, direction, aliases_to_field_names)
-            ] = convert_and_respect_annotation_metadata(
-                object_=value, annotation=type_, direction=direction
+            converted_object[_alias_key(key, type_, direction, aliases_to_field_names)] = (
+                convert_and_respect_annotation_metadata(object_=value, annotation=type_, direction=direction)
             )
     return converted_object
 

--- a/generators/python/tests/utils/example_models/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/example_models/types/core/unchecked_base_model.py
@@ -125,11 +125,11 @@ class UncheckedBaseModel(UniversalBaseModel):
 def _validate_collection_items_compatible(collection: typing.Any, target_type: typing.Type[typing.Any]) -> bool:
     """
     Validate that all items in a collection are compatible with the target type.
-    
+
     Args:
         collection: The collection to validate (list, set, or dict values)
         target_type: The target type to validate against
-        
+
     Returns:
         True if all items are compatible, False otherwise
     """

--- a/generators/python/tests/utils/example_models/types/resources/types/circle.py
+++ b/generators/python/tests/utils/example_models/types/resources/types/circle.py
@@ -10,9 +10,7 @@ class Circle(UncheckedBaseModel):
     radius: float
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/example_models/types/resources/types/object_with_defaults.py
+++ b/generators/python/tests/utils/example_models/types/resources/types/object_with_defaults.py
@@ -16,9 +16,7 @@ class ObjectWithDefaults(UncheckedBaseModel):
     required_string: str = "I neeeeeeeeeed this!"
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/example_models/types/resources/types/object_with_optional_field.py
+++ b/generators/python/tests/utils/example_models/types/resources/types/object_with_optional_field.py
@@ -22,13 +22,9 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     date: typing.Optional[dt.date] = None
     uuid_: typing.Optional[uuid.UUID] = pydantic.Field(alias="uuid", default=None)
     base_64: typing.Optional[str] = pydantic.Field(alias="base64", default=None)
-    list_: typing.Optional[typing.List[str]] = pydantic.Field(
-        alias="list", default=None
-    )
+    list_: typing.Optional[typing.List[str]] = pydantic.Field(alias="list", default=None)
     set_: typing.Optional[typing.Set[str]] = pydantic.Field(alias="set", default=None)
-    map_: typing.Optional[typing.Dict[int, str]] = pydantic.Field(
-        alias="map", default=None
-    )
+    map_: typing.Optional[typing.Dict[int, str]] = pydantic.Field(alias="map", default=None)
     enum: typing.Optional[Color] = None
     union: typing.Optional[Shape] = None
     second_union: typing.Optional[Shape] = None
@@ -36,9 +32,7 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     any: typing.Optional[typing.Any] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/example_models/types/resources/types/shape.py
+++ b/generators/python/tests/utils/example_models/types/resources/types/shape.py
@@ -13,9 +13,7 @@ class Base(UncheckedBaseModel):
     id: str
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -27,9 +25,7 @@ class Shape_Circle(Base):
     radius: float
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -41,15 +37,11 @@ class Shape_Square(Base):
     length: float
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
             extra = pydantic.Extra.allow
 
 
-Shape = typing_extensions.Annotated[
-    typing.Union[Shape_Circle, Shape_Square], UnionMetadata(discriminant="type")
-]
+Shape = typing_extensions.Annotated[typing.Union[Shape_Circle, Shape_Square], UnionMetadata(discriminant="type")]

--- a/generators/python/tests/utils/example_models/types/resources/types/square.py
+++ b/generators/python/tests/utils/example_models/types/resources/types/square.py
@@ -10,9 +10,7 @@ class Square(UncheckedBaseModel):
     length: float
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/test_construct_type.py
+++ b/generators/python/tests/utils/test_construct_type.py
@@ -1,6 +1,3 @@
-
-
-
 from datetime import datetime, date
 from typing import Any, cast, List, Union
 import uuid
@@ -33,7 +30,7 @@ def test_construct_valid() -> None:
         "undiscriminated_union": {"id": "string2", "length": 6.7},
         "enum": "red",
         "any": "something here",
-        "additional_field": "this here"
+        "additional_field": "this here",
     }
     cast_response = cast(ObjectWithOptionalField, construct_type(type_=ObjectWithOptionalField, object_=response))
 
@@ -63,7 +60,10 @@ def test_construct_valid() -> None:
     circle_expectation = Shape_Circle(id="another_string", radius=2.3)
     assert cast_response.second_union is not None
     assert cast_response.second_union.id == circle_expectation.id
-    assert isinstance(cast_response.second_union, Shape_Circle) and cast_response.second_union.radius == circle_expectation.radius
+    assert (
+        isinstance(cast_response.second_union, Shape_Circle)
+        and cast_response.second_union.radius == circle_expectation.radius
+    )
     assert cast_response.second_union.type == circle_expectation.type
 
     assert cast_response.undiscriminated_union is not None
@@ -150,7 +150,7 @@ def test_construct_valid() -> None:
 #     assert cast_response.map_ == "hello world"
 #     assert cast_response.enum == "bread"
 #     assert cast_response.any is None
-    
+
 #     shape_expectation = Shape_Square(id="123", length=1.1)
 #     assert cast_response.union is not None
 #     assert cast_response.union.id == shape_expectation.id
@@ -209,29 +209,21 @@ def test_construct_primitives() -> None:
 def test_construct_list_of_objects() -> None:
     """Test the new functionality for handling lists of objects in undiscriminated unions."""
     # Test with list of Circle objects
-    circle_list_data = [
-        {"radius": 1.5},
-        {"radius": 2.0},
-        {"radius": 3.2}
-    ]
-    
+    circle_list_data = [{"radius": 1.5}, {"radius": 2.0}, {"radius": 3.2}]
+
     result = construct_type(type_=List[Circle], object_=circle_list_data)
-    
+
     assert isinstance(result, list)
     assert len(result) == 3
     for i, circle in enumerate(result):
         assert isinstance(circle, Circle)
         assert circle.radius == circle_list_data[i]["radius"]
-    
+
     # Test with list of Square objects
-    square_list_data = [
-        {"length": 4.0},
-        {"length": 5.5},
-        {"length": 6.1}
-    ]
-    
+    square_list_data = [{"length": 4.0}, {"length": 5.5}, {"length": 6.1}]
+
     result = construct_type(type_=List[Square], object_=square_list_data)
-    
+
     assert isinstance(result, list)
     assert len(result) == 3
     for i, square in enumerate(result):
@@ -242,30 +234,22 @@ def test_construct_list_of_objects() -> None:
 def test_construct_undiscriminated_union_with_list() -> None:
     """Test undiscriminated union handling with lists of objects."""
     from .example_models.types.resources.types import UndiscriminatedShape
-    
+
     # Test with list of Circle objects in undiscriminated union
-    circle_list_data = [
-        {"radius": 1.0},
-        {"radius": 2.5},
-        {"radius": 3.0}
-    ]
-    
+    circle_list_data = [{"radius": 1.0}, {"radius": 2.5}, {"radius": 3.0}]
+
     result = construct_type(type_=List[UndiscriminatedShape], object_=circle_list_data)
-    
+
     assert isinstance(result, list)
     assert len(result) == 3
     for circle in result:
         assert isinstance(circle, Circle)
-    
+
     # Test with list of Square objects in undiscriminated union
-    square_list_data = [
-        {"length": 4.0},
-        {"length": 5.0},
-        {"length": 6.0}
-    ]
-    
+    square_list_data = [{"length": 4.0}, {"length": 5.0}, {"length": 6.0}]
+
     result = construct_type(type_=List[UndiscriminatedShape], object_=square_list_data)
-    
+
     assert isinstance(result, list)
     assert len(result) == 3
     for square in result:
@@ -275,7 +259,7 @@ def test_construct_undiscriminated_union_with_list() -> None:
 def test_construct_mixed_list_in_undiscriminated_union() -> None:
     """Test undiscriminated union handling with mixed list of objects."""
     from .example_models.types.resources.types import UndiscriminatedShape
-    
+
     # Test with mixed list of Circle and Square objects
     mixed_list_data = [
         {"radius": 1.0},  # Circle
@@ -283,22 +267,22 @@ def test_construct_mixed_list_in_undiscriminated_union() -> None:
         {"radius": 2.5},  # Circle
         {"length": 5.0},  # Square
     ]
-    
+
     result = construct_type(type_=List[UndiscriminatedShape], object_=mixed_list_data)
-    
+
     assert isinstance(result, list)
     assert len(result) == 4
-    
+
     # Check that each item is correctly parsed
     assert isinstance(result[0], Circle)
     assert result[0].radius == 1.0
-    
+
     assert isinstance(result[1], Square)
     assert result[1].length == 4.0
-    
+
     assert isinstance(result[2], Circle)
     assert result[2].radius == 2.5
-    
+
     assert isinstance(result[3], Square)
     assert result[3].length == 5.0
 
@@ -306,7 +290,7 @@ def test_construct_mixed_list_in_undiscriminated_union() -> None:
 def test_construct_list_with_invalid_objects() -> None:
     """Test list handling when some objects are invalid."""
     from .example_models.types.resources.types import UndiscriminatedShape
-    
+
     # Test with list containing invalid objects
     invalid_list_data = [
         {"radius": 1.0},  # Valid Circle
@@ -314,17 +298,17 @@ def test_construct_list_with_invalid_objects() -> None:
         {"length": 4.0},  # Valid Square
         {"another_invalid": 123},  # Invalid object
     ]
-    
+
     result = construct_type(type_=List[UndiscriminatedShape], object_=invalid_list_data)
-    
+
     # Should still return a list, but invalid objects might be handled differently
     assert isinstance(result, list)
     assert len(result) == 4
-    
+
     # Valid objects should be correctly parsed
     assert isinstance(result[0], Circle)
     assert result[0].radius == 1.0
-    
+
     assert isinstance(result[2], Square)
     assert result[2].length == 4.0
 
@@ -332,9 +316,9 @@ def test_construct_list_with_invalid_objects() -> None:
 def test_construct_empty_list() -> None:
     """Test handling of empty lists in undiscriminated unions."""
     from .example_models.types.resources.types import UndiscriminatedShape
-        
+
     result = construct_type(type_=List[UndiscriminatedShape], object_=[])
-    
+
     assert isinstance(result, list)
     assert len(result) == 0
 
@@ -343,17 +327,17 @@ def test_construct_list_with_primitive_types() -> None:
     """Test list handling with primitive types (should not use the new list parsing logic)."""
     # Test with list of strings
     string_list_data = ["hello", "world", "test"]
-    
+
     result = construct_type(type_=List[str], object_=string_list_data)
-    
+
     assert isinstance(result, list)
     assert result == string_list_data
-    
+
     # Test with list of integers
     int_list_data = [1, 2, 3, 4, 5]
-    
+
     result = construct_type(type_=List[int], object_=int_list_data)
-    
+
     assert isinstance(result, list)
     assert result == int_list_data
 
@@ -361,28 +345,19 @@ def test_construct_list_with_primitive_types() -> None:
 def test_construct_nested_lists() -> None:
     """Test handling of nested lists with objects."""
     from .example_models.types.resources.types import UndiscriminatedShape
-    
+
     # Test with nested list structure
-    nested_list_data = [
-        [
-            {"radius": 1.0},
-            {"length": 4.0}
-        ],
-        [
-            {"radius": 2.0},
-            {"length": 5.0}
-        ]
-    ]
-    
+    nested_list_data = [[{"radius": 1.0}, {"length": 4.0}], [{"radius": 2.0}, {"length": 5.0}]]
+
     result = construct_type(type_=List[List[UndiscriminatedShape]], object_=nested_list_data)
-    
+
     assert isinstance(result, list)
     assert len(result) == 2
-    
+
     for sublist in result:
         assert isinstance(sublist, list)
         assert len(sublist) == 2
-        
+
         # Check first sublist
         if sublist == result[0]:
             assert isinstance(sublist[0], Circle)
@@ -405,11 +380,7 @@ def test_undiscriminated_union_with_list_types() -> None:
     TestUnion = cast(type[Any], Union[str, List[Circle], List[Square], int])
 
     # Test with list of Circle data - should match List[Circle]
-    circle_list_data = [
-        {"radius": 1.5},
-        {"radius": 2.0},
-        {"radius": 3.2}
-    ]
+    circle_list_data = [{"radius": 1.5}, {"radius": 2.0}, {"radius": 3.2}]
 
     result = construct_type(type_=TestUnion, object_=circle_list_data)
 
@@ -420,11 +391,7 @@ def test_undiscriminated_union_with_list_types() -> None:
         assert circle.radius == circle_list_data[i]["radius"]
 
     # Test with list of Square data - should match List[Square]
-    square_list_data = [
-        {"length": 4.0},
-        {"length": 5.5},
-        {"length": 6.1}
-    ]
+    square_list_data = [{"length": 4.0}, {"length": 5.5}, {"length": 6.1}]
 
     result = construct_type(type_=TestUnion, object_=square_list_data)
 
@@ -525,10 +492,7 @@ def test_undiscriminated_union_list_parsing_failures() -> None:
     assert len(result) == 0
 
     # Test with list containing invalid objects - should fallback gracefully
-    invalid_list_data = [
-        {"invalid_field": "value"},
-        {"another_invalid": 123}
-    ]
+    invalid_list_data = [{"invalid_field": "value"}, {"another_invalid": 123}]
     result = construct_type(type_=TestUnion, object_=invalid_list_data)
     # The result behavior depends on implementation - it should either parse or fallback
     assert result is not None
@@ -547,10 +511,7 @@ def test_nested_undiscriminated_union_with_lists() -> None:
     TestUnion = cast(type[Any], Union[List[List[Circle]], List[Square], str])
 
     # Test with nested list of Circles
-    nested_circle_data = [
-        [{"radius": 1.0}, {"radius": 2.0}],
-        [{"radius": 3.0}, {"radius": 4.0}]
-    ]
+    nested_circle_data = [[{"radius": 1.0}, {"radius": 2.0}], [{"radius": 3.0}, {"radius": 4.0}]]
 
     result = construct_type(type_=TestUnion, object_=nested_circle_data)
 
@@ -609,24 +570,24 @@ def test_undiscriminated_union_list_type_precedence() -> None:
 #         {"radius": 2.0},
 #         {"radius": 3.2}
 #     ]
-    
+
 #     result = construct_type(type_=set[Circle], object_=circle_set_data)
-    
+
 #     assert isinstance(result, set)
 #     assert len(result) == 3
 #     for circle in result:
 #         assert isinstance(circle, Circle)
 #         assert circle.radius in [1.5, 2.0, 3.2]
-    
+
 #     # Test with set of Square objects
 #     square_set_data = [
 #         {"length": 4.0},
 #         {"length": 5.5},
 #         {"length": 6.1}
 #     ]
-    
+
 #     result = construct_type(type_=set[Square], object_=square_set_data)
-    
+
 #     assert isinstance(result, set)
 #     assert len(result) == 3
 #     for square in result:
@@ -644,23 +605,23 @@ def test_undiscriminated_union_list_type_precedence() -> None:
 #         {"radius": 2.5},
 #         {"radius": 3.0}
 #     ]
-    
+
 #     result = construct_type(type_=set[Circle], object_=circle_set_data)
-    
+
 #     assert isinstance(result, set)
 #     assert len(result) == 3
 #     for circle in result:
 #         assert isinstance(circle, Circle)
-    
+
 #     # Test with set of Square objects in undiscriminated union
 #     square_set_data = [
 #         {"length": 4.0},
 #         {"length": 5.0},
 #         {"length": 6.0}
 #     ]
-    
+
 #     result = construct_type(type_=set[Square], object_=square_set_data)
-    
+
 #     assert isinstance(result, set)
 #     assert len(result) == 3
 #     for square in result:
@@ -678,10 +639,10 @@ def test_undiscriminated_union_list_type_precedence() -> None:
 #         {"radius": 2.5},  # Circle
 #         {"length": 5.0},  # Square
 #     ]
-    
+
 #     # This should work with the current implementation since it processes each item individually
 #     result = construct_type(type_=set[Circle], object_=mixed_set_data)
-    
+
 #     assert isinstance(result, set)
 #     # Only Circle objects should be successfully parsed
 #     circle_count = sum(1 for item in result if isinstance(item, Circle))
@@ -693,29 +654,21 @@ def test_construct_dict_of_objects() -> None:
     from .example_models.types.resources.types import Circle, Square
 
     # Test with dict of Circle objects
-    circle_dict_data = {
-        "circle1": {"radius": 1.5},
-        "circle2": {"radius": 2.0},
-        "circle3": {"radius": 3.2}
-    }
-    
+    circle_dict_data = {"circle1": {"radius": 1.5}, "circle2": {"radius": 2.0}, "circle3": {"radius": 3.2}}
+
     result = construct_type(type_=dict[str, Circle], object_=circle_dict_data)
-    
+
     assert isinstance(result, dict)
     assert len(result) == 3
     for key, circle in result.items():
         assert isinstance(circle, Circle)
         assert key in ["circle1", "circle2", "circle3"]
-    
+
     # Test with dict of Square objects
-    square_dict_data = {
-        "square1": {"length": 4.0},
-        "square2": {"length": 5.5},
-        "square3": {"length": 6.1}
-    }
-    
+    square_dict_data = {"square1": {"length": 4.0}, "square2": {"length": 5.5}, "square3": {"length": 6.1}}
+
     result = construct_type(type_=dict[str, Square], object_=square_dict_data)
-    
+
     assert isinstance(result, dict)
     assert len(result) == 3
     for key, square in result.items():
@@ -728,28 +681,20 @@ def test_construct_undiscriminated_union_with_dict() -> None:
     from .example_models.types.resources.types import Circle, Square
 
     # Test with dict of Circle objects in undiscriminated union
-    circle_dict_data = {
-        "circle1": {"radius": 1.0},
-        "circle2": {"radius": 2.5},
-        "circle3": {"radius": 3.0}
-    }
-    
+    circle_dict_data = {"circle1": {"radius": 1.0}, "circle2": {"radius": 2.5}, "circle3": {"radius": 3.0}}
+
     result = construct_type(type_=dict[str, Circle], object_=circle_dict_data)
-    
+
     assert isinstance(result, dict)
     assert len(result) == 3
     for circle in result.values():
         assert isinstance(circle, Circle)
-    
+
     # Test with dict of Square objects in undiscriminated union
-    square_dict_data = {
-        "square1": {"length": 4.0},
-        "square2": {"length": 5.0},
-        "square3": {"length": 6.0}
-    }
-    
+    square_dict_data = {"square1": {"length": 4.0}, "square2": {"length": 5.0}, "square3": {"length": 6.0}}
+
     result = construct_type(type_=dict[str, Square], object_=square_dict_data)
-    
+
     assert isinstance(result, dict)
     assert len(result) == 3
     for square in result.values():
@@ -767,14 +712,14 @@ def test_construct_undiscriminated_union_with_dict() -> None:
 #         {"radius": 2.0},  # Valid Circle
 #         {"another_invalid": 123},  # Invalid object
 #     ]
-    
+
 #     result = construct_type(type_=set[Circle], object_=invalid_set_data)
-    
+
 #     # Should still return a set, but invalid objects might be handled differently
 #     assert isinstance(result, set)
 #     # Valid objects should be correctly parsed
 #     valid_circles = [circle for circle in result if isinstance(circle, Circle)]
-    # assert len(valid_circles) > 0
+# assert len(valid_circles) > 0
 
 
 def test_construct_dict_with_invalid_objects() -> None:
@@ -788,9 +733,9 @@ def test_construct_dict_with_invalid_objects() -> None:
         "valid2": {"radius": 2.0},  # Valid Circle
         "invalid2": {"another_invalid": 123},  # Invalid object
     }
-    
+
     result = construct_type(type_=dict[str, Circle], object_=invalid_dict_data)
-    
+
     # Should still return a dict, but invalid objects might be handled differently
     assert isinstance(result, dict)
     # Valid objects should be correctly parsed
@@ -801,9 +746,9 @@ def test_construct_dict_with_invalid_objects() -> None:
 def test_construct_empty_set() -> None:
     """Test handling of empty sets in undiscriminated unions."""
     from .example_models.types.resources.types import Circle
-    
+
     result = construct_type(type_=set[Circle], object_=set())
-    
+
     assert isinstance(result, set)
     assert len(result) == 0
 
@@ -811,9 +756,9 @@ def test_construct_empty_set() -> None:
 def test_construct_empty_dict() -> None:
     """Test handling of empty dictionaries in undiscriminated unions."""
     from .example_models.types.resources.types import Circle
-    
+
     result = construct_type(type_=dict[str, Circle], object_={})
-    
+
     assert isinstance(result, dict)
     assert len(result) == 0
 
@@ -822,17 +767,17 @@ def test_construct_set_with_primitive_types() -> None:
     """Test set handling with primitive types (should not use the new set parsing logic)."""
     # Test with set of strings
     string_set_data = ["hello", "world", "test"]
-    
+
     result = construct_type(type_=set[str], object_=string_set_data)
-    
+
     assert isinstance(result, set)
     assert result == {"hello", "world", "test"}
-    
+
     # Test with set of integers
     int_set_data = [1, 2, 3, 4, 5]
-    
+
     result = construct_type(type_=set[int], object_=int_set_data)
-    
+
     assert isinstance(result, set)
     assert result == {1, 2, 3, 4, 5}
 
@@ -841,17 +786,17 @@ def test_construct_dict_with_primitive_types() -> None:
     """Test dict handling with primitive types (should not use the new dict parsing logic)."""
     # Test with dict of strings
     string_dict_data = {"key1": "value1", "key2": "value2"}
-    
+
     result = construct_type(type_=dict[str, str], object_=string_dict_data)
-    
+
     assert isinstance(result, dict)
     assert result == {"key1": "value1", "key2": "value2"}
-    
+
     # Test with dict of integers
     int_dict_data = {"a": 1, "b": 2, "c": 3}
-    
+
     result = construct_type(type_=dict[str, int], object_=int_dict_data)
-    
+
     assert isinstance(result, dict)
     assert result == {"a": 1, "b": 2, "c": 3}
 
@@ -1042,4 +987,3 @@ def test_construct_dict_with_primitive_types() -> None:
 #     assert len(result) == 1
 #     assert isinstance(list(result.values())[0], Circle)
 #     assert list(result.values())[0].radius == 1.0
-

--- a/generators/python/tests/utils/test_defaults.py
+++ b/generators/python/tests/utils/test_defaults.py
@@ -2,15 +2,12 @@ from tests.utils.example_models.types.resources.types.object_with_defaults impor
 
 
 def test_defaulted_object() -> None:
-    obj_with_none = ObjectWithDefaults(
-        decimal=None,
-        string=None,
-        required_string="something else"
-    )
+    obj_with_none = ObjectWithDefaults(decimal=None, string=None, required_string="something else")
 
     assert obj_with_none.decimal is None
     assert obj_with_none.string is None
     assert obj_with_none.required_string is "something else"
+
 
 def test_defaulted_object_with_defaults() -> None:
     obj_with_defaults = ObjectWithDefaults()
@@ -19,12 +16,9 @@ def test_defaulted_object_with_defaults() -> None:
     assert obj_with_defaults.string == "here's a sentence!"
     assert obj_with_defaults.required_string == "I neeeeeeeeeed this!"
 
+
 def test_with_non_none_setting() -> None:
-    obj_with_defaults = ObjectWithDefaults(
-        decimal=3.14,
-        string="hello",
-        required_string="something else"
-    )
+    obj_with_defaults = ObjectWithDefaults(decimal=3.14, string="hello", required_string="something else")
 
     assert obj_with_defaults.decimal == 3.14
     assert obj_with_defaults.string == "hello"

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -1,85 +1,58 @@
 from core_utilities.shared.http_client import get_request_body
 from core_utilities.shared.request_options import RequestOptions
 
+
 def get_request_options() -> RequestOptions:
     return {"additional_body_parameters": {"see you": "later"}}
 
+
 def test_get_json_request_body() -> None:
-    json_body, data_body = get_request_body(
-        json={"hello": "world"},
-        data=None,
-        request_options=None,
-        omit=None
-    )
+    json_body, data_body = get_request_body(json={"hello": "world"}, data=None, request_options=None, omit=None)
     assert json_body == {"hello": "world"}
     assert data_body is None
 
     json_body_extras, data_body_extras = get_request_body(
-        json={"goodbye": "world"},
-        data=None,
-        request_options=get_request_options(),
-        omit=None
+        json={"goodbye": "world"}, data=None, request_options=get_request_options(), omit=None
     )
 
     assert json_body_extras == {"goodbye": "world", "see you": "later"}
     assert data_body_extras is None
 
+
 def test_get_files_request_body() -> None:
-    json_body, data_body = get_request_body(
-        json=None,
-        data={"hello": "world"},
-        request_options=None,
-        omit=None
-    )
+    json_body, data_body = get_request_body(json=None, data={"hello": "world"}, request_options=None, omit=None)
     assert data_body == {"hello": "world"}
     assert json_body is None
 
     json_body_extras, data_body_extras = get_request_body(
-        json=None,
-        data={"goodbye": "world"},
-        request_options=get_request_options(),
-        omit=None
+        json=None, data={"goodbye": "world"}, request_options=get_request_options(), omit=None
     )
 
     assert data_body_extras == {"goodbye": "world", "see you": "later"}
     assert json_body_extras is None
 
+
 def test_get_none_request_body() -> None:
-    json_body, data_body = get_request_body(
-        json=None,
-        data=None,
-        request_options=None,
-        omit=None
-    )
+    json_body, data_body = get_request_body(json=None, data=None, request_options=None, omit=None)
     assert data_body is None
     assert json_body is None
 
     json_body_extras, data_body_extras = get_request_body(
-        json=None,
-        data=None,
-        request_options=get_request_options(),
-        omit=None
+        json=None, data=None, request_options=get_request_options(), omit=None
     )
 
     assert json_body_extras == {"see you": "later"}
     assert data_body_extras is None
 
+
 def test_get_empty_json_request_body() -> None:
     unrelated_request_options: RequestOptions = {"max_retries": 3}
-    json_body, data_body = get_request_body(
-        json=None,
-        data=None,
-        request_options=unrelated_request_options,
-        omit=None
-    )
+    json_body, data_body = get_request_body(json=None, data=None, request_options=unrelated_request_options, omit=None)
     assert json_body is None
     assert data_body is None
 
     json_body_extras, data_body_extras = get_request_body(
-        json={},
-        data=None,
-        request_options=unrelated_request_options,
-        omit=None
+        json={}, data=None, request_options=unrelated_request_options, omit=None
     )
 
     assert json_body_extras is None

--- a/generators/python/tests/utils/test_parse_obj_as.py
+++ b/generators/python/tests/utils/test_parse_obj_as.py
@@ -6,64 +6,34 @@ from .unaliased_models.types import ObjectWithOptionalField, Shape_Circle
 
 
 UNION_TEST = {"radius_measurement": 1.0, "shape_type": "circle", "id": "1"}
-UNION_TEST_CONVERTED = {
-    "shapeType": "circle",
-    "radiusMeasurement": 1.0,
-    "id": "1"
-}
+UNION_TEST_CONVERTED = {"shapeType": "circle", "radiusMeasurement": 1.0, "id": "1"}
+
 
 def test_convert_and_respect_annotation_metadata() -> None:
     wire_data = {"string": "string", "long": 12345, "bool": True, "literal": "lit_one", "any": "any"}
     converted = parse_obj_as(ObjectWithOptionalField, wire_data)
-    assert converted == ObjectWithOptionalField(
-        string="string",
-        long_=12345,
-        bool_=True,
-        literal="lit_one",
-        any="any"
-    )
+    assert converted == ObjectWithOptionalField(string="string", long_=12345, bool_=True, literal="lit_one", any="any")
+
 
 def test_convert_and_respect_annotation_metadata_in_list() -> None:
-    wire_data= [
+    wire_data = [
         {"string": "string", "long": 12345, "bool": True, "literal": "lit_one", "any": "any"},
-        {"string": "another string", "long": 67890, "list": [], "literal": "lit_one", "any": "any"}
+        {"string": "another string", "long": 67890, "list": [], "literal": "lit_one", "any": "any"},
     ]
 
     converted = parse_obj_as(List[ObjectWithOptionalField], wire_data)
 
-    assert converted == [ObjectWithOptionalField(
-        string="string",
-        long_=12345,
-        bool_=True,
-        literal="lit_one",
-        any="any"
-    ), ObjectWithOptionalField(
-        string="another string",
-        long_=67890,
-        list_=[],
-        literal="lit_one",
-        any="any"
-    )]
+    assert converted == [
+        ObjectWithOptionalField(string="string", long_=12345, bool_=True, literal="lit_one", any="any"),
+        ObjectWithOptionalField(string="another string", long_=67890, list_=[], literal="lit_one", any="any"),
+    ]
 
 
 def test_convert_and_respect_annotation_metadata_in_nested_object() -> None:
-    wire_data = {
-        "string": "string",
-        "long": 12345,
-        "union": UNION_TEST_CONVERTED,
-        "literal": "lit_one",
-        "any": "any"
-    }
+    wire_data = {"string": "string", "long": 12345, "union": UNION_TEST_CONVERTED, "literal": "lit_one", "any": "any"}
 
     converted = parse_obj_as(ObjectWithOptionalField, wire_data)
 
-    assert converted ==  ObjectWithOptionalField(
-        string="string",
-        long_=12345,
-        union=Shape_Circle(
-            radius_measurement=1.0,
-            id="1"
-        ),
-        literal="lit_one",
-        any="any"
+    assert converted == ObjectWithOptionalField(
+        string="string", long_=12345, union=Shape_Circle(radius_measurement=1.0, id="1"), literal="lit_one", any="any"
     )

--- a/generators/python/tests/utils/test_query_encoding.py
+++ b/generators/python/tests/utils/test_query_encoding.py
@@ -1,15 +1,33 @@
-
 from core_utilities.shared.query_encoder import encode_query
 
 
 def test_query_encoding_deep_objects() -> None:
     assert encode_query({"hello world": "hello world"}) == [("hello world", "hello world")]
-    assert encode_query({"hello_world": {"hello" : "world"}}) == [("hello_world[hello]", "world")]
-    assert encode_query({"hello_world": {"hello" : {"world" : "today"}, "test": "this"}, "hi": "there"}) == [("hello_world[hello][world]", "today"), ("hello_world[test]", "this"), ("hi", "there")]
+    assert encode_query({"hello_world": {"hello": "world"}}) == [("hello_world[hello]", "world")]
+    assert encode_query({"hello_world": {"hello": {"world": "today"}, "test": "this"}, "hi": "there"}) == [
+        ("hello_world[hello][world]", "today"),
+        ("hello_world[test]", "this"),
+        ("hi", "there"),
+    ]
+
 
 def test_query_encoding_deep_object_arrays() -> None:
-    assert encode_query({"objects": [{"key": "hello", "value": "world"}, {"key": "foo", "value": "bar"}]}) == [("objects[key]", "hello"), ("objects[value]", "world"), ("objects[key]", "foo"), ("objects[value]", "bar")]
-    assert encode_query({"users": [{"name": "string", "tags": ["string"]}, {"name": "string2", "tags": ["string2", "string3"]}]}) == [("users[name]", "string"), ("users[tags]", "string"), ("users[name]", "string2"), ("users[tags]", "string2"), ("users[tags]", "string3")]
+    assert encode_query({"objects": [{"key": "hello", "value": "world"}, {"key": "foo", "value": "bar"}]}) == [
+        ("objects[key]", "hello"),
+        ("objects[value]", "world"),
+        ("objects[key]", "foo"),
+        ("objects[value]", "bar"),
+    ]
+    assert encode_query(
+        {"users": [{"name": "string", "tags": ["string"]}, {"name": "string2", "tags": ["string2", "string3"]}]}
+    ) == [
+        ("users[name]", "string"),
+        ("users[tags]", "string"),
+        ("users[name]", "string2"),
+        ("users[tags]", "string2"),
+        ("users[tags]", "string3"),
+    ]
+
 
 def test_encode_query_with_none() -> None:
     encoded = encode_query(None)

--- a/generators/python/tests/utils/test_serialization.py
+++ b/generators/python/tests/utils/test_serialization.py
@@ -5,40 +5,48 @@ from .typeddict_models.types import ShapeParams, ObjectWithOptionalFieldParams
 
 
 UNION_TEST: ShapeParams = {"radius_measurement": 1.0, "shape_type": "circle", "id": "1"}
-UNION_TEST_CONVERTED = {
-    "shapeType": "circle",
-    "radiusMeasurement": 1.0,
-    "id": "1"
-}
+UNION_TEST_CONVERTED = {"shapeType": "circle", "radiusMeasurement": 1.0, "id": "1"}
+
 
 def test_convert_and_respect_annotation_metadata() -> None:
-    data: ObjectWithOptionalFieldParams = {"string": "string", "long_": 12345, "bool_": True, "literal": "lit_one", "any": "any"}
+    data: ObjectWithOptionalFieldParams = {
+        "string": "string",
+        "long_": 12345,
+        "bool_": True,
+        "literal": "lit_one",
+        "any": "any",
+    }
     converted = convert_and_respect_annotation_metadata(
-        object_=data,
-        annotation=ObjectWithOptionalFieldParams,
-        direction="write"
+        object_=data, annotation=ObjectWithOptionalFieldParams, direction="write"
     )
     assert converted == {"string": "string", "long": 12345, "bool": True, "literal": "lit_one", "any": "any"}
 
+
 def test_convert_and_respect_annotation_metadata_in_list() -> None:
-    data: List[ObjectWithOptionalFieldParams] = [{"string": "string", "long_": 12345, "bool_": True, "literal": "lit_one", "any": "any"}, {"string": "another string", "long_": 67890, "list_": [], "literal": "lit_one", "any": "any"}]
+    data: List[ObjectWithOptionalFieldParams] = [
+        {"string": "string", "long_": 12345, "bool_": True, "literal": "lit_one", "any": "any"},
+        {"string": "another string", "long_": 67890, "list_": [], "literal": "lit_one", "any": "any"},
+    ]
     converted = convert_and_respect_annotation_metadata(
-        object_=data,
-        annotation=List[ObjectWithOptionalFieldParams],
-        direction="write"
+        object_=data, annotation=List[ObjectWithOptionalFieldParams], direction="write"
     )
 
     assert converted == [
         {"string": "string", "long": 12345, "bool": True, "literal": "lit_one", "any": "any"},
-        {"string": "another string", "long": 67890, "list": [], "literal": "lit_one", "any": "any"}
+        {"string": "another string", "long": 67890, "list": [], "literal": "lit_one", "any": "any"},
     ]
 
+
 def test_convert_and_respect_annotation_metadata_in_nested_object() -> None:
-    data: ObjectWithOptionalFieldParams = {"string": "string", "long_": 12345, "union": UNION_TEST, "literal": "lit_one", "any": "any"}
+    data: ObjectWithOptionalFieldParams = {
+        "string": "string",
+        "long_": 12345,
+        "union": UNION_TEST,
+        "literal": "lit_one",
+        "any": "any",
+    }
     converted = convert_and_respect_annotation_metadata(
-        object_=data,
-        annotation=ObjectWithOptionalFieldParams,
-        direction="write"
+        object_=data, annotation=ObjectWithOptionalFieldParams, direction="write"
     )
 
     assert converted == {
@@ -46,23 +54,17 @@ def test_convert_and_respect_annotation_metadata_in_nested_object() -> None:
         "long": 12345,
         "union": UNION_TEST_CONVERTED,
         "literal": "lit_one",
-        "any": "any"
+        "any": "any",
     }
 
+
 def test_convert_and_respect_annotation_metadata_in_union() -> None:
-    converted = convert_and_respect_annotation_metadata(
-        object_=UNION_TEST,
-        annotation=ShapeParams,
-        direction="write"
-    )
+    converted = convert_and_respect_annotation_metadata(object_=UNION_TEST, annotation=ShapeParams, direction="write")
 
     assert converted == UNION_TEST_CONVERTED
 
+
 def test_convert_and_respect_annotation_metadata_with_empty_object() -> None:
     data: Any = {}
-    converted = convert_and_respect_annotation_metadata(
-        object_=data,
-        annotation=ShapeParams,
-        direction="write"
-    )
+    converted = convert_and_respect_annotation_metadata(object_=data, annotation=ShapeParams, direction="write")
     assert converted == data

--- a/generators/python/tests/utils/test_union_utils.py
+++ b/generators/python/tests/utils/test_union_utils.py
@@ -7,13 +7,11 @@ def test_union_utils() -> None:
     dummy = '{ "type": "circle", "radius": 1.1 }'
     circle = Shape.parse_raw(dummy)
 
-    is_circle = circle.visit(
-        circle=lambda _: True,
-        square=lambda _: False
-    )
+    is_circle = circle.visit(circle=lambda _: True, square=lambda _: False)
 
     assert is_circle
     assert circle.dict() == json.loads(dummy)
+
 
 def test_equality() -> None:
     dummy = '{ "type": "circle", "radius": 1.1 }'

--- a/generators/python/tests/utils/test_unset.py
+++ b/generators/python/tests/utils/test_unset.py
@@ -8,10 +8,12 @@ class SomeObject(UniversalBaseModel):
     city: str = "NY"
     optional: Optional[str] = None
 
+
 def test_unset() -> None:
     so = SomeObject(name="John", age=30)
     assert so.dict() == {"name": "John", "age": 30, "city": "NY"}
     assert so.dict(exclude_unset=True) == {"name": "John", "age": 30, "city": "NY"}
+
 
 def test_unset_with_updates() -> None:
     so = SomeObject(name="John", age=30, city="Washington", optional="extra")

--- a/generators/python/tests/utils/typeddict_models/types/core/datetime_utils.py
+++ b/generators/python/tests/utils/typeddict_models/types/core/datetime_utils.py
@@ -13,9 +13,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(
-            None
-        ):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/generators/python/tests/utils/typeddict_models/types/core/pydantic_utilities.py
+++ b/generators/python/tests/utils/typeddict_models/types/core/pydantic_utilities.py
@@ -133,9 +133,7 @@ class UniversalBaseModel(pydantic.BaseModel):
                     # If the default values are non-null act like they've been set
                     # This effectively allows exclude_unset to work like exclude_none where
                     # the latter passes through intentionally set none values.
-                    if default is not None or (
-                        "exclude_unset" in kwargs and not kwargs["exclude_unset"]
-                    ):
+                    if default is not None or ("exclude_unset" in kwargs and not kwargs["exclude_unset"]):
                         _fields_set.add(name)
 
                         if default is not None:
@@ -175,9 +173,9 @@ else:
 
 
 def encode_by_type(o: typing.Any) -> typing.Any:
-    encoders_by_class_tuples: typing.Dict[
-        typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]
-    ] = defaultdict(tuple)
+    encoders_by_class_tuples: typing.Dict[typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]] = (
+        defaultdict(tuple)
+    )
     for type_, encoder in encoders_by_type.items():
         encoders_by_class_tuples[encoder] += (type_,)
 
@@ -211,14 +209,10 @@ def universal_root_validator(
     return decorator
 
 
-def universal_field_validator(
-    field_name: str, pre: bool = False
-) -> typing.Callable[[AnyCallable], AnyCallable]:
+def universal_field_validator(field_name: str, pre: bool = False) -> typing.Callable[[AnyCallable], AnyCallable]:
     def decorator(func: AnyCallable) -> AnyCallable:
         if IS_PYDANTIC_V2:
-            return pydantic.field_validator(
-                field_name, mode="before" if pre else "after"
-            )(func)  # type: ignore # Pydantic v2
+            return pydantic.field_validator(field_name, mode="before" if pre else "after")(func)  # type: ignore # Pydantic v2
         else:
             return pydantic.validator(field_name, pre=pre)(func)  # type: ignore # Pydantic v1
 

--- a/generators/python/tests/utils/typeddict_models/types/core/serialization.py
+++ b/generators/python/tests/utils/typeddict_models/types/core/serialization.py
@@ -68,9 +68,7 @@ def convert_and_respect_annotation_metadata(
     ):
         return _convert_mapping(object_, clean_type, direction)
     # TypedDicts
-    if typing_extensions.is_typeddict(clean_type) and isinstance(
-        object_, typing.Mapping
-    ):
+    if typing_extensions.is_typeddict(clean_type) and isinstance(object_, typing.Mapping):
         return _convert_mapping(object_, clean_type, direction)
 
     if (
@@ -183,10 +181,8 @@ def _convert_mapping(
                 object_=value, annotation=type_, direction=direction
             )
         else:
-            converted_object[
-                _alias_key(key, type_, direction, aliases_to_field_names)
-            ] = convert_and_respect_annotation_metadata(
-                object_=value, annotation=type_, direction=direction
+            converted_object[_alias_key(key, type_, direction, aliases_to_field_names)] = (
+                convert_and_respect_annotation_metadata(object_=value, annotation=type_, direction=direction)
             )
     return converted_object
 

--- a/generators/python/tests/utils/typeddict_models/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/typeddict_models/types/core/unchecked_base_model.py
@@ -37,9 +37,7 @@ Model = typing.TypeVar("Model", bound=pydantic.BaseModel)
 
 class UncheckedBaseModel(UniversalBaseModel):
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -80,9 +78,7 @@ class UncheckedBaseModel(UniversalBaseModel):
             if (key is None or field.alias == name) and name in field_aliases:
                 key = field_aliases[name]
 
-            if key is None or (
-                key not in values and populate_by_name
-            ):  # Added this to allow population by field name
+            if key is None or (key not in values and populate_by_name):  # Added this to allow population by field name
                 key = name
 
             if key in values:
@@ -92,9 +88,7 @@ class UncheckedBaseModel(UniversalBaseModel):
                     type_ = typing.cast(typing.Type, field.outer_type_)  # type: ignore # Pydantic < v1.10.15
 
                 fields_values[name] = (
-                    construct_type(object_=values[key], type_=type_)
-                    if type_ is not None
-                    else values[key]
+                    construct_type(object_=values[key], type_=type_) if type_ is not None else values[key]
                 )
                 _fields_set.add(name)
             else:
@@ -113,9 +107,7 @@ class UncheckedBaseModel(UniversalBaseModel):
         internal_alias_fields = list(field_aliases.values())
         for key, value in values.items():
             # If the key is not a field by name, nor an alias to a field, then it's extra
-            if (
-                key not in pydantic_alias_fields and key not in internal_alias_fields
-            ) and key not in fields:
+            if (key not in pydantic_alias_fields and key not in internal_alias_fields) and key not in fields:
                 if IS_PYDANTIC_V2:
                     extras[key] = value
                 else:
@@ -134,18 +126,14 @@ class UncheckedBaseModel(UniversalBaseModel):
         return m
 
 
-def _convert_undiscriminated_union_type(
-    union_type: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def _convert_undiscriminated_union_type(union_type: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     inner_types = get_args(union_type)
     if typing.Any in inner_types:
         return object_
 
     for inner_type in inner_types:
         try:
-            if inspect.isclass(inner_type) and issubclass(
-                inner_type, pydantic.BaseModel
-            ):
+            if inspect.isclass(inner_type) and issubclass(inner_type, pydantic.BaseModel):
                 # Attempt a validated parse until one works
                 return parse_obj_as(inner_type, object_)
         except Exception:
@@ -159,9 +147,7 @@ def _convert_undiscriminated_union_type(
             continue
 
 
-def _convert_union_type(
-    type_: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def _convert_union_type(type_: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     base_type = get_origin(type_) or type_
     union_type = type_
     if base_type == typing_extensions.Annotated:  # type: ignore[comparison-overlap]
@@ -173,15 +159,10 @@ def _convert_union_type(
                     # Cast to the correct type, based on the discriminant
                     for inner_type in get_args(union_type):
                         try:
-                            objects_discriminant = getattr(
-                                object_, metadata.discriminant
-                            )
+                            objects_discriminant = getattr(object_, metadata.discriminant)
                         except:
                             objects_discriminant = object_[metadata.discriminant]
-                        if (
-                            inner_type.__fields__[metadata.discriminant].default
-                            == objects_discriminant
-                        ):
+                        if inner_type.__fields__[metadata.discriminant].default == objects_discriminant:
                             return construct_type(object_=object_, type_=inner_type)
                 except Exception:
                     # Allow to fall through to our regular union handling
@@ -189,9 +170,7 @@ def _convert_union_type(
     return _convert_undiscriminated_union_type(union_type, object_)
 
 
-def construct_type(
-    *, type_: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def construct_type(*, type_: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     """
     Here we are essentially creating the same `construct` method in spirit as the above, but for all types, not just
     Pydantic models.
@@ -204,9 +183,7 @@ def construct_type(
     base_type = get_origin(type_) or type_
     is_annotated = base_type == typing_extensions.Annotated  # type: ignore[comparison-overlap]
     maybe_annotation_members = get_args(type_)
-    is_annotated_union = is_annotated and is_union(
-        get_origin(maybe_annotation_members[0])
-    )
+    is_annotated_union = is_annotated and is_union(get_origin(maybe_annotation_members[0]))
 
     if base_type == typing.Any:  # type: ignore[comparison-overlap]
         return object_
@@ -217,9 +194,7 @@ def construct_type(
 
         key_type, items_type = get_args(type_)
         d = {
-            construct_type(object_=key, type_=key_type): construct_type(
-                object_=item, type_=items_type
-            )
+            construct_type(object_=key, type_=key_type): construct_type(object_=item, type_=items_type)
             for key, item in object_.items()
         }
         return d

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/circle.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/circle.py
@@ -10,9 +10,7 @@ class Circle(UncheckedBaseModel):
     radius_measurement: float = pydantic.Field(alias="radiusMeasurement")
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/object_with_defaults.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/object_with_defaults.py
@@ -16,9 +16,7 @@ class ObjectWithDefaults(UncheckedBaseModel):
     required_string: str = "I neeeeeeeeeed this!"
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/object_with_optional_field.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/object_with_optional_field.py
@@ -22,13 +22,9 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     date: typing.Optional[dt.date] = None
     uuid_: typing.Optional[uuid.UUID] = pydantic.Field(alias="uuid", default=None)
     base_64: typing.Optional[str] = pydantic.Field(alias="base64", default=None)
-    list_: typing.Optional[typing.List[str]] = pydantic.Field(
-        alias="list", default=None
-    )
+    list_: typing.Optional[typing.List[str]] = pydantic.Field(alias="list", default=None)
     set_: typing.Optional[typing.Set[str]] = pydantic.Field(alias="set", default=None)
-    map_: typing.Optional[typing.Dict[int, str]] = pydantic.Field(
-        alias="map", default=None
-    )
+    map_: typing.Optional[typing.Dict[int, str]] = pydantic.Field(alias="map", default=None)
     enum: typing.Optional[Color] = None
     union: typing.Optional[Shape] = None
     second_union: typing.Optional[Shape] = None
@@ -36,9 +32,7 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     any: typing.Optional[typing.Any] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/requests/circle.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/requests/circle.py
@@ -6,6 +6,4 @@ from ....core.serialization import FieldMetadata
 
 
 class CircleParams(typing_extensions.TypedDict):
-    radius_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="radiusMeasurement")
-    ]
+    radius_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="radiusMeasurement")]

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/requests/object_with_optional_field.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/requests/object_with_optional_field.py
@@ -15,30 +15,16 @@ class ObjectWithOptionalFieldParams(typing_extensions.TypedDict):
     literal: typing.Literal["lit_one"]
     string: typing_extensions.NotRequired[str]
     integer: typing_extensions.NotRequired[int]
-    long_: typing_extensions.NotRequired[
-        typing_extensions.Annotated[int, FieldMetadata(alias="long")]
-    ]
+    long_: typing_extensions.NotRequired[typing_extensions.Annotated[int, FieldMetadata(alias="long")]]
     double: typing_extensions.NotRequired[float]
-    bool_: typing_extensions.NotRequired[
-        typing_extensions.Annotated[bool, FieldMetadata(alias="bool")]
-    ]
+    bool_: typing_extensions.NotRequired[typing_extensions.Annotated[bool, FieldMetadata(alias="bool")]]
     datetime: typing_extensions.NotRequired[dt.datetime]
     date: typing_extensions.NotRequired[dt.date]
-    uuid_: typing_extensions.NotRequired[
-        typing_extensions.Annotated[uuid.UUID, FieldMetadata(alias="uuid")]
-    ]
-    base_64: typing_extensions.NotRequired[
-        typing_extensions.Annotated[str, FieldMetadata(alias="base64")]
-    ]
-    list_: typing_extensions.NotRequired[
-        typing_extensions.Annotated[typing.Sequence[str], FieldMetadata(alias="list")]
-    ]
-    set_: typing_extensions.NotRequired[
-        typing_extensions.Annotated[typing.Set[str], FieldMetadata(alias="set")]
-    ]
-    map_: typing_extensions.NotRequired[
-        typing_extensions.Annotated[typing.Dict[int, str], FieldMetadata(alias="map")]
-    ]
+    uuid_: typing_extensions.NotRequired[typing_extensions.Annotated[uuid.UUID, FieldMetadata(alias="uuid")]]
+    base_64: typing_extensions.NotRequired[typing_extensions.Annotated[str, FieldMetadata(alias="base64")]]
+    list_: typing_extensions.NotRequired[typing_extensions.Annotated[typing.Sequence[str], FieldMetadata(alias="list")]]
+    set_: typing_extensions.NotRequired[typing_extensions.Annotated[typing.Set[str], FieldMetadata(alias="set")]]
+    map_: typing_extensions.NotRequired[typing_extensions.Annotated[typing.Dict[int, str], FieldMetadata(alias="map")]]
     enum: typing_extensions.NotRequired[Color]
     union: typing_extensions.NotRequired[ShapeParams]
     second_union: typing_extensions.NotRequired[ShapeParams]

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/requests/shape.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/requests/shape.py
@@ -12,21 +12,13 @@ class Base(typing_extensions.TypedDict):
 
 
 class Shape_CircleParams(Base):
-    shape_type: typing_extensions.Annotated[
-        typing.Literal["circle"], FieldMetadata(alias="shapeType")
-    ]
-    radius_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="radiusMeasurement")
-    ]
+    shape_type: typing_extensions.Annotated[typing.Literal["circle"], FieldMetadata(alias="shapeType")]
+    radius_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="radiusMeasurement")]
 
 
 class Shape_SquareParams(Base):
-    shape_type: typing_extensions.Annotated[
-        typing.Literal["square"], FieldMetadata(alias="shapeType")
-    ]
-    length_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="lengthMeasurement")
-    ]
+    shape_type: typing_extensions.Annotated[typing.Literal["square"], FieldMetadata(alias="shapeType")]
+    length_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="lengthMeasurement")]
 
 
 ShapeParams = typing.Union[Shape_CircleParams, Shape_SquareParams]

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/requests/square.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/requests/square.py
@@ -6,6 +6,4 @@ from ....core.serialization import FieldMetadata
 
 
 class SquareParams(typing_extensions.TypedDict):
-    length_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="lengthMeasurement")
-    ]
+    length_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="lengthMeasurement")]

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/shape.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/shape.py
@@ -13,9 +13,7 @@ class Base(UncheckedBaseModel):
     id: str
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -23,15 +21,11 @@ class Base(UncheckedBaseModel):
 
 
 class Shape_Circle(Base):
-    shape_type: typing.Literal["circle"] = pydantic.Field(
-        alias="shapeType", default="circle"
-    )
+    shape_type: typing.Literal["circle"] = pydantic.Field(alias="shapeType", default="circle")
     radius_measurement: float = pydantic.Field(alias="radiusMeasurement")
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -39,21 +33,15 @@ class Shape_Circle(Base):
 
 
 class Shape_Square(Base):
-    shape_type: typing.Literal["square"] = pydantic.Field(
-        alias="shapeType", default="square"
-    )
+    shape_type: typing.Literal["square"] = pydantic.Field(alias="shapeType", default="square")
     length_measurement: float = pydantic.Field(alias="lengthMeasurement")
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
             extra = pydantic.Extra.allow
 
 
-Shape = typing_extensions.Annotated[
-    typing.Union[Shape_Circle, Shape_Square], UnionMetadata(discriminant="shapeType")
-]
+Shape = typing_extensions.Annotated[typing.Union[Shape_Circle, Shape_Square], UnionMetadata(discriminant="shapeType")]

--- a/generators/python/tests/utils/typeddict_models/types/resources/types/square.py
+++ b/generators/python/tests/utils/typeddict_models/types/resources/types/square.py
@@ -10,9 +10,7 @@ class Square(UncheckedBaseModel):
     length_measurement: float = pydantic.Field(alias="lengthMeasurement")
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/unaliased_models/types/core/datetime_utils.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/datetime_utils.py
@@ -13,9 +13,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(
-            None
-        ):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/generators/python/tests/utils/unaliased_models/types/core/pydantic_utilities.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/pydantic_utilities.py
@@ -57,9 +57,7 @@ Model = typing.TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: typing.Type[T], object_: typing.Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(
-        object_=object_, annotation=type_, direction="read"
-    )
+    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore # Pydantic v2
         return adapter.validate_python(dealiased_object)
@@ -88,10 +86,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore # Pydantic v2
         def serialize_model(self) -> typing.Any:  # type: ignore # Pydantic v2
             serialized = self.model_dump()
-            data = {
-                k: serialize_datetime(v) if isinstance(v, dt.datetime) else v
-                for k, v in serialized.items()
-            }
+            data = {k: serialize_datetime(v) if isinstance(v, dt.datetime) else v for k, v in serialized.items()}
             return data
 
     else:
@@ -106,9 +101,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         _fields_set: typing.Optional[typing.Set[str]] = None,
         **values: typing.Any,
     ) -> "Model":
-        dealiased_object = convert_and_respect_annotation_metadata(
-            object_=values, annotation=cls, direction="read"
-        )
+        dealiased_object = convert_and_respect_annotation_metadata(object_=values, annotation=cls, direction="read")
         return cls.construct(_fields_set, **dealiased_object)
 
     @classmethod
@@ -117,9 +110,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         _fields_set: typing.Optional[typing.Set[str]] = None,
         **values: typing.Any,
     ) -> "Model":
-        dealiased_object = convert_and_respect_annotation_metadata(
-            object_=values, annotation=cls, direction="read"
-        )
+        dealiased_object = convert_and_respect_annotation_metadata(object_=values, annotation=cls, direction="read")
         if IS_PYDANTIC_V2:
             return super().model_construct(_fields_set, **dealiased_object)  # type: ignore # Pydantic v2
         else:
@@ -175,9 +166,7 @@ class UniversalBaseModel(pydantic.BaseModel):
                     # If the default values are non-null act like they've been set
                     # This effectively allows exclude_unset to work like exclude_none where
                     # the latter passes through intentionally set none values.
-                    if default is not None or (
-                        "exclude_unset" in kwargs and not kwargs["exclude_unset"]
-                    ):
+                    if default is not None or ("exclude_unset" in kwargs and not kwargs["exclude_unset"]):
                         _fields_set.add(name)
 
                         if default is not None:
@@ -190,13 +179,12 @@ class UniversalBaseModel(pydantic.BaseModel):
                 **kwargs,
             }
 
-            dict_dump = super().dict(
-                **kwargs_with_defaults_exclude_unset_include_fields
-            )
+            dict_dump = super().dict(**kwargs_with_defaults_exclude_unset_include_fields)
 
-        return typing.cast(typing.Dict[str, typing.Any], convert_and_respect_annotation_metadata(
-            object_=dict_dump, annotation=self.__class__, direction="write"
-        ))
+        return typing.cast(
+            typing.Dict[str, typing.Any],
+            convert_and_respect_annotation_metadata(object_=dict_dump, annotation=self.__class__, direction="write"),
+        )
 
 
 def deep_union_pydantic_dicts(
@@ -223,9 +211,9 @@ else:
 
 
 def encode_by_type(o: typing.Any) -> typing.Any:
-    encoders_by_class_tuples: typing.Dict[
-        typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]
-    ] = defaultdict(tuple)
+    encoders_by_class_tuples: typing.Dict[typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]] = (
+        defaultdict(tuple)
+    )
     for type_, encoder in encoders_by_type.items():
         encoders_by_class_tuples[encoder] += (type_,)
 
@@ -259,14 +247,10 @@ def universal_root_validator(
     return decorator
 
 
-def universal_field_validator(
-    field_name: str, pre: bool = False
-) -> typing.Callable[[AnyCallable], AnyCallable]:
+def universal_field_validator(field_name: str, pre: bool = False) -> typing.Callable[[AnyCallable], AnyCallable]:
     def decorator(func: AnyCallable) -> AnyCallable:
         if IS_PYDANTIC_V2:
-            return pydantic.field_validator(
-                field_name, mode="before" if pre else "after"
-            )(func)  # type: ignore # Pydantic v2
+            return pydantic.field_validator(field_name, mode="before" if pre else "after")(func)  # type: ignore # Pydantic v2
         else:
             return pydantic.validator(field_name, pre=pre)(func)  # type: ignore # Pydantic v1
 

--- a/generators/python/tests/utils/unaliased_models/types/core/serialization.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/serialization.py
@@ -68,9 +68,7 @@ def convert_and_respect_annotation_metadata(
     ):
         return _convert_mapping(object_, clean_type, direction)
     # TypedDicts
-    if typing_extensions.is_typeddict(clean_type) and isinstance(
-        object_, typing.Mapping
-    ):
+    if typing_extensions.is_typeddict(clean_type) and isinstance(object_, typing.Mapping):
         return _convert_mapping(object_, clean_type, direction)
 
     if (
@@ -183,10 +181,8 @@ def _convert_mapping(
                 object_=value, annotation=type_, direction=direction
             )
         else:
-            converted_object[
-                _alias_key(key, type_, direction, aliases_to_field_names)
-            ] = convert_and_respect_annotation_metadata(
-                object_=value, annotation=type_, direction=direction
+            converted_object[_alias_key(key, type_, direction, aliases_to_field_names)] = (
+                convert_and_respect_annotation_metadata(object_=value, annotation=type_, direction=direction)
             )
     return converted_object
 

--- a/generators/python/tests/utils/unaliased_models/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/unchecked_base_model.py
@@ -37,9 +37,7 @@ Model = typing.TypeVar("Model", bound=pydantic.BaseModel)
 
 class UncheckedBaseModel(UniversalBaseModel):
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -80,9 +78,7 @@ class UncheckedBaseModel(UniversalBaseModel):
             if (key is None or field.alias == name) and name in field_aliases:
                 key = field_aliases[name]
 
-            if key is None or (
-                key not in values and populate_by_name
-            ):  # Added this to allow population by field name
+            if key is None or (key not in values and populate_by_name):  # Added this to allow population by field name
                 key = name
 
             if key in values:
@@ -92,9 +88,7 @@ class UncheckedBaseModel(UniversalBaseModel):
                     type_ = typing.cast(typing.Type, field.outer_type_)  # type: ignore # Pydantic < v1.10.15
 
                 fields_values[name] = (
-                    construct_type(object_=values[key], type_=type_)
-                    if type_ is not None
-                    else values[key]
+                    construct_type(object_=values[key], type_=type_) if type_ is not None else values[key]
                 )
                 _fields_set.add(name)
             else:
@@ -113,9 +107,7 @@ class UncheckedBaseModel(UniversalBaseModel):
         internal_alias_fields = list(field_aliases.values())
         for key, value in values.items():
             # If the key is not a field by name, nor an alias to a field, then it's extra
-            if (
-                key not in pydantic_alias_fields and key not in internal_alias_fields
-            ) and key not in fields:
+            if (key not in pydantic_alias_fields and key not in internal_alias_fields) and key not in fields:
                 if IS_PYDANTIC_V2:
                     extras[key] = value
                 else:
@@ -134,18 +126,14 @@ class UncheckedBaseModel(UniversalBaseModel):
         return m
 
 
-def _convert_undiscriminated_union_type(
-    union_type: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def _convert_undiscriminated_union_type(union_type: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     inner_types = get_args(union_type)
     if typing.Any in inner_types:
         return object_
 
     for inner_type in inner_types:
         try:
-            if inspect.isclass(inner_type) and issubclass(
-                inner_type, pydantic.BaseModel
-            ):
+            if inspect.isclass(inner_type) and issubclass(inner_type, pydantic.BaseModel):
                 # Attempt a validated parse until one works
                 return parse_obj_as(inner_type, object_)
         except Exception:
@@ -159,9 +147,7 @@ def _convert_undiscriminated_union_type(
             continue
 
 
-def _convert_union_type(
-    type_: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def _convert_union_type(type_: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     base_type = get_origin(type_) or type_
     union_type = type_
     if base_type == typing_extensions.Annotated:  # type: ignore[comparison-overlap]
@@ -173,15 +159,10 @@ def _convert_union_type(
                     # Cast to the correct type, based on the discriminant
                     for inner_type in get_args(union_type):
                         try:
-                            objects_discriminant = getattr(
-                                object_, metadata.discriminant
-                            )
+                            objects_discriminant = getattr(object_, metadata.discriminant)
                         except:
                             objects_discriminant = object_[metadata.discriminant]
-                        if (
-                            inner_type.__fields__[metadata.discriminant].default
-                            == objects_discriminant
-                        ):
+                        if inner_type.__fields__[metadata.discriminant].default == objects_discriminant:
                             return construct_type(object_=object_, type_=inner_type)
                 except Exception:
                     # Allow to fall through to our regular union handling
@@ -189,9 +170,7 @@ def _convert_union_type(
     return _convert_undiscriminated_union_type(union_type, object_)
 
 
-def construct_type(
-    *, type_: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def construct_type(*, type_: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     """
     Here we are essentially creating the same `construct` method in spirit as the above, but for all types, not just
     Pydantic models.
@@ -204,9 +183,7 @@ def construct_type(
     base_type = get_origin(type_) or type_
     is_annotated = base_type == typing_extensions.Annotated  # type: ignore[comparison-overlap]
     maybe_annotation_members = get_args(type_)
-    is_annotated_union = is_annotated and is_union(
-        get_origin(maybe_annotation_members[0])
-    )
+    is_annotated_union = is_annotated and is_union(get_origin(maybe_annotation_members[0]))
 
     if base_type == typing.Any:  # type: ignore[comparison-overlap]
         return object_
@@ -217,9 +194,7 @@ def construct_type(
 
         key_type, items_type = get_args(type_)
         d = {
-            construct_type(object_=key, type_=key_type): construct_type(
-                object_=item, type_=items_type
-            )
+            construct_type(object_=key, type_=key_type): construct_type(object_=item, type_=items_type)
             for key, item in object_.items()
         }
         return d

--- a/generators/python/tests/utils/unaliased_models/types/resources/types/circle.py
+++ b/generators/python/tests/utils/unaliased_models/types/resources/types/circle.py
@@ -9,14 +9,10 @@ import pydantic
 
 
 class Circle(UncheckedBaseModel):
-    radius_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="radiusMeasurement")
-    ]
+    radius_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="radiusMeasurement")]
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/unaliased_models/types/resources/types/object_with_defaults.py
+++ b/generators/python/tests/utils/unaliased_models/types/resources/types/object_with_defaults.py
@@ -16,9 +16,7 @@ class ObjectWithDefaults(UncheckedBaseModel):
     required_string: str = "I neeeeeeeeeed this!"
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/unaliased_models/types/resources/types/object_with_optional_field.py
+++ b/generators/python/tests/utils/unaliased_models/types/resources/types/object_with_optional_field.py
@@ -17,30 +17,16 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     literal: typing.Literal["lit_one"] = "lit_one"
     string: typing.Optional[str] = None
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[
-        typing.Optional[int], FieldMetadata(alias="long")
-    ] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[
-        typing.Optional[bool], FieldMetadata(alias="bool")
-    ] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[
-        typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")
-    ] = None
-    base_64: typing_extensions.Annotated[
-        typing.Optional[str], FieldMetadata(alias="base64")
-    ] = None
-    list_: typing_extensions.Annotated[
-        typing.Optional[typing.List[str]], FieldMetadata(alias="list")
-    ] = None
-    set_: typing_extensions.Annotated[
-        typing.Optional[typing.Set[str]], FieldMetadata(alias="set")
-    ] = None
-    map_: typing_extensions.Annotated[
-        typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")
-    ] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
     enum: typing.Optional[Color] = None
     union: typing.Optional[Shape] = None
     second_union: typing.Optional[Shape] = None
@@ -48,9 +34,7 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     any: typing.Optional[typing.Any] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/unaliased_models/types/resources/types/shape.py
+++ b/generators/python/tests/utils/unaliased_models/types/resources/types/shape.py
@@ -14,9 +14,7 @@ class Base(UncheckedBaseModel):
     id: str
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -24,17 +22,11 @@ class Base(UncheckedBaseModel):
 
 
 class Shape_Circle(Base):
-    shape_type: typing_extensions.Annotated[
-        typing.Literal["circle"], FieldMetadata(alias="shapeType")
-    ] = "circle"
-    radius_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="radiusMeasurement")
-    ]
+    shape_type: typing_extensions.Annotated[typing.Literal["circle"], FieldMetadata(alias="shapeType")] = "circle"
+    radius_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="radiusMeasurement")]
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -42,23 +34,15 @@ class Shape_Circle(Base):
 
 
 class Shape_Square(Base):
-    shape_type: typing_extensions.Annotated[
-        typing.Literal["square"], FieldMetadata(alias="shapeType")
-    ] = "square"
-    length_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="lengthMeasurement")
-    ]
+    shape_type: typing_extensions.Annotated[typing.Literal["square"], FieldMetadata(alias="shapeType")] = "square"
+    length_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="lengthMeasurement")]
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
             extra = pydantic.Extra.allow
 
 
-Shape = typing_extensions.Annotated[
-    typing.Union[Shape_Circle, Shape_Square], UnionMetadata(discriminant="shapeType")
-]
+Shape = typing_extensions.Annotated[typing.Union[Shape_Circle, Shape_Square], UnionMetadata(discriminant="shapeType")]

--- a/generators/python/tests/utils/unaliased_models/types/resources/types/square.py
+++ b/generators/python/tests/utils/unaliased_models/types/resources/types/square.py
@@ -9,14 +9,10 @@ import pydantic
 
 
 class Square(UncheckedBaseModel):
-    length_measurement: typing_extensions.Annotated[
-        float, FieldMetadata(alias="lengthMeasurement")
-    ]
+    length_measurement: typing_extensions.Annotated[float, FieldMetadata(alias="lengthMeasurement")]
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/union_utils/types/core/datetime_utils.py
+++ b/generators/python/tests/utils/union_utils/types/core/datetime_utils.py
@@ -13,9 +13,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(
-            None
-        ):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/generators/python/tests/utils/union_utils/types/core/pydantic_utilities.py
+++ b/generators/python/tests/utils/union_utils/types/core/pydantic_utilities.py
@@ -133,9 +133,7 @@ class UniversalBaseModel(pydantic.BaseModel):
                     # If the default values are non-null act like they've been set
                     # This effectively allows exclude_unset to work like exclude_none where
                     # the latter passes through intentionally set none values.
-                    if default is not None or (
-                        "exclude_unset" in kwargs and not kwargs["exclude_unset"]
-                    ):
+                    if default is not None or ("exclude_unset" in kwargs and not kwargs["exclude_unset"]):
                         _fields_set.add(name)
 
                         if default is not None:
@@ -175,9 +173,9 @@ else:
 
 
 def encode_by_type(o: typing.Any) -> typing.Any:
-    encoders_by_class_tuples: typing.Dict[
-        typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]
-    ] = defaultdict(tuple)
+    encoders_by_class_tuples: typing.Dict[typing.Callable[[typing.Any], typing.Any], typing.Tuple[typing.Any, ...]] = (
+        defaultdict(tuple)
+    )
     for type_, encoder in encoders_by_type.items():
         encoders_by_class_tuples[encoder] += (type_,)
 
@@ -211,14 +209,10 @@ def universal_root_validator(
     return decorator
 
 
-def universal_field_validator(
-    field_name: str, pre: bool = False
-) -> typing.Callable[[AnyCallable], AnyCallable]:
+def universal_field_validator(field_name: str, pre: bool = False) -> typing.Callable[[AnyCallable], AnyCallable]:
     def decorator(func: AnyCallable) -> AnyCallable:
         if IS_PYDANTIC_V2:
-            return pydantic.field_validator(
-                field_name, mode="before" if pre else "after"
-            )(func)  # type: ignore # Pydantic v2
+            return pydantic.field_validator(field_name, mode="before" if pre else "after")(func)  # type: ignore # Pydantic v2
         else:
             return pydantic.validator(field_name, pre=pre)(func)  # type: ignore # Pydantic v1
 

--- a/generators/python/tests/utils/union_utils/types/core/serialization.py
+++ b/generators/python/tests/utils/union_utils/types/core/serialization.py
@@ -68,9 +68,7 @@ def convert_and_respect_annotation_metadata(
     ):
         return _convert_mapping(object_, clean_type, direction)
     # TypedDicts
-    if typing_extensions.is_typeddict(clean_type) and isinstance(
-        object_, typing.Mapping
-    ):
+    if typing_extensions.is_typeddict(clean_type) and isinstance(object_, typing.Mapping):
         return _convert_mapping(object_, clean_type, direction)
 
     if (
@@ -183,10 +181,8 @@ def _convert_mapping(
                 object_=value, annotation=type_, direction=direction
             )
         else:
-            converted_object[
-                _alias_key(key, type_, direction, aliases_to_field_names)
-            ] = convert_and_respect_annotation_metadata(
-                object_=value, annotation=type_, direction=direction
+            converted_object[_alias_key(key, type_, direction, aliases_to_field_names)] = (
+                convert_and_respect_annotation_metadata(object_=value, annotation=type_, direction=direction)
             )
     return converted_object
 

--- a/generators/python/tests/utils/union_utils/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/union_utils/types/core/unchecked_base_model.py
@@ -37,9 +37,7 @@ Model = typing.TypeVar("Model", bound=pydantic.BaseModel)
 
 class UncheckedBaseModel(UniversalBaseModel):
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:
@@ -80,9 +78,7 @@ class UncheckedBaseModel(UniversalBaseModel):
             if (key is None or field.alias == name) and name in field_aliases:
                 key = field_aliases[name]
 
-            if key is None or (
-                key not in values and populate_by_name
-            ):  # Added this to allow population by field name
+            if key is None or (key not in values and populate_by_name):  # Added this to allow population by field name
                 key = name
 
             if key in values:
@@ -92,9 +88,7 @@ class UncheckedBaseModel(UniversalBaseModel):
                     type_ = typing.cast(typing.Type, field.outer_type_)  # type: ignore # Pydantic < v1.10.15
 
                 fields_values[name] = (
-                    construct_type(object_=values[key], type_=type_)
-                    if type_ is not None
-                    else values[key]
+                    construct_type(object_=values[key], type_=type_) if type_ is not None else values[key]
                 )
                 _fields_set.add(name)
             else:
@@ -113,9 +107,7 @@ class UncheckedBaseModel(UniversalBaseModel):
         internal_alias_fields = list(field_aliases.values())
         for key, value in values.items():
             # If the key is not a field by name, nor an alias to a field, then it's extra
-            if (
-                key not in pydantic_alias_fields and key not in internal_alias_fields
-            ) and key not in fields:
+            if (key not in pydantic_alias_fields and key not in internal_alias_fields) and key not in fields:
                 if IS_PYDANTIC_V2:
                     extras[key] = value
                 else:
@@ -134,18 +126,14 @@ class UncheckedBaseModel(UniversalBaseModel):
         return m
 
 
-def _convert_undiscriminated_union_type(
-    union_type: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def _convert_undiscriminated_union_type(union_type: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     inner_types = get_args(union_type)
     if typing.Any in inner_types:
         return object_
 
     for inner_type in inner_types:
         try:
-            if inspect.isclass(inner_type) and issubclass(
-                inner_type, pydantic.BaseModel
-            ):
+            if inspect.isclass(inner_type) and issubclass(inner_type, pydantic.BaseModel):
                 # Attempt a validated parse until one works
                 return parse_obj_as(inner_type, object_)
         except Exception:
@@ -159,9 +147,7 @@ def _convert_undiscriminated_union_type(
             continue
 
 
-def _convert_union_type(
-    type_: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def _convert_union_type(type_: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     base_type = get_origin(type_) or type_
     union_type = type_
     if base_type == typing_extensions.Annotated:  # type: ignore[comparison-overlap]
@@ -173,15 +159,10 @@ def _convert_union_type(
                     # Cast to the correct type, based on the discriminant
                     for inner_type in get_args(union_type):
                         try:
-                            objects_discriminant = getattr(
-                                object_, metadata.discriminant
-                            )
+                            objects_discriminant = getattr(object_, metadata.discriminant)
                         except:
                             objects_discriminant = object_[metadata.discriminant]
-                        if (
-                            inner_type.__fields__[metadata.discriminant].default
-                            == objects_discriminant
-                        ):
+                        if inner_type.__fields__[metadata.discriminant].default == objects_discriminant:
                             return construct_type(object_=object_, type_=inner_type)
                 except Exception:
                     # Allow to fall through to our regular union handling
@@ -189,9 +170,7 @@ def _convert_union_type(
     return _convert_undiscriminated_union_type(union_type, object_)
 
 
-def construct_type(
-    *, type_: typing.Type[typing.Any], object_: typing.Any
-) -> typing.Any:
+def construct_type(*, type_: typing.Type[typing.Any], object_: typing.Any) -> typing.Any:
     """
     Here we are essentially creating the same `construct` method in spirit as the above, but for all types, not just
     Pydantic models.
@@ -204,9 +183,7 @@ def construct_type(
     base_type = get_origin(type_) or type_
     is_annotated = base_type == typing_extensions.Annotated  # type: ignore[comparison-overlap]
     maybe_annotation_members = get_args(type_)
-    is_annotated_union = is_annotated and is_union(
-        get_origin(maybe_annotation_members[0])
-    )
+    is_annotated_union = is_annotated and is_union(get_origin(maybe_annotation_members[0]))
 
     if base_type == typing.Any:  # type: ignore[comparison-overlap]
         return object_
@@ -217,9 +194,7 @@ def construct_type(
 
         key_type, items_type = get_args(type_)
         d = {
-            construct_type(object_=key, type_=key_type): construct_type(
-                object_=item, type_=items_type
-            )
+            construct_type(object_=key, type_=key_type): construct_type(object_=item, type_=items_type)
             for key, item in object_.items()
         }
         return d

--- a/generators/python/tests/utils/union_utils/types/resources/types/circle.py
+++ b/generators/python/tests/utils/union_utils/types/resources/types/circle.py
@@ -12,9 +12,7 @@ class Circle(UncheckedBaseModel):
     surname: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/generators/python/tests/utils/union_utils/types/resources/types/shape.py
+++ b/generators/python/tests/utils/union_utils/types/resources/types/shape.py
@@ -17,23 +17,15 @@ T_Result = typing.TypeVar("T_Result")
 class _Factory:
     def circle(self, value: resources_types_circle_Circle) -> Shape:
         if IS_PYDANTIC_V2:
-            return Shape(
-                root=_Shape.Circle(**value.dict(exclude_unset=True), type="circle")
-            )  # type: ignore
+            return Shape(root=_Shape.Circle(**value.dict(exclude_unset=True), type="circle"))  # type: ignore
         else:
-            return Shape(
-                __root__=_Shape.Circle(**value.dict(exclude_unset=True), type="circle")
-            )  # type: ignore
+            return Shape(__root__=_Shape.Circle(**value.dict(exclude_unset=True), type="circle"))  # type: ignore
 
     def square(self, value: resources_types_square_Square) -> Shape:
         if IS_PYDANTIC_V2:
-            return Shape(
-                root=_Shape.Square(**value.dict(exclude_unset=True), type="square")
-            )  # type: ignore
+            return Shape(root=_Shape.Square(**value.dict(exclude_unset=True), type="square"))  # type: ignore
         else:
-            return Shape(
-                __root__=_Shape.Square(**value.dict(exclude_unset=True), type="square")
-            )  # type: ignore
+            return Shape(__root__=_Shape.Square(**value.dict(exclude_unset=True), type="square"))  # type: ignore
 
 
 class Shape(UniversalRootModel):
@@ -85,17 +77,9 @@ class Shape(UniversalRootModel):
     ) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "circle":
-            return circle(
-                resources_types_circle_Circle(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
-                )
-            )
+            return circle(resources_types_circle_Circle(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
         if unioned_value.type == "square":
-            return square(
-                resources_types_square_Square(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
-                )
-            )
+            return square(resources_types_square_Square(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
 
 
 class _Shape:

--- a/generators/python/tests/utils/union_utils/types/resources/types/square.py
+++ b/generators/python/tests/utils/union_utils/types/resources/types/square.py
@@ -10,9 +10,7 @@ class Square(UncheckedBaseModel):
     length: float
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-            extra="allow"
-        )  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2
     else:
 
         class Config:


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6395/help-needed-to-fix-sdk-generation-config-for-kraken
<!-- Provide a clear and concise description of the changes made in this PR -->

- On valid OAS, we could possibly re-write 2 params to a function call or constructor. 
- We also fail generation on the ambiguous name error [E741](https://docs.astral.sh/ruff/rules/ambiguous-variable-name/) 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Ensures this never happens by checking the params written against a hash set of already written params
- Ignores the ambiguous name error - respecting the OAS's naming standard

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
