### PR TITLE
fix(cli): gracefully fail on unsupported security schemes

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -83,7 +83,9 @@ function convertSecuritySchemeHelper(
     } catch (error) {
         taskContext.logger.debug(`Error converting security scheme: ${(error as Error)?.message}`);
     }
-    taskContext.logger.debug(`Skipping security scheme: ${(JSON.stringify(securityScheme, null))} - not currently supported. Please reach out to Fern support team!`);
+    taskContext.logger.debug(
+        `Skipping security scheme: ${JSON.stringify(securityScheme, null)} - not currently supported. Please reach out to Fern support team!`
+    );
     return undefined;
 }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -83,6 +83,7 @@ function convertSecuritySchemeHelper(
     } catch (error) {
         taskContext.logger.debug(`Error converting security scheme: ${(error as Error)?.message}`);
     }
+    taskContext.logger.debug(`Skipping security scheme: ${(JSON.stringify(securityScheme, null))} - not currently supported. Please reach out to Fern support team!`);
     return undefined;
 }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -66,13 +66,15 @@ export function generateIr({
     openApi = runResolutions({ openapi: openApi });
 
     const securitySchemes: Record<string, SecurityScheme> = Object.fromEntries(
-        Object.entries(openApi.components?.securitySchemes ?? {}).map(([key, securityScheme]) => {
-            const convertedSecurityScheme = convertSecurityScheme(securityScheme, source, taskContext);
-            if (convertedSecurityScheme == null) {
-                return [];
-            }
-            return [key, convertSecurityScheme(securityScheme, source, taskContext)];
-        })
+        Object.entries(openApi.components?.securitySchemes ?? {})
+            .map(([key, securityScheme]) => {
+                const convertedSecurityScheme = convertSecurityScheme(securityScheme, source, taskContext);
+                if (convertedSecurityScheme == null) {
+                    return null;
+                }
+                return [key, convertedSecurityScheme];
+            })
+            .filter((entry): entry is [string, SecurityScheme] => entry !== null)
     );
     const authHeaders = new Set(
         ...Object.entries(securitySchemes).map(([_, securityScheme]) => {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Additional handling of OpenAPI parsing failures for security schemes.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-09-12"
+  version: 0.76.2
+
+- changelogEntry:
+    - summary: |
         Handle OpenAPI parsing failures for security schemes gracefully.
       type: fix
   irVersion: 59


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
In our openapi parser, if there was a `securityScheme` we didn't handle yet we would hard fail on generation. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
This allows graceful failure and includes a warning to users on `--log-level debug` that the scheme was skipped 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
