### PR TITLE
feat(ruby): Adding Gemfile.lock files to ruby-v2 .gitignore

### DIFF
--- a/seed/ruby-sdk-v2/.gitignore
+++ b/seed/ruby-sdk-v2/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the ruby Gemfile.lock files generated within seed
+seed/**/Gemfile.lock


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6543/ruby-add-gemfilelock-files-to-gitignore
Adding a .gitignore file to the ruby-v2 seed folder that will ignore the Gemfile.lock files

## Changes Made
Added .gitignore directly to the ruby-sdk-v2 seed folder
Deleted all Gemfile.lock files

## Testing
Made .gitignore file, deleted all Gemfile.lock files in the ruby-sdk-v2 seed folder, verified after rerunning seed generation that the Gemfile.lock files don't show in `git diff`
