### PR TITLE
fix(java): handle null version parameter without NPE in header API versioning

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -718,9 +718,7 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                 } else {
                     fromMethod.beginControlFlow("if (clientOptions.$L != null)", apiVersionField.name);
                     fromMethod.addStatement(
-                            "builder.$L = clientOptions.$L",
-                            apiVersionField.name,
-                            apiVersionField.name);
+                            "builder.$L = clientOptions.$L", apiVersionField.name, apiVersionField.name);
                     fromMethod.endControlFlow();
                 }
             }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -586,7 +586,7 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                 .returns(builderClassName)
                 .addParameter(
                         clientGeneratorContext.getPoetClassNameFactory().getApiVersionClassName(), apiVersionField.name)
-                .addStatement("this.$L = $T.of($L)", apiVersionField.name, Optional.class, apiVersionField.name)
+                .addStatement("this.$L = $T.ofNullable($L)", apiVersionField.name, Optional.class, apiVersionField.name)
                 .addStatement("return this")
                 .build();
     }
@@ -692,14 +692,15 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                     clientGeneratorContext.getIr().getApiVersion().get();
             if (apiVersionScheme.getHeader().isPresent()) {
                 HeaderApiVersionScheme header = apiVersionScheme.getHeader().get();
-                fromMethod.beginControlFlow("if (clientOptions.$L != null)", apiVersionField.name);
-                fromMethod.addStatement(
-                        "builder.$L = $T.of(clientOptions.$L)",
-                        apiVersionField.name,
-                        Optional.class,
-                        apiVersionField.name);
-                fromMethod.endControlFlow();
                 if (header.getValue().getDefault().isPresent()) {
+                    // When there's a default, the field is Optional<ApiVersion> if not just ApiVersion
+                    fromMethod.beginControlFlow("if (clientOptions.$L != null)", apiVersionField.name);
+                    fromMethod.addStatement(
+                            "builder.$L = $T.ofNullable(clientOptions.$L)",
+                            apiVersionField.name,
+                            Optional.class,
+                            apiVersionField.name);
+                    fromMethod.endControlFlow();
                     fromMethod.beginControlFlow("else");
                     fromMethod.addStatement(
                             "builder.$L = $T.of($T.$L)",
@@ -713,6 +714,13 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                                     .getName()
                                     .getScreamingSnakeCase()
                                     .getSafeName());
+                    fromMethod.endControlFlow();
+                } else {
+                    fromMethod.beginControlFlow("if (clientOptions.$L != null)", apiVersionField.name);
+                    fromMethod.addStatement(
+                            "builder.$L = clientOptions.$L",
+                            apiVersionField.name,
+                            apiVersionField.name);
                     fromMethod.endControlFlow();
                 }
             }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.2.1
+  changelogEntry:
+    - summary: |
+        Changed Optional.of() to Optional.ofNullable() to handle null values gracefully, allowing users to reset to default version.
+      type: fix
+  createdAt: "2025-09-15"
+  irVersion: 59
+
 - version: 3.2.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ClientOptions.java
+++ b/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ClientOptions.java
@@ -200,7 +200,7 @@ public final class ClientOptions {
             builder.timeout = Optional.of(clientOptions.timeout(null));
             builder.httpClient = clientOptions.httpClient();
             if (clientOptions.version != null) {
-                builder.version = Optional.of(clientOptions.version);
+                builder.version = clientOptions.version;
             }
             return builder;
         }

--- a/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/ClientOptions.java
+++ b/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/ClientOptions.java
@@ -165,7 +165,7 @@ public final class ClientOptions {
          * version.toString() is sent as the "X-API-Version" header.
          */
         public Builder version(ApiVersion version) {
-            this.version = Optional.of(version);
+            this.version = Optional.ofNullable(version);
             return this;
         }
 
@@ -203,7 +203,7 @@ public final class ClientOptions {
             builder.timeout = Optional.of(clientOptions.timeout(null));
             builder.httpClient = clientOptions.httpClient();
             if (clientOptions.version != null) {
-                builder.version = Optional.of(clientOptions.version);
+                builder.version = Optional.ofNullable(clientOptions.version);
             } else {
                 builder.version = Optional.of(ApiVersion.V_2);
             }

--- a/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ClientOptions.java
+++ b/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ClientOptions.java
@@ -165,7 +165,7 @@ public final class ClientOptions {
          * version.toString() is sent as the "X-API-Version" header.
          */
         public Builder version(ApiVersion version) {
-            this.version = Optional.of(version);
+            this.version = Optional.ofNullable(version);
             return this;
         }
 
@@ -203,7 +203,7 @@ public final class ClientOptions {
             builder.timeout = Optional.of(clientOptions.timeout(null));
             builder.httpClient = clientOptions.httpClient();
             if (clientOptions.version != null) {
-                builder.version = Optional.of(clientOptions.version);
+                builder.version = Optional.ofNullable(clientOptions.version);
             } else {
                 builder.version = Optional.of(ApiVersion.V_2);
             }


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6365/java-mercoa-java-compiler-issue-when-version-default-not-handled

Changed Optional.of() to Optional.ofNullable() in ClientOptionsGenerator to prevent NullPointerException when users pass null to version() method for APIs with default version headers.

## Changes Made
- See files changed

## Testing
<!-- Describe how you tested these changes -->
- [X] Unit tests added/updated
- Verified version fixture compiles and handles null correctly
- Verified version-no-default fixture still works with required version

