### PR TITLE
feat(ci): Add rust to update seed workflow

### DIFF
--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -53,7 +53,7 @@ runs:
         commit-message: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         title: "chore(${{ inputs.language-name }}): update ${{ inputs.generator-name }} seed"
         branch: update-${{ inputs.generator-name }}-seed
-        body: "Auto-generated PR, triggered by GitHub event: ${{ github.event_name }} from branch: ${{ github.ref_name }} with run ID: ${{ github.run_id }}"
+        body: "Auto-generated PR, triggered by GitHub event: ${{ github.event_name }} from branch: ${{ github.ref_name }}.\nGitHub workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         delete-branch: true
         labels: |
           seed

--- a/.github/actions/get-generator-changes/action.yaml
+++ b/.github/actions/get-generator-changes/action.yaml
@@ -167,4 +167,5 @@ runs:
       with:
         files: |
           generators/rust/**
+          seed/rust-model/**
           seed/rust-sdk/**

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -474,7 +474,6 @@ jobs:
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
-
   rust-model:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -473,3 +473,44 @@ jobs:
           allow-unexpected-failures: true
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
+
+
+  rust-model:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    runs-on: Seed
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
+        with:
+          generator-name: rust-model
+          generator-path: generators/rust
+          language-name: rust
+          allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
+
+  rust-sdk:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    runs-on: Seed
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
+        with:
+          generator-name: rust-sdk
+          generator-path: generators/rust
+          language-name: rust
+          allow-unexpected-failures: true
+          secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
+          secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6473/ci-add-rust-generator-to-update-seed-workflow
Adding rust to the auto-updated generators for seed output 
Quality of life update - instead of adding the github run ID to the PR, make it the full link

## Changes Made
- Fix to get-generator-changes action file to include rust model
- Adding rust-model and sdk to update-seed workflow
- Updated action file for auto-update-seed so that it provides a full link instead of just the run ID to link the PR back to the run that created it

## Testing
Already verified auto-update workflow, simply enabled rust for rust-sdk and model seed outputs
Verification again on this workflow run: https://github.com/fern-api/fern/actions/runs/17679491395
Quality of life update can be seen in corresponding Rust PR here: https://github.com/fern-api/fern/pull/9362 (for model) and here: https://github.com/fern-api/fern/pull/9363 (for sdk)
