### PR TITLE
fix(cli): 'upgrades available' only display on actual upgrade needed

### DIFF
--- a/packages/cli/cli/src/cli-context/CliEnvironment.ts
+++ b/packages/cli/cli/src/cli-context/CliEnvironment.ts
@@ -1,5 +1,5 @@
 export interface CliEnvironment {
     readonly packageName: string;
-    readonly packageVersion: string;
+    packageVersion: string;
     readonly cliName: string;
 }

--- a/packages/cli/cli/src/cli-context/upgrade-utils/getFernUpgradeMessage.ts
+++ b/packages/cli/cli/src/cli-context/upgrade-utils/getFernUpgradeMessage.ts
@@ -24,7 +24,7 @@ export async function getFernUpgradeMessage({
     cliEnvironment: CliEnvironment;
     upgradeInfo: FernUpgradeInfo;
 }): Promise<string | undefined> {
-    if (!hasUpgrade(upgradeInfo)) {
+    if (!hasUpgrade(upgradeInfo) || cliEnvironment.packageVersion == upgradeInfo.cliUpgradeInfo?.latestVersion) {
         return;
     }
 

--- a/packages/cli/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgrade.ts
@@ -105,6 +105,7 @@ export async function upgrade({
             )}`
         );
 
+        cliContext.environment.packageVersion = fernCliUpgradeInfo.targetVersion;
         // special case: if we're running the local-dev version of the CLI, simulate a re-run
         if (cliContext.environment.packageVersion === "0.0.0") {
             await runPostUpgradeSteps({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: \'upgrades available\' only display on actual upgrade needed
+      type: fix
+  irVersion: 59
+  createdAt: "2025-09-15"
+  version: 0.77.1
+
+- changelogEntry:
     - summary: Add customSections property to ReadmeConfig.
       type: feat
   irVersion: 59


### PR DESCRIPTION
## Description
Linear ticket:
<!-- Provide a clear and concise description of the changes made in this PR -->
On a `fern upgrade` we would see an erroneous message about needing to upgrade after already doing that.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
Fixes internal state of cliContext to not show that warning

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
