### PR TITLE
fix(ci): Temporarily turn off go seed updates

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -651,7 +651,8 @@ jobs:
 
   go-fiber:
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    # if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    if: false
     runs-on: Seed
     steps:
       - name: Checkout repo
@@ -697,7 +698,8 @@ jobs:
 
   go-model:
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    # if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    if: false
     runs-on: Seed
     steps:
       - name: Checkout repo
@@ -743,7 +745,8 @@ jobs:
 
   go-sdk:
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    # if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
+    if: false
     runs-on: Seed
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6535/ci-temp-disable-seed-update-for-go
Temporarily turn off seed updates for Go. Since packages.go is currently generating in a nondeterministic, the automations are constantly running and updating for Go, which merges to main, which kicks off the process again

## Changes Made
- Force go to not run the update-seed workflow

## Testing
Pushed, will verify on merge 
